### PR TITLE
Use python, not py.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
 
     - name: Install environment
       run: |
-        py -m venv ./venv
+        python -m venv ./venv
 
     - name: Install dependencies
       run: |
         ./venv/scripts/activate
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
         # For some reason the shiboken2.abi3.dll is not found properly, so I copy it instead
         Copy-Item .\venv\Lib\site-packages\shiboken2\shiboken2.abi3.dll .\venv\Lib\site-packages\PySide2\ -Force
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
 
     - name: Install environment
       run: |
-        py -m venv ./venv
+        python -m venv ./venv
 
     - name: Install dependencies
       run: |
         ./venv/scripts/activate
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
         # For some reason the shiboken2.abi3.dll is not found properly, so I copy it instead
         Copy-Item .\venv\Lib\site-packages\shiboken2\shiboken2.abi3.dll .\venv\Lib\site-packages\PySide2\ -Force
 


### PR DESCRIPTION
py is a shortcut that launches the *latest* version of Python on the
machine. https://stackoverflow.com/a/50896577/632035

The build machines were updated to include python 3.9, so we were
doing everything with 3.9 instead of 3.8. pyproj doesn't have a binary
wheel for 3.9 on pypi yet, so we were falling back to building it from
source, which we aren't able to do, breaking the build.