### PR TITLE
Fixes issue Khopa#203 TER weapons not selectable in custom payload

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 
 ## Fixes :
 * **[Campaign generator]** Ship group and offshore buildings should not be generated on land anymore 
-
+* **[UI]** Missing TER weapons in custom payload now selectable.
 
 # 2.1.5
 

--- a/qt_ui/windows/mission/flight/payload/QPylonEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QPylonEditor.py
@@ -11,7 +11,7 @@ class QPylonEditor(QComboBox):
         self.pylon_number = pylon_number
         self.flight = flight
 
-        self.possible_loadout = [i for i in self.pylon.__dict__.keys() if i[:1] != '_']
+        self.possible_loadout = [i for i in self.pylon.__dict__.keys() if i[:2] != '__']
 
         if not str(self.pylon_number) in self.flight.loadout.keys():
             self.flight.loadout[str(self.pylon_number)] = ""


### PR DESCRIPTION
Conditional in comprehension appears to be intended to exclude dunders, but was also excluding many TER weapons from Weapon class variables beginning with '_'