### PR TITLE
Fix typo in CombatStance enumeration

### DIFF
--- a/game/event/event.py
+++ b/game/event/event.py
@@ -267,7 +267,7 @@ class Event:
 
                 ratio = (1.0 + enemy_casualties) / (1.0 + ally_casualties)
 
-                player_aggresive = cp.stances[enemy_cp.id] in [CombatStance.AGGRESIVE, CombatStance.ELIMINATION, CombatStance.BREAKTHROUGH]
+                player_aggresive = cp.stances[enemy_cp.id] in [CombatStance.AGGRESSIVE, CombatStance.ELIMINATION, CombatStance.BREAKTHROUGH]
 
                 if ally_units_alive == 0:
                     player_won = False

--- a/gen/armor.py
+++ b/gen/armor.py
@@ -30,7 +30,7 @@ class GroundConflictGenerator:
         self.enemy_planned_combat_groups = enemy_planned_combat_groups
         self.player_planned_combat_groups = player_planned_combat_groups
         self.player_stance = CombatStance(player_stance)
-        self.enemy_stance = random.choice([CombatStance.AGGRESIVE, CombatStance.AGGRESIVE, CombatStance.AGGRESIVE, CombatStance.ELIMINATION, CombatStance.BREAKTHROUGH]) if len(enemy_planned_combat_groups) > len(player_planned_combat_groups) else random.choice([CombatStance.DEFENSIVE, CombatStance.DEFENSIVE, CombatStance.DEFENSIVE, CombatStance.AMBUSH, CombatStance.AGGRESIVE])
+        self.enemy_stance = random.choice([CombatStance.AGGRESSIVE, CombatStance.AGGRESSIVE, CombatStance.AGGRESSIVE, CombatStance.ELIMINATION, CombatStance.BREAKTHROUGH]) if len(enemy_planned_combat_groups) > len(player_planned_combat_groups) else random.choice([CombatStance.DEFENSIVE, CombatStance.DEFENSIVE, CombatStance.DEFENSIVE, CombatStance.AMBUSH, CombatStance.AGGRESSIVE])
         self.game = game
 
     def _group_point(self, point) -> Point:
@@ -222,7 +222,7 @@ class GroundConflictGenerator:
                                 u.heading = forward_heading + random.randint(-5,5)
 
             elif group.role in [CombatGroupRole.TANK, CombatGroupRole.IFV]:
-                if stance == CombatStance.AGGRESIVE:
+                if stance == CombatStance.AGGRESSIVE:
                     # Attack nearest enemy if any
                     # Then move forward OR Attack enemy base if it is not too far away
                     target = self.find_nearest_enemy_group(dcs_group, enemy_groups)
@@ -263,7 +263,7 @@ class GroundConflictGenerator:
 
             elif group.role in [CombatGroupRole.APC, CombatGroupRole.ATGM]:
 
-                if stance in [CombatStance.AGGRESIVE, CombatStance.BREAKTHROUGH, CombatStance.ELIMINATION]:
+                if stance in [CombatStance.AGGRESSIVE, CombatStance.BREAKTHROUGH, CombatStance.ELIMINATION]:
                     # APC & ATGM will never move too much forward, but will follow along any offensive
                     if to_cp.position.distance_to_point(dcs_group.points[0].position) <= AGGRESIVE_MOVE_DISTANCE:
                         attack_point = to_cp.position.random_point_within(500, 0)

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -148,7 +148,7 @@ class BriefingGenerator:
                     self.description += "We do not have a single vehicle available to hold our position, the situation is critical, and we will lose ground inevitably.\n"
                 elif enemy_base.base.total_armor == 0:
                     self.description += "The enemy forces have been crushed, we will be able to make significant progress toward " + enemy_base.name + ". \n"
-                if stance == CombatStance.AGGRESIVE:
+                if stance == CombatStance.AGGRESSIVE:
                     if has_numerical_superiority:
                         self.description += "On this location, our ground forces will try to make progress against the enemy"
                         self.description += ". As the enemy is outnumbered, our forces should have no issue making progress.\n"

--- a/gen/ground_forces/ai_ground_planner.py
+++ b/gen/ground_forces/ai_ground_planner.py
@@ -197,7 +197,7 @@ DISTANCE_FROM_FRONTLINE = {
 
 GROUP_SIZES_BY_COMBAT_STANCE = {
     CombatStance.DEFENSIVE: [2, 4, 6],
-    CombatStance.AGGRESIVE: [2, 4, 6],
+    CombatStance.AGGRESSIVE: [2, 4, 6],
     CombatStance.RETREAT: [2, 4, 6, 8],
     CombatStance.BREAKTHROUGH: [4, 6, 6, 8],
     CombatStance.ELIMINATION: [2, 4, 4, 4, 6],

--- a/gen/ground_forces/combat_stance.py
+++ b/gen/ground_forces/combat_stance.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class CombatStance(Enum):
     DEFENSIVE = 0    # Unit will adopt defensive stance with medium group of units
-    AGGRESIVE = 1    # Unit will attempt to make progress with medium sized group of units
+    AGGRESSIVE = 1    # Unit will attempt to make progress with medium sized group of units
     RETREAT = 2      # Unit will retreat
     BREAKTHROUGH = 3 # Unit will attempt a breakthrough, rushing forward very aggresively with big group of armored units, and even less armored units will move aggresively
     ELIMINATION = 4  # Unit will progress aggresively toward anemy units, attempting to eliminate the ennemy force


### PR DESCRIPTION
Just a small typo fix in the CombatStance enumeration. The "typo" is visible when selecting the stance of the ground forces.