### PR TITLE
add tanker type to tanker name

### DIFF
--- a/gen/airsupportgen.py
+++ b/gen/airsupportgen.py
@@ -65,7 +65,7 @@ class AirSupportConflictGenerator:
             tanker_position = player_cp.position.point_from_heading(tanker_heading, TANKER_DISTANCE)
             tanker_group = self.mission.refuel_flight(
                 country=self.mission.country(self.game.player_country),
-                name=namegen.next_tanker_name(self.mission.country(self.game.player_country)),
+                name=namegen.next_tanker_name(self.mission.country(self.game.player_country), tanker_unit_type),
                 airport=None,
                 plane_type=tanker_unit_type,
                 position=tanker_position,

--- a/gen/naming.py
+++ b/gen/naming.py
@@ -61,9 +61,9 @@ class NameGenerator:
         self.number += 1
         return "awacs|{}|{}|0|".format(country.id, self.number)
 
-    def next_tanker_name(self, country):
+    def next_tanker_name(self, country, unit_type):
         self.number += 1
-        return "tanker|{}|{}|0|".format(country.id, self.number)
+        return "tanker|{}|{}|0|{}".format(country.id, self.number, db.unit_type_name(unit_type))
 
     def next_carrier_name(self, country):
         self.number += 1


### PR DESCRIPTION
This is because I use the group name as the tanker name in a command menu (in my VEAF scripts, namely the one called "Move Tanker to me" which calls a tanker to the player's position), and it's easier to distinguish between tankers when their type is in their name.