### PR TITLE
Make mission portable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 2.x.x
+* **[Mission Generator]** Use inline loading of the JSON.lua library, and save to either %LIBERATION_EXPORT_DIR%, to %TEMP%, or to DCS working directory
+
 # 2.1.2
 
 ## Fixes :

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -250,22 +250,25 @@ class Operation:
             print(e)
 
         # Inject Mist Script if not done already in the plugins
-        if not "mist.lua" in listOfPluginsScripts and not "mist_4_3_74.lua" in listOfPluginsScripts: # don't load mist twice
-            trigger = TriggerStart(comment="Load Mist Lua Framework")
+        if not "mist.lua" in listOfPluginsScripts and not "mist_4_3_74.lua" in listOfPluginsScripts: # don't load the script twice
+            trigger = TriggerStart(comment="Load Mist Lua framework")
             fileref = self.current_mission.map_resource.add_resource_file("./resources/scripts/mist_4_3_74.lua")
             trigger.add_action(DoScriptFile(fileref))
             self.current_mission.triggerrules.triggers.append(trigger)
 
-        # Inject Liberation script
-        load_dcs_libe = TriggerStart(comment="Load DCS Liberation Script")
-        with open("./resources/scripts/dcs_liberation.lua") as f:
-            script = f.read()
-            json_location = "[["+os.path.abspath("resources\\scripts\\json.lua")+"]]"
-            state_location = "[[" + os.path.abspath("state.json") + "]]"
-            script = script.replace("{{json_file_abs_location}}", json_location)
-            script = script.replace("{{debriefing_file_location}}", state_location)
-            load_dcs_libe.add_action(DoScript(String(script)))
-        self.current_mission.triggerrules.triggers.append(load_dcs_libe)
+        # Inject JSON library if not done already in the plugins
+        if not "json.lua" in listOfPluginsScripts : # don't load the script twice
+            trigger = TriggerStart(comment="Load JSON Lua library")
+            fileref = self.current_mission.map_resource.add_resource_file("./resources/scripts/json.lua")
+            trigger.add_action(DoScriptFile(fileref))
+            self.current_mission.triggerrules.triggers.append(trigger)
+
+        # Inject DCS-Liberation script if not done already in the plugins
+        if not "json.lua" in listOfPluginsScripts : # don't load the script twice
+            trigger = TriggerStart(comment="Load DCS Liberation script")
+            fileref = self.current_mission.map_resource.add_resource_file("./resources/scripts/dcs_liberation.lua")
+            trigger.add_action(DoScriptFile(fileref))
+            self.current_mission.triggerrules.triggers.append(trigger)
 
         # Load Ciribob's JTACAutoLase script if not done already in the plugins
         if not "JTACAutoLase.lua" in listOfPluginsScripts: # don't load JTACAutoLase twice

--- a/resources/scripts/dcs_liberation.lua
+++ b/resources/scripts/dcs_liberation.lua
@@ -1,9 +1,5 @@
-local jsonlib = {{json_file_abs_location}}
-json = loadfile(jsonlib)()
-
 logger = mist.Logger:new("DCSLiberation", "info")
-
-debriefing_file_location = {{debriefing_file_location}}
+logger:info("Check that json.lua is loaded : json = "..tostring(json))
 
 killed_aircrafts = {}
 killed_ground_units = {}
@@ -32,12 +28,41 @@ write_state = function()
         ["mission_ended"] = mission_ended,
         ["destroyed_objects_positions"] = destroyed_objects_positions,
     }
+    if not json then
+        local message = string.format("Unable to save DCS Liberation state to %s, JSON library is not loaded !",debriefing_file_location)
+        logger:error(message)
+        messageAll(message)
+    end
     fp:write(json:encode(game_state))
     fp:close()
     -- logger.info("Done writing DCS Liberation state")
     -- messageAll("Done writing DCS Liberation state.")
 end
 
