### PR TITLE
Fix incorrect pydcs import paths.

### DIFF
--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -5,9 +5,9 @@ from gen.airfields import AIRFIELD_DATA
 from gen.beacons import load_beacons_for_terrain
 from gen.radios import RadioRegistry
 from gen.tacan import TacanRegistry
-from pydcs.dcs.countries import country_dict
-from pydcs.dcs.lua.parse import loads
-from pydcs.dcs.terrain.terrain import Terrain
+from dcs.countries import country_dict
+from dcs.lua.parse import loads
+from dcs.terrain.terrain import Terrain
 from userdata.debriefing import *
 
 

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -1,5 +1,12 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+
+from dcs import helicopters
+from dcs.action import ActivateGroup, AITaskPush, MessageToAll
+from dcs.condition import TimeAfter, CoalitionHasAirdrome, PartOfCoalitionInZone
+from dcs.flyingunit import FlyingUnit
+from dcs.helicopters import helicopter_map, UH_1H
+from dcs.terrain.terrain import Airport, NoParkingSlotError
+from dcs.triggers import TriggerOnce, Event
 
 from game.data.cap_capabilities_db import GUNFIGHTERS
 from game.settings import Settings
@@ -13,27 +20,6 @@ from gen.flights.flight import (
     FlightWaypointType,
 )
 from gen.radios import get_radio, MHz, Radio, RadioFrequency, RadioRegistry
-from pydcs.dcs import helicopters
-from pydcs.dcs.action import ActivateGroup, AITaskPush, MessageToAll
-from pydcs.dcs.condition import TimeAfter, CoalitionHasAirdrome, PartOfCoalitionInZone
-from pydcs.dcs.flyingunit import FlyingUnit
-from pydcs.dcs.helicopters import helicopter_map, UH_1H
-from pydcs.dcs.mission import Mission, StartType
-from pydcs.dcs.planes import (
-    Bf_109K_4,
-    FW_190A8,
-    FW_190D9,
-    I_16,
-    Ju_88A4,
-    P_47D_30,
-    P_51D,
-    P_51D_30_NA,
-    SpitfireLFMkIX,
-    SpitfireLFMkIXCW,
-)
-from pydcs.dcs.terrain.terrain import Airport, NoParkingSlotError
-from pydcs.dcs.triggers import TriggerOnce, Event
-from pydcs.dcs.unittype import FlyingType, UnitType
 from .conflictgen import *
 from .naming import *
 

--- a/gen/airfields.py
+++ b/gen/airfields.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 import logging
 from typing import Dict, Optional, Tuple
 
-from pydcs.dcs.terrain.terrain import Airport
+from dcs.terrain.terrain import Airport
 from .radios import MHz, RadioFrequency
 from .tacan import TacanBand, TacanChannel
 

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -5,7 +5,7 @@ import random
 from typing import List, Tuple
 
 from game import db
-from pydcs.dcs.mission import Mission
+from dcs.mission import Mission
 from .aircraft import FlightData
 from .airfields import RunwayData
 from .airsupportgen import AwacsInfo, TankerInfo

--- a/gen/flights/flight.py
+++ b/gen/flights/flight.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List
 
 from game import db
-from pydcs.dcs.unittype import UnitType
+from dcs.unittype import UnitType
 
 
 class FlightType(Enum):

--- a/gen/groundobjectsgen.py
+++ b/gen/groundobjectsgen.py
@@ -1,14 +1,8 @@
+from dcs.statics import *
+from dcs.unit import Ship, Vehicle
+
 from game.data.building_data import FORTIFICATION_UNITS_ID, FORTIFICATION_UNITS
 from game.db import unit_type_from_name
-from pydcs.dcs.mission import *
-from pydcs.dcs.statics import *
-from pydcs.dcs.task import (
-    ActivateBeaconCommand,
-    ActivateICLSCommand,
-    OptAlarmState,
-)
-from pydcs.dcs.unit import Ship, Vehicle
-from pydcs.dcs.unitgroup import StaticGroup
 from .airfields import RunwayData
 from .conflictgen import *
 from .naming import *

--- a/gen/kneeboard.py
+++ b/gen/kneeboard.py
@@ -29,8 +29,8 @@ from typing import Dict, List, Optional, Tuple
 from PIL import Image, ImageDraw, ImageFont
 from tabulate import tabulate
 
-from pydcs.dcs.mission import Mission
-from pydcs.dcs.unittype import FlyingType
+from dcs.mission import Mission
+from dcs.unittype import FlyingType
 from . import units
 from .aircraft import FlightData
 from .airfields import RunwayData


### PR DESCRIPTION
I've been wrongly importing these from `pydcs.dcs` instead of just `dcs`,
because that was what PyCharm thought they were. These will all be
broken when we get back to using a real pydcs instead of relying on
its directory being in our tree.

This page in the wiki should be updated:
https://github.com/Khopa/dcs_liberation/wiki/Developer's-Guide

Instead of recommending that `PYTHONPATH` be updated in the run
configuration, it should instead recommend that Settings -> Project:
dcs_liberation -> Project Structure be set to exclude the pydcs
directory from the dcs_liberation content root, and add the pydcs
directory as a *separate* content root.

Alternatively, we could recommend that configure a virtualenv (good
advice anyway, and pycharm knows how to set them up) that have people
run `pip install -e pydcs`.

I think even easier would be switching from the virtualenv-style
requirements.txt to pipenv, which can actually encode the `-e` style
pip install into its equivalent of requirements.txt.