### PR TITLE
add budget preview to purchase dialogue

### DIFF
--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -7,6 +7,7 @@ from game.event import ControlPointType
 from qt_ui.uiconstants import EVENT_ICONS
 from qt_ui.windows.GameUpdateSignal import GameUpdateSignal
 from qt_ui.windows.basemenu.QBaseMenuTabs import QBaseMenuTabs
+from qt_ui.windows.basemenu.QRecruitBehaviour import QRecruitBehaviour
 from theater import ControlPoint
 
 
@@ -19,6 +20,7 @@ class QBaseMenu2(QDialog):
         self.cp = cp
         self.game = game
         self.is_carrier = self.cp.cptype in [ControlPointType.AIRCRAFT_CARRIER_GROUP, ControlPointType.LHA_GROUP]
+        self.objectName = "menuDialogue"
 
         # Widgets
         self.qbase_menu_tab = QBaseMenuTabs(cp, game)
@@ -58,7 +60,6 @@ class QBaseMenu2(QDialog):
         title.setProperty("style", "base-title")
         unitsPower = QLabel("{} / {} /  Runway : {}".format(self.cp.base.total_planes, self.cp.base.total_armor,
                                                             "Available" if self.cp.has_runway() else "Unavailable"))
-
         self.topLayout.addWidget(title)
         self.topLayout.addWidget(unitsPower)
         self.topLayout.setAlignment(Qt.AlignTop)
@@ -69,7 +70,11 @@ class QBaseMenu2(QDialog):
         self.mainLayout.addWidget(header, 0, 0)
         self.mainLayout.addWidget(self.topLayoutWidget, 1, 0)
         self.mainLayout.addWidget(self.qbase_menu_tab, 2, 0)
-
+        totalBudget = QLabel(QRecruitBehaviour.BUDGET_FORMAT.format(self.game.budget))
+        totalBudget.setObjectName("budgetField")
+        totalBudget.setAlignment(Qt.AlignRight | Qt.AlignBottom)
+        totalBudget.setProperty("style", "budget-label")
+        self.mainLayout.addWidget(totalBudget)
         self.setLayout(self.mainLayout)
 
     def closeEvent(self, closeEvent:QCloseEvent):

--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -5,6 +5,7 @@ from dcs.unittype import UnitType
 from theater import db
 
 
+
 class QRecruitBehaviour:
 
     game = None
@@ -12,10 +13,12 @@ class QRecruitBehaviour:
     deliveryEvent = None
     existing_units_labels = None
     bought_amount_labels = None
+    BUDGET_FORMAT = "Available Budget: <b>${}M</b>"
 
     def __init__(self):
         self.bought_amount_labels = {}
         self.existing_units_labels = {}
+        self.update_available_budget()
 
     def add_purchase_row(self, unit_type, layout, row):
 
@@ -91,12 +94,22 @@ class QRecruitBehaviour:
             self.cp.base.total_units_of_type(unit_type)
         ))
 
+    def update_available_budget(self):
+        parent = self.parent()
+        while parent.objectName != "menuDialogue":
+            parent = parent.parent()
+        for child in parent.children():
+            if child.objectName() == "budgetField":
+                child.setText(QRecruitBehaviour.BUDGET_FORMAT.format(self.game.budget))
+
     def buy(self, unit_type):
+
         price = db.PRICES[unit_type]
         if self.game.budget >= price:
             self.deliveryEvent.deliver({unit_type: 1})
             self.game.budget -= price
         self._update_count_label(unit_type)
+        self.update_available_budget()
 
     def sell(self, unit_type):
         if self.deliveryEvent.units.get(unit_type, 0) > 0:
@@ -111,3 +124,4 @@ class QRecruitBehaviour:
             self.cp.base.commit_losses({unit_type: 1})
 
         self._update_count_label(unit_type)
+        self.update_available_budget()

--- a/resources/stylesheets/style-dcs.css
+++ b/resources/stylesheets/style-dcs.css
@@ -184,6 +184,11 @@ QLabel[style="base-title"]{
     font-size: 24px;
 }
 
+QLabel[style="budget-label"]{
+    font-size: 16px;
+    margin-right: 20px;
+}
+
 QLabel[style="icon-plane"]{
     background-color:#48719D;
     min-height:24px;


### PR DESCRIPTION
TL;DR Change:

- added budget update to purchase window

Currently when purchasing vehicles, there is no live update to the available budget.

User must wait until committing to the purchases to see remaining budget, or reach the point where further vehicles are unable to be purchased to determine insufficient funds.

This update provides live feedback to the user - in the purchase window - of remaining budget.


Pre-purchase:
![unchanged](https://user-images.githubusercontent.com/69777262/90358060-87192400-e087-11ea-8e40-a96ef1d96edf.png)

Add units:
![add_units](https://user-images.githubusercontent.com/69777262/90357940-2853aa80-e087-11ea-9418-107fcad8a76f.png)

Remove units:
![remove_units](https://user-images.githubusercontent.com/69777262/90357943-2b4e9b00-e087-11ea-863b-6e1223ef0373.png)
