### PR TITLE
Add checking new version to Help menu

### DIFF
--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -242,14 +242,13 @@ class QLiberationWindow(QMainWindow):
         self.debriefing.show()
 
     def _check_and_download_new_version(self):
-        file_name, browser_download_url = '', ''
+        browser_download_url = ''
         try:
             response = get('https://api.github.com/repos/Khopa/dcs_liberation/releases/latest')
             if response.status_code == 200:
                 online_version = response.json()['tag_name']
                 if version.parse(online_version) > version.parse(CONST.VERSION_STRING):
                     print(f'There is new version of dcs_liberation: {online_version}')
-                    file_name = response.json()['assets'][0]['name']
                     browser_download_url = response.json()['assets'][0]['browser_download_url']
                 elif version.parse(online_version) == version.parse(CONST.VERSION_STRING):
                     print(f'This is up-to-date version: {CONST.VERSION_STRING}')

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -120,6 +120,7 @@ class QLiberationWindow(QMainWindow):
         help_menu.addAction("Online Manual", lambda: webbrowser.open_new_tab(URLS["Manual"]))
         help_menu.addAction("ED Forum Thread", lambda: webbrowser.open_new_tab(URLS["ForumThread"]))
         help_menu.addAction("Report an issue", lambda: webbrowser.open_new_tab(URLS["Issues"]))
+        help_menu.addAction("Check new version", lambda: self._check_new_version)
 
         help_menu.addSeparator()
         help_menu.addAction(self.showAboutDialogAction)
@@ -236,3 +237,24 @@ class QLiberationWindow(QMainWindow):
         logging.info("On Debriefing")
         self.debriefing = QDebriefingWindow(debrief.debriefing, debrief.gameEvent, debrief.game)
         self.debriefing.show()
+
+    def _check_new_version(self):
+        file_name, browser_download_url = '', ''
+        try:
+            response = get('https://api.github.com/repos/Khopa/dcs_liberation/releases/latest')
+            if response.status_code == 200:
+                online_version = response.json()['tag_name']
+                if version.parse(online_version) > version.parse(CONST.VERSION_STRING):
+                    print(f'There is new version of dcs_liberation: {online_version}')
+                    file_name = response.json()['assets'][0]['name']
+                    browser_download_url = response.json()['assets'][0]['browser_download_url']
+                elif version.parse(online_version) == version.parse(CONST.VERSION_STRING):
+                    print(f'This is up-to-date version: {CONST.VERSION_STRING}')
+            else:
+                print(f'Unable to check version online. Try again later. Status={response.status_code}')
+        except Exception as exc:
+            print(f'Unable to check version online: {exc}')
+
+        if browser_download_url:
+            with open(file_name, 'wb') as zip_file:
+                zip_file.write(get(browser_download_url).content)

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -6,6 +6,8 @@ from PySide2.QtCore import Qt
 from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QWidget, QVBoxLayout, QMainWindow, QAction, QMessageBox, QDesktopWidget, \
     QSplitter, QFileDialog
+from requests import get
+from packaging import version
 
 import qt_ui.uiconstants as CONST
 from game import Game

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -123,7 +123,7 @@ class QLiberationWindow(QMainWindow):
         help_menu.addAction("Online Manual", lambda: webbrowser.open_new_tab(URLS["Manual"]))
         help_menu.addAction("ED Forum Thread", lambda: webbrowser.open_new_tab(URLS["ForumThread"]))
         help_menu.addAction("Report an issue", lambda: webbrowser.open_new_tab(URLS["Issues"]))
-        help_menu.addAction("Check new version", lambda: self._check_and_download_new_version)
+        help_menu.addAction("Check new version", lambda: self._check_and_download_new_version())
 
         help_menu.addSeparator()
         help_menu.addAction(self.showAboutDialogAction)

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -123,7 +123,7 @@ class QLiberationWindow(QMainWindow):
         help_menu.addAction("Online Manual", lambda: webbrowser.open_new_tab(URLS["Manual"]))
         help_menu.addAction("ED Forum Thread", lambda: webbrowser.open_new_tab(URLS["ForumThread"]))
         help_menu.addAction("Report an issue", lambda: webbrowser.open_new_tab(URLS["Issues"]))
-        help_menu.addAction("Check new version", lambda: self._check_new_version)
+        help_menu.addAction("Check new version", lambda: self._check_and_download_new_version)
 
         help_menu.addSeparator()
         help_menu.addAction(self.showAboutDialogAction)
@@ -241,7 +241,7 @@ class QLiberationWindow(QMainWindow):
         self.debriefing = QDebriefingWindow(debrief.debriefing, debrief.gameEvent, debrief.game)
         self.debriefing.show()
 
-    def _check_new_version(self):
+    def _check_and_download_new_version(self):
         file_name, browser_download_url = '', ''
         try:
             response = get('https://api.github.com/repos/Khopa/dcs_liberation/releases/latest')
@@ -259,8 +259,8 @@ class QLiberationWindow(QMainWindow):
             print(f'Unable to check version online: {exc}')
 
         if browser_download_url:
-            full_zip_path = QFileDialog.getSaveFileName(self, caption='Save File', directory=environ['HOME'],
-                                                        filter='All Files [*.*](*.*)', options=QFileDialog.ReadOnly)
+            full_zip_path, _ = QFileDialog.getSaveFileName(self, caption='Save File', directory=environ['HOME'],
+                                                           filter='All Files [*.*](*.*)', options=QFileDialog.ReadOnly)
             if full_zip_path:
                 with open(full_zip_path, 'wb') as zip_file:
                     zip_file.write(get(browser_download_url).content)

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import webbrowser
+from os import environ
 
 from PySide2.QtCore import Qt
 from PySide2.QtGui import QIcon
@@ -258,5 +259,8 @@ class QLiberationWindow(QMainWindow):
             print(f'Unable to check version online: {exc}')
 
         if browser_download_url:
-            with open(file_name, 'wb') as zip_file:
-                zip_file.write(get(browser_download_url).content)
+            full_zip_path = QFileDialog.getSaveFileName(self, caption='Save File', directory=environ['HOME'],
+                                                        filter='All Files [*.*](*.*)', options=QFileDialog.ReadOnly)
+            if full_zip_path:
+                with open(full_zip_path, 'wb') as zip_file:
+                    zip_file.write(get(browser_download_url).content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 Pyside2>=5.13.0
 pyinstaller==3.6
 pyproj==2.6.1.post1
+requests
+packaging


### PR DESCRIPTION
It will add new entry to Help menu, to check if there is new release version of DCS Liberation to download. 
* It will check only for official releases (maked green) and not Pre-release (orange one)
* Once there is new version, save dialog will pop-up let user select directory.

This PR needs new requirements (in any version):
* packaging
* requests