### PR TITLE
Add radio information for more aircraft.

### DIFF
--- a/gen/airsupportgen.py
+++ b/gen/airsupportgen.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from .aircraft import callsign_for_support_unit
+from .callsigns import callsign_for_support_unit
 from .conflictgen import *
 from .naming import *
 from .radios import RadioFrequency, RadioRegistry

--- a/gen/armor.py
+++ b/gen/armor.py
@@ -6,7 +6,7 @@ from dcs.triggers import TriggerOnce, Event
 
 from gen import namegen
 from gen.ground_forces.ai_ground_planner import CombatGroupRole, DISTANCE_FROM_FRONTLINE
-from .aircraft import callsign_for_support_unit
+from .callsigns import callsign_for_support_unit
 from .conflictgen import *
 
 SPREAD_DISTANCE_FACTOR = 0.1, 0.3

--- a/gen/callsigns.py
+++ b/gen/callsigns.py
@@ -1,0 +1,34 @@
+"""Support for working with DCS group callsigns."""
+import logging
+import re
+
+from dcs.unitgroup import FlyingGroup
+from dcs.flyingunit import FlyingUnit
+
+
+def callsign_for_support_unit(group: FlyingGroup) -> str:
+    # Either something like Overlord11 for Western AWACS, or else just a number.
+    # Convert to either "Overlord" or "Flight 123".
+    lead = group.units[0]
+    raw_callsign = lead.callsign_as_str()
+    try:
+        return f"Flight {int(raw_callsign)}"
+    except ValueError:
+        return raw_callsign.rstrip("1234567890")
+
+
+def create_group_callsign_from_unit(lead: FlyingUnit) -> str:
+    raw_callsign = lead.callsign_as_str()
+    if not lead.callsign_is_western:
+        # Callsigns for non-Western countries are just a number per flight,
+        # similar to tail numbers.
+        return f"Flight {raw_callsign}"
+
+    # Callsign from pydcs is in the format `<name><group ID><unit ID>`,
+    # where unit ID is guaranteed to be a single digit but the group ID may
+    # be more.
+    match = re.search(r"^(\D+)(\d+)(\d)$", raw_callsign)
+    if match is None:
+        logging.error(f"Could not parse unit callsign: {raw_callsign}")
+        return f"Flight {raw_callsign}"
+    return f"{match.group(1)} {match.group(2)}"

--- a/gen/radios.py
+++ b/gen/radios.py
@@ -116,6 +116,12 @@ RADIOS: List[Radio] = [
     # to 400 MHz range, but we can't model gaps with the current implementation.
     # https://www.heatblur.se/F-14Manual/general.html#an-arc-182-v-uhf-2-radio
     Radio("AN/ARC-182", MHz(108), MHz(174), step=MHz(1)),
+
+    # Also capable of [103, 156) at 25 kHz intervals, but we can't do gaps.
+    Radio("FR 22", MHz(225), MHz(400), step=kHz(50)),
+
+    Radio("R&S M3AR VHF", MHz(108), MHz(174), step=MHz(1)),
+    Radio("R&S M3AR UHF", MHz(225), MHz(400), step=MHz(1)),
 ]
 
 


### PR DESCRIPTION
Adds the following:

* AJS37
* AV-8B
* JF-17

This does move the preset channel allocation logic into its own class,
since we need to customize that behavior for the AJS37 since it has a
rather unique preset channel layout (see the comments in
`ViggenRadioChannelAllocator` for details).