### PR TITLE
Handle callsigns for flights.

### DIFF
--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -199,7 +199,7 @@ class Operation:
                 )
 
         # Generate ground units on frontline everywhere
-        self.game.jtacs = []
+        jtacs: List[JtacInfo] = []
         for player_cp, enemy_cp in self.game.theater.conflicts(True):
             conflict = Conflict.frontline_cas_conflict(self.attacker_name, self.defender_name,
                                                        self.current_mission.country(self.attacker_country),
@@ -210,6 +210,7 @@ class Operation:
             enemy_gp = self.game.ground_planners[enemy_cp.id].units_per_cp[player_cp.id]
             groundConflictGen = GroundConflictGenerator(self.current_mission, conflict, self.game, player_gp, enemy_gp, player_cp.stances[enemy_cp.id])
             groundConflictGen.generate()
+            jtacs.extend(groundConflictGen.jtacs)
 
         # Setup combined arms parameters
         self.current_mission.groundControl.pilot_can_control_vehicles = self.ca_slots > 0
@@ -250,8 +251,8 @@ class Operation:
                 if not self.game.settings.jtac_smoke_on:
                     smoke = "false"
 
-            for jtac in self.game.jtacs:
-                script = script + "\n" + "JTACAutoLase('" + str(jtac[2]) + "', " + str(jtac[1]) + ", " + smoke + ", \"vehicle\")" + "\n"
+            for jtac in jtacs:
+                script += f"\nJTACAutoLase('{jtac.unit_name}', {jtac.code}, {smoke}, 'vehicle')\n"
 
             load_autolase.add_action(DoScript(String(script)))
         self.current_mission.triggerrules.triggers.append(load_autolase)
@@ -282,9 +283,7 @@ class Operation:
                 self.briefinggen.add_awacs(awacs)
                 kneeboard_generator.add_awacs(awacs)
 
-        for region, code, name in self.game.jtacs:
-            # TODO: Radio info? Type?
-            jtac = JtacInfo(name, region, code)
+        for jtac in jtacs:
             self.briefinggen.add_jtac(jtac)
             kneeboard_generator.add_jtac(jtac)
 

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -2,13 +2,14 @@ import os
 from collections import defaultdict
 from dataclasses import dataclass
 import random
-from typing import List, Tuple
+from typing import List
 
 from game import db
 from dcs.mission import Mission
 from .aircraft import FlightData
 from .airfields import RunwayData
 from .airsupportgen import AwacsInfo, TankerInfo
+from .armor import JtacInfo
 from .conflictgen import Conflict
 from .ground_forces.combat_stance import CombatStance
 from .radios import RadioFrequency
@@ -19,14 +20,6 @@ class CommInfo:
     """Communications information for the kneeboard."""
     name: str
     freq: RadioFrequency
-
-
-@dataclass
-class JtacInfo:
-    """JTAC information for the kneeboard."""
-    callsign: str
-    region: str
-    code: str
 
 
 class MissionInfoGenerator:

--- a/gen/kneeboard.py
+++ b/gen/kneeboard.py
@@ -109,9 +109,7 @@ class BriefingPage(KneeboardPage):
 
     def write(self, path: Path) -> None:
         writer = KneeboardPageWriter()
-        # TODO: Assign callsigns to flights and include that info.
-        # https://github.com/Khopa/dcs_liberation/issues/113
-        writer.title(f"Mission Info")
+        writer.title(f"{self.flight.callsign} Mission Info")
 
         # TODO: Handle carriers.
         writer.heading("Airfield Info")


### PR DESCRIPTION
We don't configure the callsigns that pydcs uses, so instead read
those from pydcs and use them where appropriate instead of just
guessing.

Fixes https://github.com/Khopa/dcs_liberation/issues/113.