### PR TITLE
Specify a name to the flight for multiplayer dispatching

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -53,8 +53,8 @@ class Debriefing:
 
         for aircraft in self.killed_aircrafts:
             try:
-                country = int(aircraft.split("|")[1])
-                type = db.unit_type_from_name(aircraft.split("|")[4])
+                country = int(aircraft.split("|")[2])
+                type = db.unit_type_from_name(aircraft.split("|")[5])
                 player_unit = (country == self.player_country_id)
                 aircraft = DebriefingDeadUnitInfo(country, player_unit, type)
                 if type is not None:

--- a/game/event/event.py
+++ b/game/event/event.py
@@ -107,8 +107,8 @@ class Event:
         cp_map = {cp.id: cp for cp in self.game.theater.controlpoints}
         for destroyed_aircraft in debriefing.killed_aircrafts:
             try:
-                cpid = int(destroyed_aircraft.split("|")[3])
-                type = db.unit_type_from_name(destroyed_aircraft.split("|")[4])
+                cpid = int(destroyed_aircraft.split("|")[4])
+                type = db.unit_type_from_name(destroyed_aircraft.split("|")[5])
                 if cpid in cp_map.keys():
                     cp = cp_map[cpid]
                     if type in cp.base.aircraft.keys():

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -786,7 +786,7 @@ class AircraftConflictGenerator:
                 if flight.client_count == 0 and culled:
                     logging.info("Flight not generated: culled")
                     continue
-                logging.info(f"Generating flight: {flight.unit_type}")
+                logging.info(f"Generating flight: {flight.name} of {flight.unit_type}")
                 group = self.generate_planned_flight(flight.from_cp, country,
                                                      flight)
                 self.setup_flight_group(group, flight, dynamic_runways)
