### PR TITLE
External scripts plugin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+  
     {
       "name": "Python: Main",
       "type": "python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "python.pythonPath": "g:\\python\\dcs_liberation\\venv\\Scripts\\python.exe",
   "vsintellicode.python.completionsEnabled": true
 }

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -234,29 +234,27 @@ class Operation:
         if self.game.settings.perf_smoke_gen:
             self.visualgen.generate()
 
+        # Inject Plugins Lua Scripts
+        listOfPluginsScripts = []
+        try:
+            with open("./resources/scripts/plugins/__plugins.lst", "r") as a_file:
+                for line in a_file:
+                    name = line.strip()
+                    if not name.startswith( '#' ):
+                        trigger = TriggerStart(comment="Load " + name)
+                        listOfPluginsScripts.append(name)
+                        fileref = self.current_mission.map_resource.add_resource_file("./resources/scripts/plugins/" + name)
+                        trigger.add_action(DoScriptFile(fileref))
+                        self.current_mission.triggerrules.triggers.append(trigger)
+        except Exception as e:
+            print(e)
+
         # Inject Lua Scripts
-        load_mist = TriggerStart(comment="Load Mist Lua Framework")
-        with open("./resources/scripts/mist_4_3_74.lua") as f:
-            load_mist.add_action(DoScript(String(f.read())))
-        self.current_mission.triggerrules.triggers.append(load_mist)
-
-        # Load Ciribob's JTACAutoLase script
-        load_autolase = TriggerStart(comment="Load JTAC script")
-        with open("./resources/scripts/JTACAutoLase.lua") as f:
-
-            script = f.read()
-            script = script + "\n"
-
-            smoke = "true"
-            if hasattr(self.game.settings, "jtac_smoke_on"):
-                if not self.game.settings.jtac_smoke_on:
-                    smoke = "false"
-
-            for jtac in jtacs:
-                script += f"\nJTACAutoLase('{jtac.unit_name}', {jtac.code}, {smoke}, 'vehicle')\n"
-
-            load_autolase.add_action(DoScript(String(script)))
-        self.current_mission.triggerrules.triggers.append(load_autolase)
+        if not "mist.lua" in listOfPluginsScripts and not "mist_4_3_74.lua" in listOfPluginsScripts:
+            trigger = TriggerStart(comment="Load Mist Lua Framework")
+            fileref = self.current_mission.map_resource.add_resource_file("./resources/scripts/mist_4_3_74.lua")
+            trigger.add_action(DoScriptFile(fileref))
+            self.current_mission.triggerrules.triggers.append(trigger)
 
         load_dcs_libe = TriggerStart(comment="Load DCS Liberation Script")
         with open("./resources/scripts/dcs_liberation.lua") as f:
@@ -267,6 +265,26 @@ class Operation:
             script = script.replace("{{debriefing_file_location}}", state_location)
             load_dcs_libe.add_action(DoScript(String(script)))
         self.current_mission.triggerrules.triggers.append(load_dcs_libe)
+
+
+        # Load Ciribob's JTACAutoLase script
+        if not "JTACAutoLase.lua" in listOfPluginsScripts:
+            load_autolase = TriggerStart(comment="Load JTAC script")
+            with open("./resources/scripts/JTACAutoLase.lua") as f:
+
+                script = f.read()
+                script = script + "\n"
+
+                smoke = "true"
+                if hasattr(self.game.settings, "jtac_smoke_on"):
+                    if not self.game.settings.jtac_smoke_on:
+                        smoke = "false"
+
+                for jtac in jtacs:
+                    script += f"\nJTACAutoLase('{jtac.unit_name}', {jtac.code}, {smoke}, 'vehicle')\n"
+
+                load_autolase.add_action(DoScript(String(script)))
+            self.current_mission.triggerrules.triggers.append(load_autolase)
 
         self.assign_channels_to_flights()
 

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -555,6 +555,10 @@ class AircraftConflictGenerator:
         group.points[0].tasks.append(OptReactOnThreat(OptReactOnThreat.Values.EvadeFire))
 
         channel = self.get_intra_flight_channel(unit_type)
+        if group.units[0].skill == Skill.Client:
+            aircraft_data = AIRCRAFT_DATA[unit_type.id]
+            channel = self.radio_registry.alloc_for_radio(aircraft_data.inter_flight_radio)
+            
         group.set_frequency(channel.mhz)
 
         # TODO: Support for different departure/arrival airfields.

--- a/resources/scripts/MissionScripting.original.lua
+++ b/resources/scripts/MissionScripting.original.lua
@@ -2,16 +2,29 @@
 
 dofile('Scripts/ScriptingSystem.lua')
 
+-- Add LuaSocket to the LUAPATH, so that it can be found.
+package.path  = package.path..";.\\LuaSocket\\?.lua;"
+
 --Sanitize Mission Scripting environment
---This makes unavailable some unsecure functions.
+--This makes unavailable some unsecure functions. 
 --Mission downloaded from server to client may contain potentialy harmful lua code that may use these functions.
 --You can remove the code below and make availble these functions at your own risk.
 
 local function sanitizeModule(name)
+	local veafName = "veafSanitized_"..name
+	_G[veafName] = _G[name]
+	package.loaded[veafName] = package.loaded[name]
 	_G[name] = nil
 	package.loaded[name] = nil
 end
 
+do
+	witchcraft = {}
+	witchcraft.host = "localhost"
+	witchcraft.port = 3001
+	dofile(lfs.writedir().."Scripts\\witchcraft.lua")
+end
+	
 do
 	sanitizeModule('os')
 	sanitizeModule('io')

--- a/resources/scripts/plugins/__plugins.lst
+++ b/resources/scripts/plugins/__plugins.lst
@@ -1,0 +1,1 @@
+# this is a list of lua scripts that will be loaded, in order


### PR DESCRIPTION
corrected bug with Client A-10C group frequency
  For A-10C groups with a Client or Player first unit, it is now
  forbidden to use a VHF frequency for the group.

introduced lua plugins
  The resources/scripts/plugins/__plugins.lst file should contain a
  a list of lua scripts that will be loaded (in order) from the
  resources/scripts/plugins/ folder

You can safely ignore the changes from the "configuration for VEAF" commit, it's specific for my use.