### PR TITLE
Make the mission planning window non-modal.

### DIFF
--- a/qt_ui/windows/mission/QMissionPlanning.py
+++ b/qt_ui/windows/mission/QMissionPlanning.py
@@ -17,7 +17,6 @@ class QMissionPlanning(QDialog):
         self.game = game
         self.setWindowFlags(Qt.WindowStaysOnTopHint)
         self.setMinimumSize(1000, 440)
-        self.setModal(True)
         self.setWindowTitle("Mission Preparation")
         self.setWindowIcon(EVENT_ICONS["strike"])
         self.init_ui()


### PR DESCRIPTION
Doesn't appear to be any need for this to be modal. Making it
non-modal allows interacting with the map during planning.