### PR TITLE
UHF Intraflight Frequency for Player and Clients A-10C

### DIFF
--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -374,7 +374,7 @@ class AircraftData:
 AIRCRAFT_DATA: Dict[str, AircraftData] = {
     "A-10C": AircraftData(
         inter_flight_radio=get_radio("AN/ARC-164"),
-        intra_flight_radio=get_radio("AN/ARC-186(V) AM"),
+        intra_flight_radio=get_radio("AN/ARC-164"),
         channel_allocator=WarthogRadioChannelAllocator()
     ),
 

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -374,7 +374,7 @@ class AircraftData:
 AIRCRAFT_DATA: Dict[str, AircraftData] = {
     "A-10C": AircraftData(
         inter_flight_radio=get_radio("AN/ARC-164"),
-        intra_flight_radio=get_radio("AN/ARC-164"),
+        intra_flight_radio=get_radio("AN/ARC-164"), # VHF for intraflight is not accepted anymore by DCS (see https://forums.eagle.ru/showthread.php?p=4499738)
         channel_allocator=WarthogRadioChannelAllocator()
     ),
 


### PR DESCRIPTION
In the mission editor, using a VHF frequency for a Player or Client A-10C results in an error. 
I changed the radio definitions to use AN/ARC-164 for intraflight comms.

See [my post](https://forums.eagle.ru/showthread.php?p=4499738) on the DCS World forums.