### PR TITLE
Ensure that allocated channels are reserved.

### DIFF
--- a/gen/radios.py
+++ b/gen/radios.py
@@ -183,6 +183,7 @@ class RadioRegistry:
         try:
             while (channel := next(allocator)) in self.allocated_channels:
                 pass
+            self.reserve(channel)
             return channel
         except StopIteration:
             raise OutOfChannelsError(radio)


### PR DESCRIPTION
This was previously mostly working because the allocator itself was
moving forward, but since each radio has its own allocator, aircraft
with different radios would often get overlapping intra-flight
frequencies.