### PR TITLE
Introduced LUA scripts plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ logs/liberation.log
 qt_ui/logs/liberation.log
 
 *.psd
+resources/scripts/plugins/*

--- a/resources/scripts/plugins/__plugins.lst.sample
+++ b/resources/scripts/plugins/__plugins.lst.sample
@@ -1,0 +1,29 @@
+# this is a list of lua scripts that will be injected in the mission, in the same order
+mist.lua
+Moose.lua
+CTLD.lua
+NIOD.lua
+WeatherMark.lua
+veaf.lua
+dcsUnits.lua
+# JTACAutoLase is an empty file, only there to disable loading the official script (already included in CTLD)
+JTACAutoLase.lua
+veafAssets.lua
+veafCarrierOperations.lua
+veafCarrierOperations2.lua
+veafCasMission.lua
+veafCombatMission.lua
+veafCombatZone.lua
+veafGrass.lua
+veafInterpreter.lua
+veafMarkers.lua
+veafMove.lua
+veafNamedPoints.lua
+veafRadio.lua
+veafRemote.lua
+veafSecurity.lua
+veafShortcuts.lua
+veafSpawn.lua
+veafTransportMission.lua
+veafUnits.lua
+missionConfig.lua

--- a/resources/scripts/plugins/link.cmd.sample
+++ b/resources/scripts/plugins/link.cmd.sample
@@ -1,0 +1,29 @@
+rem this can be used to easily create hardlinks from your plugin development folder
+
+mklink mist.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\community\mist.lua
+mklink Moose.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\community\Moose.lua
+mklink CTLD.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\community\CTLD.lua
+mklink NIOD.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\community\NIOD.lua
+mklink WeatherMark.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\community\WeatherMark.lua
+mklink veaf.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veaf.lua
+mklink dcsUnits.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\dcsUnits.lua
+mklink JTACAutoLase.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\JTACAutoLase.lua
+mklink veafAssets.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafAssets.lua
+mklink veafCarrierOperations.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafCarrierOperations.lua
+mklink veafCarrierOperations2.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafCarrierOperations2.lua
+mklink veafCasMission.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafCasMission.lua
+mklink veafCombatMission.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafCombatMission.lua
+mklink veafCombatZone.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafCombatZone.lua
+mklink veafGrass.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafGrass.lua
+mklink veafInterpreter.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafInterpreter.lua
+mklink veafMarkers.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafMarkers.lua
+mklink veafMove.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafMove.lua
+mklink veafNamedPoints.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafNamedPoints.lua
+mklink veafRadio.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafRadio.lua
+mklink veafRemote.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafRemote.lua
+mklink veafSecurity.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafSecurity.lua
+mklink veafShortcuts.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafShortcuts.lua
+mklink veafSpawn.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafSpawn.lua
+mklink veafTransportMission.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafTransportMission.lua
+mklink veafUnits.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\veafUnits.lua
+mklink missionConfig.lua d:\dev\_VEAF\VEAF-Mission-Creation-Tools\src\scripts\veaf\missionConfig.lua


### PR DESCRIPTION
In order to be able to customize the scripts that can be injected in the
mission, a __plugin.lst file is read and the scripts mentionned in this
file are injected (through DoScriptFile and not DoScript).

A mechanism checks if a standard script (Mist, JTACAutolase) has
already been loaded, to avoid loading them twice.

This has been made to allow generating mission that have the VEAF
scripts framework in them (see [here](https://github.com/VEAF/VEAF-Mission-Creation-Tools))