@@ -842,7 +842,7 @@ class AircraftConflictGenerator:
         try:
             if flight.start_type == "In Flight":
                 group = self._generate_inflight(
-                    name=namegen.next_unit_name(country, cp.id, flight.unit_type),
+                    name=namegen.next_unit_name(flight.name, country, cp.id, flight.unit_type),
                     side=country,
                     unit_type=flight.unit_type,
                     count=flight.count,
@@ -850,7 +850,7 @@ class AircraftConflictGenerator:
             elif cp.is_fleet:
                 group_name = cp.get_carrier_group_name()
                 group = self._generate_at_group(
-                    name=namegen.next_unit_name(country, cp.id, flight.unit_type),
+                    name=namegen.next_unit_name(flight.name, country, cp.id, flight.unit_type),
                     side=country,
                     unit_type=flight.unit_type,
                     count=flight.count,
@@ -858,7 +858,7 @@ class AircraftConflictGenerator:
                     at=self.m.find_group(group_name))
             else:
                 group = self._generate_at_airport(
-                    name=namegen.next_unit_name(country, cp.id, flight.unit_type),
+                    name=namegen.next_unit_name(flight.name, country, cp.id, flight.unit_type),
                     side=country,
                     unit_type=flight.unit_type,
                     count=flight.count,
@@ -870,7 +870,7 @@ class AircraftConflictGenerator:
             logging.warning("No room on runway or parking slots. Starting from the air.")
             flight.start_type = "In Flight"
             group = self._generate_inflight(
-                name=namegen.next_unit_name(country, cp.id, flight.unit_type),
+                name=namegen.next_unit_name(flight.name, country, cp.id, flight.unit_type),
                 side=country,
                 unit_type=flight.unit_type,
                 count=flight.count,

--- a/gen/armor.py
+++ b/gen/armor.py
@@ -479,7 +479,7 @@ class GroundConflictGenerator:
         logging.info("armorgen: {} for {}".format(unit, side.id))
         group = self.mission.vehicle_group(
                 side,
-                namegen.next_unit_name(side, cp.id, unit), unit,
+                namegen.next_unit_name("dusty", side, cp.id, unit), unit,
                 position=self._group_point(at),
                 group_size=count,
                 heading=heading,

--- a/gen/flights/ai_flight_planner.py
+++ b/gen/flights/ai_flight_planner.py
@@ -206,7 +206,7 @@ class PackageBuilder:
         if assignment is None:
             return False
         airfield, aircraft = assignment
-        flight = Flight(aircraft, plan.num_aircraft, airfield, plan.task,
+        flight = Flight("ai", aircraft, plan.num_aircraft, airfield, plan.task,
                         self.start_type)
         self.package.add_flight(flight)
         flight.targetPoint = self.package.target

--- a/gen/flights/flight.py
+++ b/gen/flights/flight.py
@@ -133,6 +133,7 @@ class FlightWaypoint:
 
 
 class Flight:
+    name: str = None
     count: int = 0
     client_count: int = 0
     use_custom_loadout = False
@@ -140,8 +141,9 @@ class Flight:
     group = False # Contains DCS Mission group data after mission has been generated
     targetPoint = None # Contains either None or a Strike/SEAD target point location 
 
-    def __init__(self, unit_type: UnitType, count: int, from_cp: ControlPoint,
+    def __init__(self, name: str, unit_type: UnitType, count: int, from_cp: ControlPoint,
                  flight_type: FlightType, start_type: str) -> None:
+        self.name = name
         self.unit_type = unit_type
         self.count = count
         self.from_cp = from_cp

--- a/gen/naming.py
+++ b/gen/naming.py
@@ -46,9 +46,9 @@ class NameGenerator:
         self.number = 0
         self.ANIMALS = NameGenerator.ANIMALS.copy()
 
-    def next_unit_name(self, country, parent_base_id, unit_type):
+    def next_unit_name(self, flight_name, country, parent_base_id, unit_type):
         self.number += 1
-        return "unit|{}|{}|{}|{}|".format(country.id, self.number, parent_base_id, db.unit_type_name(unit_type))
+        return "unit|{}|{}|{}|{}|{}|".format(country.id, flight_name, self.number, parent_base_id, db.unit_type_name(unit_type))
 
     def next_infantry_name(self, country, parent_base_id, unit_type):
         self.number += 1
@@ -76,7 +76,6 @@ class NameGenerator:
             animal = random.choice(self.ANIMALS)
             self.ANIMALS.remove(animal)
             return animal
-
 
 namegen = NameGenerator()
 

--- a/qt_ui/widgets/ato.py
+++ b/qt_ui/widgets/ato.py
@@ -60,12 +60,13 @@ class FlightDelegate(QStyledItemDelegate):
 
     def first_row_text(self, index: QModelIndex) -> str:
         flight = self.flight(index)
+        flight_name = flight.name
         task = flight.flight_type.name
         count = flight.count
         name = db.unit_type_name(flight.unit_type)
         estimator = TotEstimator(self.package)
         delay = datetime.timedelta(seconds=estimator.mission_start_time(flight))
-        return f"[{task}] {count} x {name} in {delay}"
+        return f"{flight_name} - [{task}] {count} x {name} in {delay}"
 
     def second_row_text(self, index: QModelIndex) -> str:
         flight = self.flight(index)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -5,6 +5,7 @@ from PySide2.QtWidgets import (
     QDialog,
     QPushButton,
     QVBoxLayout,
+    QLineEdit
 )
 from dcs.planes import PlaneType
 
@@ -33,6 +34,13 @@ class QFlightCreator(QDialog):
         self.setWindowIcon(EVENT_ICONS["strike"])
 
         layout = QVBoxLayout()
+
+        self.flight_name = QLineEdit()
+        # todo: auto generate a friendly flight name
+        # option 1: auto-increment name
+        # option 2: auto-increment by global flight number
+        layout.addLayout(QLabeledWidget("Name:", self.flight_name))
+        # todo: also on the edit screen
 
         self.task_selector = QFlightTypeComboBox(
             self.game.theater, package.target
@@ -98,6 +106,7 @@ class QFlightCreator(QDialog):
             self.error_box("Could not create flight", error)
             return
 
+        name = self.flight_name.text()
         task = self.task_selector.currentData()
         aircraft = self.aircraft_selector.currentData()
         origin = self.airfield_selector.currentData()
@@ -107,7 +116,7 @@ class QFlightCreator(QDialog):
             start_type = "Cold"
         else:
             start_type = "Warm"
-        flight = Flight(aircraft, size, origin, task, start_type)
+        flight = Flight(name, aircraft, size, origin, task, start_type)
         flight.scheduled_in = self.package.delay
         flight.client_count = self.client_slots_spinner.value()
 

--- a/qt_ui/windows/mission/flight/settings/QFlightTypeTaskInfo.py
+++ b/qt_ui/windows/mission/flight/settings/QFlightTypeTaskInfo.py
@@ -1,12 +1,13 @@
-from PySide2.QtWidgets import QLabel, QHBoxLayout, QGroupBox, QSpinBox, QGridLayout
+from PySide2.QtWidgets import QLabel, QGroupBox, QLineEdit, QGridLayout
 
 from game import db
+from gen.flights.flight import Flight
 from qt_ui.uiconstants import AIRCRAFT_ICONS
 
 
 class QFlightTypeTaskInfo(QGroupBox):
 
-    def __init__(self, flight):
+    def __init__(self, flight: Flight):
         super(QFlightTypeTaskInfo, self).__init__("Flight")
         self.flight = flight
 
@@ -20,9 +21,20 @@ class QFlightTypeTaskInfo(QGroupBox):
         self.task_type = QLabel(flight.flight_type.name)
         self.task_type.setProperty("style", flight.flight_type.name)
 
+        self.name = QLineEdit()
+        self.name.setText(flight.name)
+        self.name.textChanged.connect(self.name_changed)
+        # self.sette
+
         layout.addWidget(self.aircraft_icon, 0, 0)
 
-        layout.addWidget(self.task, 1, 0)
-        layout.addWidget(self.task_type, 1, 1)
+        layout.addWidget(QLabel("Name :"), 1, 0)
+        layout.addWidget(self.name, 1, 1)
+
+        layout.addWidget(self.task, 2, 0)
+        layout.addWidget(self.task_type, 2, 1)
 
         self.setLayout(layout)
+
+    def name_changed(self, new_name):
+        self.flight.name = new_name


### PR DESCRIPTION
### Background

At our squadron, we have different specialities and would sub-divide our flights accordingly (about 20-40 players). Ideally, we would like to identify the aircraft during the role selection screen as flights will have different loadouts, and so forth. See the illustration-

![image](https://user-images.githubusercontent.com/178498/97102544-7e357600-16fa-11eb-888e-e4e1c67ee183.png)


### Changes Required

Because the state tracking uses the unit name, some modifications to the naming

# Warning: Currently WIP as PR - Ideas and Arguments welcomed!

I have identified the following tasks before I am happy to submit a PR:

- [ ] Default naming of flights. None is fine, but is it the finese I want :)
- [ ] Don't string split everywhere - let's put that up into a single parser which knows how to pick out the different attributes from the string.
- [ ] Should we be giving names to AI or ground units?