### PR TITLE
Improve CAS AI Behavior 

### DIFF
--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -1165,10 +1165,9 @@ class IngressBuilder(PydcsWaypointBuilder):
         self.set_waypoint_tot(waypoint, self.timing.ingress)
         return waypoint
 
-class CasIngressBuilder(PydcsWaypointBuilder):
+class CasIngressBuilder(IngressBuilder):
     def build(self) -> MovingPoint:
         waypoint = super().build()
-        self.set_waypoint_tot(waypoint, self.timing.ingress)
         ingress_waypoint = self.get_flight_point('INGRESS')
         cas_waypoint = self.get_flight_point('CAS')
         try:

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -1163,7 +1163,10 @@ class CasIngressBuilder(PydcsWaypointBuilder):
         waypoint = super().build()
         self.set_waypoint_tot(waypoint, self.timing.ingress)
         waypoint.add_task(EngageTargets(max_distance=nm_to_meter(10),
-                              targets=[Targets.All.GroundUnits.GroundVehicles])
+                              targets=[
+                                  Targets.All.GroundUnits.GroundVehicles,
+                                  Targets.All.GroundUnits.AirDefence,
+                              ])
         )
         waypoint.add_task(OptROE(OptROE.Values.OpenFireWeaponFree))
         return waypoint

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -935,10 +935,6 @@ class AircraftConflictGenerator:
             roe=OptROE.Values.OpenFireWeaponFree,
             rtb_winchester=OptRTBOnOutOfAmmo.Values.Unguided,
             restrict_jettison=True)
-        group.points[0].tasks.append(
-            EngageTargets(max_distance=nm_to_meter(10),
-                          targets=[Targets.All.GroundUnits.GroundVehicles])
-        )
 
     def configure_sead(self, group: FlyingGroup, package: Package,
                       flight: Flight,
@@ -1114,7 +1110,7 @@ class PydcsWaypointBuilder:
                      mission: Mission) -> PydcsWaypointBuilder:
         builders = {
             FlightWaypointType.EGRESS: EgressPointBuilder,
-            FlightWaypointType.INGRESS_CAS: IngressBuilder,
+            FlightWaypointType.INGRESS_CAS: CasIngressBuilder,
             FlightWaypointType.INGRESS_ESCORT: IngressBuilder,
             FlightWaypointType.INGRESS_SEAD: SeadIngressBuilder,
             FlightWaypointType.INGRESS_STRIKE: StrikeIngressBuilder,
@@ -1162,6 +1158,14 @@ class IngressBuilder(PydcsWaypointBuilder):
         self.set_waypoint_tot(waypoint, self.timing.ingress)
         return waypoint
 
+class CasIngressBuilder(PydcsWaypointBuilder):
+    def build(self) -> MovingPoint:
+        waypoint = super().build()
+        self.set_waypoint_tot(waypoint, self.timing.ingress)
+        waypoint.add_task(EngageTargets(max_distance=nm_to_meter(10),
+                              targets=[Targets.All.GroundUnits.GroundVehicles])
+        )
+        return waypoint
 
 class SeadIngressBuilder(IngressBuilder):
     def build(self) -> MovingPoint:

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -1161,31 +1161,35 @@ class IngressBuilder(PydcsWaypointBuilder):
         self.set_waypoint_tot(waypoint, self.timing.ingress)
         return waypoint
 
+
 class CasIngressBuilder(IngressBuilder):
     def build(self) -> MovingPoint:
         waypoint = super().build()
-        try:
-            cas_waypoint = self.flight.waypoint_with_type((FlightWaypointType.CAS,))
-            waypoint.add_task(EngageTargetsInZone(
-                                position=cas_waypoint.position,
-                                radius=FRONTLINE_LENGTH / 2,
-                                targets=[
-                                    Targets.All.GroundUnits.GroundVehicles,
-                                    Targets.All.GroundUnits.AirDefence.AAA,
-                                    Targets.All.GroundUnits.Infantry,
-                                ])
+        cas_waypoint = self.flight.waypoint_with_type((FlightWaypointType.CAS,))
+        if cas_waypoint is None:
+            logging.error(
+                "No CAS waypoint found. Falling back to search and engage")
+            waypoint.add_task(EngageTargets(
+                max_distance=nm_to_meter(10),
+                targets=[
+                    Targets.All.GroundUnits.GroundVehicles,
+                    Targets.All.GroundUnits.AirDefence.AAA,
+                    Targets.All.GroundUnits.Infantry,
+                ])
             )
-        except AttributeError:
-            logging.exception('Unable to create CAS target zone.  Falling back to search and engage')
-            waypoint.add_task(EngageTargets(max_distance=nm_to_meter(10),
-                              targets=[
-                                  Targets.All.GroundUnits.GroundVehicles,
-                                  Targets.All.GroundUnits.AirDefence.AAA,
-                                  Targets.All.GroundUnits.Infantry,
-                              ])
+        else:
+            waypoint.add_task(EngageTargetsInZone(
+                position=cas_waypoint.position,
+                radius=FRONTLINE_LENGTH / 2,
+                targets=[
+                    Targets.All.GroundUnits.GroundVehicles,
+                    Targets.All.GroundUnits.AirDefence.AAA,
+                    Targets.All.GroundUnits.Infantry,
+                ])
             )
         waypoint.add_task(OptROE(OptROE.Values.OpenFireWeaponFree))
         return waypoint
+
 
 class SeadIngressBuilder(IngressBuilder):
     def build(self) -> MovingPoint:

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -1165,7 +1165,8 @@ class CasIngressBuilder(PydcsWaypointBuilder):
         waypoint.add_task(EngageTargets(max_distance=nm_to_meter(10),
                               targets=[
                                   Targets.All.GroundUnits.GroundVehicles,
-                                  Targets.All.GroundUnits.AirDefence,
+                                  Targets.All.GroundUnits.AirDefence.AAA,
+                                  Targets.All.GroundUnits.Infantry,
                               ])
         )
         waypoint.add_task(OptROE(OptROE.Values.OpenFireWeaponFree))

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -932,7 +932,7 @@ class AircraftConflictGenerator:
         self.configure_behavior(
             group,
             react_on_threat=OptReactOnThreat.Values.EvadeFire,
-            roe=OptROE.Values.OpenFireWeaponFree,
+            roe=OptROE.Values.WeaponHold,
             rtb_winchester=OptRTBOnOutOfAmmo.Values.Unguided,
             restrict_jettison=True)
 
@@ -1165,6 +1165,7 @@ class CasIngressBuilder(PydcsWaypointBuilder):
         waypoint.add_task(EngageTargets(max_distance=nm_to_meter(10),
                               targets=[Targets.All.GroundUnits.GroundVehicles])
         )
+        waypoint.add_task(OptROE(OptROE.Values.OpenFireWeaponFree))
         return waypoint
 
 class SeadIngressBuilder(IngressBuilder):


### PR DESCRIPTION
I tested the CAS flight plans with different airframes and scenarios, and found that "Search Then Engage In Zone" task type provides most consistent desirable AI behavior (providing CAS at the frontline). 

This update uses the INGRESS and CAS WP locations of the flight to calculate frontline size for zone radius, and CAS WP location for the center of zone.  If ever those waypoints are not available for whatever reason, it falls back to the previous "Search and Engage" within 10nm method.
Related to issue #195 