### PR TITLE
Fix radio information.

### DIFF
--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -49,8 +49,11 @@ UHF_FALLBACK_CHANNEL = MHz(251)
 class AircraftData:
     """Additional aircraft data not exposed by pydcs."""
 
-    #: The type of radios used by this plane
-    radios: List[Radio]
+    #: The type of radio used for inter-flight communications.
+    inter_flight_radio: Radio
+
+    #: The type of radio used for intra-flight communications.
+    intra_flight_radio: Radio
 
     #: Index of the radio used for intra-flight communications. Matches the
     #: index of the panel_radio field of the pydcs.dcs.planes object.
@@ -60,33 +63,28 @@ class AircraftData:
     #: index of the panel_radio field of the pydcs.dcs.planes object.
     intra_flight_radio_index: Optional[int]
 
-    @property
-    def intra_flight_radio(self):
-        return self.radios[self.intra_flight_radio_index-1]
-
-    @property
-    def inter_flight_radio(self):
-        return self.radios[self.inter_flight_radio_index-1]
-
 
 # Indexed by the id field of the pydcs PlaneType.
 AIRCRAFT_DATA: Dict[str, AircraftData] = {
     "A-10C": AircraftData(
-        [get_radio("AN/ARC-186(V) AM")],
+        inter_flight_radio=get_radio("AN/ARC-164"),
+        intra_flight_radio=get_radio("AN/ARC-186(V) AM"),
         # The A-10's radio works differently than most aircraft. Doesn't seem to
         # be a way to set these from the mission editor, let alone pydcs.
         inter_flight_radio_index=None,
         intra_flight_radio_index=None
     ),
     "F-16C_50": AircraftData(
-        [get_radio("AN/ARC-164"), get_radio("AN/ARC-222")],
+        inter_flight_radio=get_radio("AN/ARC-164"),
+        intra_flight_radio=get_radio("AN/ARC-222"),
         # COM2 is the AN/ARC-222, which is the VHF radio we want to use for
         # intra-flight communication to leave COM1 open for UHF inter-flight.
         inter_flight_radio_index=1,
         intra_flight_radio_index=2
     ),
     "FA-18C_hornet": AircraftData(
-        [get_radio("AN/ARC-210"), get_radio("AN/ARC-210")],
+        inter_flight_radio=get_radio("AN/ARC-210"),
+        intra_flight_radio=get_radio("AN/ARC-210"),
         # DCS will clobber channel 1 of the first radio compatible with the
         # flight's assigned frequency. Since the F/A-18's two radios are both
         # AN/ARC-210s, radio 1 will be compatible regardless of which frequency
@@ -96,13 +94,15 @@ AIRCRAFT_DATA: Dict[str, AircraftData] = {
     ),
 
     "M-2000C": AircraftData(
-        [get_radio("TRT ERA 7000 V/UHF"), get_radio("TRT ERA 7200 UHF")],
+        inter_flight_radio=get_radio("TRT ERA 7000 V/UHF"),
+        intra_flight_radio=get_radio("TRT ERA 7200 UHF"),
         inter_flight_radio_index=1,
         intra_flight_radio_index=2
     ),
 
     "F-14B": AircraftData(
-        [get_radio("AN/ARC-159"), get_radio("AN/ARC-182")],
+        inter_flight_radio=get_radio("AN/ARC-159"),
+        intra_flight_radio=get_radio("AN/ARC-182"),
         inter_flight_radio_index=1,
         intra_flight_radio_index=2
     )

--- a/gen/radios.py
+++ b/gen/radios.py
@@ -102,16 +102,20 @@ RADIOS: List[Radio] = [
     Radio("A.R.I. 1063", MHz(100), MHz(156), step=MHz(1)),
     Radio("BC-1206", kHz(200), kHz(400), step=kHz(10)),
 
-    # Note : The M2000C V/UHF radio has a gap between 149.970 and 225.000Mhz
-    Radio("TRT ERA 7000 V/UHF", MHz(118), MHz(400), step=MHz(1)),
+    # Note: The M2000C V/UHF can operate in both ranges, but has a gap between
+    # 150 MHz and 225 MHz. We can't allocate in that gap, and the current
+    # system doesn't model gaps, so just pretend it ends at 150 MHz for now. We
+    # can model gaps later if needed.
+    Radio("TRT ERA 7000 V/UHF", MHz(118), MHz(150), step=MHz(1)),
     Radio("TRT ERA 7200 UHF", MHz(225), MHz(400), step=MHz(1)),
 
     # Tomcat radios
     # # https://www.heatblur.se/F-14Manual/general.html#an-arc-159-uhf-1-radio
-    Radio("AN/ARC-159", MHz(225), MHz(399, 975), step=MHz(1)),
-    # AN/ARC-182, can operate : 30 to 88, 108 to 156, 156 to 174, and 225 to 399.975 MHz
+    Radio("AN/ARC-159", MHz(225), MHz(400), step=MHz(1)),
+    # AN/ARC-182 can also operate from 30 MHz to 88 MHz, as well as from 225 MHz
+    # to 400 MHz range, but we can't model gaps with the current implementation.
     # https://www.heatblur.se/F-14Manual/general.html#an-arc-182-v-uhf-2-radio
-    Radio("AN/ARC-182", MHz(108), MHz(399, 975), step=MHz(1))
+    Radio("AN/ARC-182", MHz(108), MHz(174), step=MHz(1)),
 ]
 
 


### PR DESCRIPTION
Not every aircraft has a pydcs radio index, so we can't use that to
index into a list. Any mission with an A-10C crashes, since it would
try to use `None - 1` to index into the list of radios to find the
intra-flight radio.

Also fix the radio ranges for the newly added radios. The current
implementation can't model gaps, so extending the radio ranges across
those gaps means that we might allocate channels that aren't tunable
by those radios. Additionally, the end frequency is exclusive rather
than inclusive, so fix the ranges to include that last tunable
frequency.