+
+debriefing_file_location = nil
+if not debriefing_file_location then
+    if os then
+        debriefing_file_location = os.getenv("LIBERATION_EXPORT_DIR")
+        if debriefing_file_location then debriefing_file_location = debriefing_file_location .. "\\" end
+    end
+end
+if not debriefing_file_location then
+    if os then
+        debriefing_file_location = os.getenv("TEMP")
+        if debriefing_file_location then debriefing_file_location = debriefing_file_location .. "\\" end
+    end
+end
+if not debriefing_file_location then
+    if lfs then
+        debriefing_file_location = lfs.writedir()
+    end
+end
+if debriefing_file_location then
+    debriefing_file_location = debriefing_file_location .. "state.json"
+end
+
+logger:info(string.format("DCS Liberation state will be written as json to [[%s]]",debriefing_file_location))
 
 write_state_error_handling = function()
     if pcall(write_state) then

--- a/resources/scripts/dcs_liberation.lua
+++ b/resources/scripts/dcs_liberation.lua
@@ -39,30 +39,45 @@ write_state = function()
     -- messageAll("Done writing DCS Liberation state.")
 end
 
-
 debriefing_file_location = nil
-if not debriefing_file_location then
+if dcsLiberation then 
+    debriefing_file_location = dcsLiberation.installPath
+end
+if debriefing_file_location then
+    logger:info("Using DCS Liberation install folder for state.json")
+else
     if os then
         debriefing_file_location = os.getenv("LIBERATION_EXPORT_DIR")
         if debriefing_file_location then debriefing_file_location = debriefing_file_location .. "\\" end
     end
-end
-if not debriefing_file_location then
-    if os then
-        debriefing_file_location = os.getenv("TEMP")
-        if debriefing_file_location then debriefing_file_location = debriefing_file_location .. "\\" end
-    end
-end
-if not debriefing_file_location then
-    if lfs then
-        debriefing_file_location = lfs.writedir()
+    if debriefing_file_location then
+        logger:info("Using LIBERATION_EXPORT_DIR environment variable for state.json")
+    else
+        if os then
+            debriefing_file_location = os.getenv("TEMP")
+            if debriefing_file_location then debriefing_file_location = debriefing_file_location .. "\\" end
+        end
+        if debriefing_file_location then
+            logger:info("Using TEMP environment variable for state.json")
+        else
+            if lfs then
+                debriefing_file_location = lfs.writedir()
+            end
+            if debriefing_file_location then
+                logger:info("Using DCS working directory for state.json")
+            end
+        end
     end
 end
 if debriefing_file_location then
-    debriefing_file_location = debriefing_file_location .. "state.json"
+    local filename = "state.json"
+    if not debriefing_file_location:sub(-#filename) == filename then
+        debriefing_file_location = debriefing_file_location .. filename
+    end
+    logger:info(string.format("DCS Liberation state will be written as json to [[%s]]",debriefing_file_location))
+else
+    logger:error("No usable storage path for state.json")
 end
-
-logger:info(string.format("DCS Liberation state will be written as json to [[%s]]",debriefing_file_location))
 
 write_state_error_handling = function()
     if pcall(write_state) then

--- a/resources/scripts/json.lua
+++ b/resources/scripts/json.lua
@@ -968,7 +968,7 @@ function OBJDEF:new(args)
    return setmetatable(new, OBJDEF)
 end
 
-return OBJDEF:new()
+json = OBJDEF:new()
 
 --
 -- Version history:


### PR DESCRIPTION
Uses inline json.lua and write to %LIBERATION_EXPORT_DIR%, %TEMP%, or the DCS working directory
Removes the need to modify the LUA code from dcs_liberation.lua to store the absolute path where Liberation is installed.
This makes it easier to generate the mission on a computer, run it on another one (e.g. a server) and transferring the `state.json` file back to the first computer later.
Keep in mind that the computer running the mission (the server, then) will still have to not be sanitized (meaning that a manual edit of the `Scripts/MissionScripting.lua` file to remove the sanitizing lines). User can easily copy the Liberation version of `MissionScripting.lua` to the server