### PR TITLE
WIP Briefing Refactor - Adds jinja2 dependency

### DIFF
--- a/game/operation/frontlineattack.py
+++ b/game/operation/frontlineattack.py
@@ -35,6 +35,7 @@ class FrontlineAttackOperation(Operation):
                         conflict=conflict)
 
     def generate(self):
-        self.briefinggen.title = "Frontline CAS"
-        self.briefinggen.description = "Provide CAS for the ground forces attacking enemy lines. Operation will be considered successful if total number of enemy units will be lower than your own by a factor of 1.5 (i.e. with 12 units from both sides, enemy forces need to be reduced to at least 8), meaning that you (and, probably, your wingmans) should concentrate on destroying the enemy units. Target base strength will be lowered as a result. Be advised that your flight will not attack anything until you explicitly tell them so by comms menu."
+        ## TODO: What are these for?
+        # self.briefinggen.title = "Frontline CAS"
+        # self.briefinggen.description = "Provide CAS for the ground forces attacking enemy lines. Operation will be considered successful if total number of enemy units will be lower than your own by a factor of 1.5 (i.e. with 12 units from both sides, enemy forces need to be reduced to at least 8), meaning that you (and, probably, your wingmans) should concentrate on destroying the enemy units. Target base strength will be lowered as a result. Be advised that your flight will not attack anything until you explicitly tell them so by comms menu."
         super(FrontlineAttackOperation, self).generate()

--- a/game/operation/frontlineattack.py
+++ b/game/operation/frontlineattack.py
@@ -35,7 +35,4 @@ class FrontlineAttackOperation(Operation):
                         conflict=conflict)
 
     def generate(self):
-        ## TODO: What are these for?
-        # self.briefinggen.title = "Frontline CAS"
-        # self.briefinggen.description = "Provide CAS for the ground forces attacking enemy lines. Operation will be considered successful if total number of enemy units will be lower than your own by a factor of 1.5 (i.e. with 12 units from both sides, enemy forces need to be reduced to at least 8), meaning that you (and, probably, your wingmans) should concentrate on destroying the enemy units. Target base strength will be lowered as a result. Be advised that your flight will not attack anything until you explicitly tell them so by comms menu."
         super(FrontlineAttackOperation, self).generate()

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -479,6 +479,7 @@ dcsLiberation.TargetPoints = {
 
         self.assign_channels_to_flights(airgen.flights,
                                         airsupportgen.air_support)
+        self.notify_info_generators(groundobjectgen, airsupportgen, jtacs, airgen)
 
     def assign_channels_to_flights(self, flights: List[FlightData],
                                    air_support: AirSupport) -> None:

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -357,9 +357,9 @@ class Operation:
                         "position": { "x": flightTarget.position.x, "y": flightTarget.position.y}
                     }
                 
-
-        self.briefinggen.generate()
-        kneeboard_generator.generate()
+        ## These are being called twice in this method?
+        # self.briefinggen.generate()
+        # kneeboard_generator.generate()
 
 
         # set a LUA table with data from Liberation that we want to set

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -300,12 +300,12 @@ class Operation:
                                         airsupportgen.air_support)
 
         kneeboard_generator = KneeboardGenerator(self.current_mission)
-        for dynamic_runway in groundobjectgen.runways.values():
-            self.briefinggen.add_dynamic_runway(dynamic_runway)
+        # for dynamic_runway in groundobjectgen.runways.values():
+        #     self.briefinggen.add_dynamic_runway(dynamic_runway)
 
         for tanker in airsupportgen.air_support.tankers:
-            self.briefinggen.add_tanker(tanker)
-            kneeboard_generator.add_tanker(tanker)
+            # self.briefinggen.add_tanker(tanker)
+            # kneeboard_generator.add_tanker(tanker)
             luaData["Tankers"][tanker.callsign] = { 
                 "dcsGroupName": tanker.dcsGroupName,
                 "callsign": tanker.callsign,
@@ -316,8 +316,8 @@ class Operation:
 
         if self.is_awacs_enabled:
             for awacs in airsupportgen.air_support.awacs:
-                self.briefinggen.add_awacs(awacs)
-                kneeboard_generator.add_awacs(awacs)
+                # self.briefinggen.add_awacs(awacs)
+                # kneeboard_generator.add_awacs(awacs)
                 luaData["AWACs"][awacs.callsign] = { 
                     "dcsGroupName": awacs.dcsGroupName,
                     "callsign": awacs.callsign,
@@ -325,8 +325,8 @@ class Operation:
                 }
 
         for jtac in jtacs:
-            self.briefinggen.add_jtac(jtac)
-            kneeboard_generator.add_jtac(jtac)
+            # self.briefinggen.add_jtac(jtac)
+            # kneeboard_generator.add_jtac(jtac)
             luaData["JTACs"][jtac.callsign] = { 
                 "dcsGroupName": jtac.dcsGroupName,
                 "callsign": jtac.callsign,
@@ -336,8 +336,8 @@ class Operation:
             }
 
         for flight in airgen.flights:
-            self.briefinggen.add_flight(flight)
-            kneeboard_generator.add_flight(flight)
+            # self.briefinggen.add_flight(flight)
+            # kneeboard_generator.add_flight(flight)
             if flight.friendly and flight.flight_type in [FlightType.ANTISHIP, FlightType.DEAD, FlightType.SEAD, FlightType.STRIKE]:
                 flightType = flight.flight_type.name
                 flightTarget = flight.package.target

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -90,8 +90,7 @@ class Operation:
     def initialize(self, mission: Mission, conflict: Conflict):
         self.current_mission = mission
         self.conflict = conflict
-        self.briefinggen = BriefingGenerator(self.current_mission,
-                                             self.conflict, self.game)
+        self.briefinggen = BriefingGenerator(self.current_mission, self.game)
 
     def prepare(self, terrain: Terrain, is_quick: bool):
         with open("resources/default_options.lua", "r") as f:

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Dict, List, Optional, Type, Union
 
 from dcs import helicopters
@@ -272,6 +273,10 @@ class FlightData:
     def aircraft_type(self) -> FlyingType:
         """Returns the type of aircraft in this flight."""
         return self.units[0].unit_type
+    
+    @property
+    def departure_delay_delta(self) -> timedelta:
+        return timedelta(seconds=self.departure_delay)
 
     def num_radio_channels(self, radio_id: int) -> int:
         """Returns the number of preset channels for the given radio."""

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -1,3 +1,6 @@
+'''
+Briefing generation logic
+'''
 import os
 import random
 import logging
@@ -58,7 +61,7 @@ class FrontLineInfo:
                     "critical, and we will lose ground inevitably.")
         elif self.enemy_zero:
             return ("The enemy forces have been crushed, we will be able to make significant progress"
-                    f" toward {enemy_base.name}.")
+                    f" toward {self.enemy_base.name}.")
         return None
 
     @property
@@ -73,14 +76,14 @@ class FrontLineInfo:
         elif self.stance == CombatStance.ELIMINATION:
             return (
                 "On this location, our ground forces will focus on the destruction of enemy"
-                f"assets, before attempting to make progress toward {enemy_base.name}. "
+                f"assets, before attempting to make progress toward {self.enemy_base.name}. "
                 "The enemy is already outnumbered, and this maneuver might draw a final "
                 "blow to their forces."
             )
         elif self.stance == CombatStance.BREAKTHROUGH:
             return (
                 "On this location, our ground forces will focus on progression toward "
-                f"{enemy_base.name}."
+                f"{self.enemy_base.name}."
             )
         elif self.stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
             return (
@@ -109,7 +112,7 @@ class FrontLineInfo:
         elif self.stance == CombatStance.BREAKTHROUGH:
             return (
                 "On this location, our ground forces have been ordered to rush toward "
-                f"{enemy_base.name}. Wish them luck... We are also expecting a counter attack."
+                f"{self.enemy_base.name}. Wish them luck... We are also expecting a counter attack."
             )
         elif self.stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
             return (
@@ -131,6 +134,8 @@ class FrontLineInfo:
             situation += self._advantage_description
         else:
             situation += self._disadvantage_description
+        return situation
+        
 class MissionInfoGenerator:
     """Base type for generators of mission information for the player.
 

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -1,6 +1,8 @@
 import os
 import random
+import logging
 from dataclasses import dataclass
+from theater.frontline import FrontLine
 from typing import List, Dict, TYPE_CHECKING
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -9,7 +11,8 @@ from dcs.mission import Mission
 from .aircraft import FlightData
 from .airsupportgen import AwacsInfo, TankerInfo
 from .armor import JtacInfo
-from .conflictgen import Conflict
+# from .conflictgen import Conflict
+from theater import ControlPoint
 from .ground_forces.combat_stance import CombatStance
 from .radios import RadioFrequency
 from .runways import RunwayData
@@ -23,18 +26,6 @@ class CommInfo:
     """Communications information for the kneeboard."""
     name: str
     freq: RadioFrequency
-
-
-@dataclass
-class BriefingInfo:
-    description: str
-
-
-@dataclass
-class FrontLineInfo(BriefingInfo):
-    enemy_base: str
-    player_base: str
-
 
 class MissionInfoGenerator:
     """Base type for generators of mission information for the player.
@@ -102,9 +93,9 @@ class MissionInfoGenerator:
 
 class BriefingGenerator(MissionInfoGenerator):
 
-    def __init__(self, mission: Mission, conflict: Conflict, game: 'Game'):
+    def __init__(self, mission: Mission, game: 'Game'):
         super().__init__(mission)
-        self.conflict = conflict
+        # self.conflict = conflict
         self.game = game
         self.title = ""
         self.description = ""
@@ -129,74 +120,15 @@ class BriefingGenerator(MissionInfoGenerator):
         self.dynamic_runways.append(runway)
 
     def generate(self):
-        self.generate_ongoing_war_text()
+        self._generate_frontline_info()
         self.generate_allied_flights_by_departure()
         self.mission.set_description_text(self.template.render(vars(self)))
         self.mission.add_picture_blue(os.path.abspath(
             "./resources/ui/splash_screen.png"))
 
-    def __random_frontline_sentence(self, player_base_name, enemy_base_name):
-        templates = [
-            "There are combats between {} and {}. ",
-            "The war on the ground is still going on between {} and {}. ",
-            "Our ground forces in {} are opposed to enemy forces based in {}. ",
-            "Our forces from {} are fighting enemies based in {}. ",
-            "There is an active frontline between {} and {}. ",
-        ]
-        return random.choice(templates).format(player_base_name, enemy_base_name)
-
-    # TODO: refactor this, perhaps move to FrontLineInfo factory object or template?
-    def generate_ongoing_war_text(self):
+    def _generate_frontline_info(self):
         for front_line in self.game.theater.conflicts(from_player=True):
-            player_base = front_line.control_point_a
-            enemy_base = front_line.control_point_b
-            has_numerical_superiority = player_base.base.total_armor > enemy_base.base.total_armor
-            description = self.__random_frontline_sentence(player_base.name, enemy_base.name)
-            stance = player_base.stances[enemy_base.id]
-            if player_base.base.total_armor == 0:
-                player_zero = True
-                description += ("We do not have a single vehicle available to hold our position, the situation is"
-                                "critical, and we will lose ground inevitably.\n")
-            elif enemy_base.base.total_armor == 0:
-                player_zero = False
-                description += ("The enemy forces have been crushed, we will be able to make significant progress"
-                                f" toward {enemy_base.name}. \n")
-            else:
-                player_zero = False
-            if not player_zero:
-                if stance == CombatStance.AGGRESSIVE:
-                    if has_numerical_superiority:
-                        description += ("On this location, our ground forces will try to make "
-                                        "progress against the enemy. As the enemy is outnumbered, "
-                                        "our forces should have no issue making progress.\n")
-                    else:
-                        description += ("On this location, our ground forces will try an audacious "
-                                        "assault against enemies in superior numbers. The operation"
-                                        " is risky, and the enemy might counter attack.\n")
-                elif stance == CombatStance.ELIMINATION:
-                    if has_numerical_superiority:
-                        description += ("On this location, our ground forces will focus on the destruction of enemy"
-                                        f"assets, before attempting to make progress toward {enemy_base.name}. "
-                                        "The enemy is already outnumbered, and this maneuver might draw a final "
-                                        "blow to their forces.\n")
-                    else:
-                        description += ("On this location, our ground forces will try an audacious assault against "
-                                        "enemies in superior numbers. The operation is risky, and the enemy might "
-                                        "counter attack.\n")
-                elif stance == CombatStance.BREAKTHROUGH:
-                    if has_numerical_superiority:
-                        description += ("On this location, our ground forces will focus on progression toward "
-                                        f"{enemy_base.name}.\n")
-                    else:
-                        description += ("On this location, our ground forces have been ordered to rush toward "
-                                        f"{enemy_base.name}. Wish them luck... We are also expecting a counter attack.\n")
-                elif stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
-                    if has_numerical_superiority:
-                        description += "On this location, our ground forces will hold position. We are not expecting an enemy assault.\n"
-                    else:
-                        description += ("On this location, our ground forces have been ordered to hold still, "
-                                        "and defend against enemy attacks. An enemy assault might be iminent.\n")
-            self.add_frontline(FrontLineInfo(description, enemy_base, player_base))
+            self.add_frontline(front_line)
 
     # TODO: This should determine if runway is friendly through a method more robust than the existing string match
     def generate_allied_flights_by_departure(self) -> None:
@@ -207,3 +139,109 @@ class BriefingGenerator(MissionInfoGenerator):
                     self.allied_flights_by_departure[name].append(flight)
                 else:
                     self.allied_flights_by_departure[name] = [flight]
+
+@dataclass
+class FrontLineInfo:
+    front_line: FrontLine
+    description: str = FrontLine.name
+    player_base: ControlPoint = FrontLine.control_point_a
+    enemy_base: ControlPoint = FrontLine.control_point_b
+    player_zero: bool = player_base.base.total_armor == 0
+    enemy_zero: bool = enemy_base.base.total_armor == 0
+    advantage: bool = player_base.base.total_armor > enemy_base.base.total_armor
+    stance: CombatStance = player_base.stances[enemy_base.id]
+    
+
+    @property
+    def _random_frontline_sentence(self) -> str:
+        '''Random sentences for start of situation briefing'''
+        templates = [
+            f"There are combats between {self.player_base.name} and {self.enemy_base.name}. ",
+            f"The war on the ground is still going on between {self.player_base.name} and {self.enemy_base.name}. ",
+            f"Our ground forces in {self.player_base.name} are opposed to enemy forces based in {self.enemy_base.name}. ",
+            f"Our forces from {self.player_base.name} are fighting enemies based in {self.enemy_base.name}. ",
+            f"There is an active frontline between {self.player_base.name} and {self.enemy_base.name}. ",
+        ]
+        return random.choice(templates)
+    
+    @property
+    def _zero_units_sentence(self) -> str:
+        '''Situation description if either side has zero units on a frontline'''
+        if self.player_zero:
+            return ("We do not have a single vehicle available to hold our position, the situation is"
+                    "critical, and we will lose ground inevitably.")
+        elif self.enemy_zero:
+            return ("The enemy forces have been crushed, we will be able to make significant progress"
+                    f" toward {enemy_base.name}.")
+
+    @property
+    def _advantage_description(self) -> str:
+        '''Situation description for when player has numerical advantage on the frontline'''
+        if self.stance == CombatStance.AGGRESSIVE:
+            return (
+                "On this location, our ground forces will try to make "
+                "progress against the enemy. As the enemy is outnumbered, "
+                "our forces should have no issue making progress."
+                )
+        elif self.stance == CombatStance.ELIMINATION:
+            return (
+                "On this location, our ground forces will focus on the destruction of enemy"
+                f"assets, before attempting to make progress toward {enemy_base.name}. "
+                "The enemy is already outnumbered, and this maneuver might draw a final "
+                "blow to their forces."
+            )
+        elif self.stance == CombatStance.BREAKTHROUGH:
+            return (
+                "On this location, our ground forces will focus on progression toward "
+                f"{enemy_base.name}."
+            )
+        elif self.stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
+            return (
+                "On this location, our ground forces will hold position. We are not expecting an enemy assault."
+            )
+        # TODO: Write a situation description for player RETREAT stance
+        elif self.stance == CombatStance.RETREAT:
+            return ''
+        else:
+            logging.warning('Briefing did not receive a known CombatStance')
+    
+    @property
+    def _disadvantage_description(self):
+        if self.stance == CombatStance.AGGRESSIVE:
+            return (
+                "On this location, our ground forces will try an audacious "
+                "assault against enemies in superior numbers. The operation"
+                " is risky, and the enemy might counter attack."
+                )
+        elif self.stance == CombatStance.ELIMINATION:
+            return (
+                "On this location, our ground forces will try an audacious assault against "
+                "enemies in superior numbers. The operation is risky, and the enemy might "
+                "counter attack.\n"
+            )
+        elif self.stance == CombatStance.BREAKTHROUGH:
+            return (
+                "On this location, our ground forces have been ordered to rush toward "
+                f"{enemy_base.name}. Wish them luck... We are also expecting a counter attack."
+            )
+        elif self.stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
+            return (
+                "On this location, our ground forces have been ordered to hold still, "
+                "and defend against enemy attacks. An enemy assault might be iminent."
+            )
+        # TODO: Write a situation description for player RETREAT stance
+        elif self.stance == CombatStance.RETREAT:
+            return ''
+        else:
+            logging.warning('Briefing did not receive a known CombatStance')
+    
+    @property
+    def brief(self):
+        if self.player_zero:
+            return self._zero_units_sentence
+        
+        situation = self._zero_units_sentence
+        if self.advantage:
+            situation += self._advantage_description
+        else:
+            situation += self._disadvantage_description

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -1,13 +1,11 @@
-import datetime
 import os
 import random
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict, TYPE_CHECKING
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from dcs.mission import Mission
 
-from game import db
 from .aircraft import FlightData
 from .airsupportgen import AwacsInfo, TankerInfo
 from .armor import JtacInfo
@@ -16,12 +14,26 @@ from .ground_forces.combat_stance import CombatStance
 from .radios import RadioFrequency
 from .runways import RunwayData
 
+if TYPE_CHECKING:
+    from game import Game
+
 
 @dataclass
 class CommInfo:
     """Communications information for the kneeboard."""
     name: str
     freq: RadioFrequency
+
+
+@dataclass
+class BriefingInfo:
+    description: str
+
+
+@dataclass
+class FrontLineInfo(BriefingInfo):
+    enemy_base: str
+    player_base: str
 
 
 class MissionInfoGenerator:
@@ -37,6 +49,7 @@ class MissionInfoGenerator:
         self.flights: List[FlightData] = []
         self.jtacs: List[JtacInfo] = []
         self.tankers: List[TankerInfo] = []
+        self.frontlines: List[FrontLineInfo] = []
 
     def add_awacs(self, awacs: AwacsInfo) -> None:
         """Adds an AWACS/GCI to the mission.
@@ -79,6 +92,9 @@ class MissionInfoGenerator:
         """
         self.tankers.append(tanker)
 
+    def add_frontline(self, frontline: FrontLineInfo) -> None:
+        self.frontlines.append(frontline)
+
     def generate(self) -> None:
         """Generates the mission information."""
         raise NotImplementedError
@@ -86,13 +102,23 @@ class MissionInfoGenerator:
 
 class BriefingGenerator(MissionInfoGenerator):
 
-    def __init__(self, mission: Mission, conflict: Conflict, game):
+    def __init__(self, mission: Mission, conflict: Conflict, game: 'Game'):
         super().__init__(mission)
         self.conflict = conflict
         self.game = game
         self.title = ""
         self.description = ""
         self.dynamic_runways: List[RunwayData] = []
+        self.allied_flights_by_departure: Dict[str, List[FlightData]] = {}
+        env = Environment(
+            loader=FileSystemLoader('resources/briefing/templates'),
+            autoescape=select_autoescape(
+                disabled_extensions=('txt'),
+                default_for_string=True,
+                default=True,
+                )
+            )
+        self.template = env.get_template('briefingtemplate_EN.j2')
 
     def add_dynamic_runway(self, runway: RunwayData) -> None:
         """Adds a dynamically generated runway to the briefing.
@@ -102,141 +128,15 @@ class BriefingGenerator(MissionInfoGenerator):
         """
         self.dynamic_runways.append(runway)
 
-    def add_flight_description(self, flight: FlightData):
-        assert flight.client_units
-
-        aircraft = flight.aircraft_type
-        flight_unit_name = db.unit_type_name(aircraft)
-        self.description += "-" * 50 + "\n"
-        self.description += f"{flight_unit_name} x {flight.size}\n\n"
-
-        for i, wpt in enumerate(flight.waypoints):
-            self.description += f"#{i + 1} -- {wpt.name} : {wpt.description}\n"
-        self.description += f"#{len(flight.waypoints) + 1} -- RTB\n\n"
-
-    def add_ally_flight_description(self, flight: FlightData):
-        assert not flight.client_units
-        aircraft = flight.aircraft_type
-        flight_unit_name = db.unit_type_name(aircraft)
-        delay = datetime.timedelta(seconds=flight.departure_delay)
-        self.description += (
-            f"{flight.flight_type.name} {flight_unit_name} x {flight.size}, "
-            f"departing in {delay}\n"
-        )
-
     def generate(self):
-        self.description = ""
-
-        self.description += "DCS Liberation turn #" + str(self.game.turn) + "\n"
-        self.description += "=" * 15 + "\n\n"
-
-        self.description += (
-            "Most briefing information, including communications and flight "
-            "plan information, can be found on your kneeboard.\n\n"
-        )
-
         self.generate_ongoing_war_text()
-
-        self.description += "\n"*2
-        self.description += "Your flights:" + "\n"
-        self.description += "=" * 15 + "\n\n"
-
-        for flight in self.flights:
-            if flight.client_units:
-                self.add_flight_description(flight)
-
-        self.description += "\n"*2
-        self.description += "Planned ally flights:" + "\n"
-        self.description += "=" * 15 + "\n"
-        allied_flights_by_departure = defaultdict(list)
-        for flight in self.flights:
-            if not flight.client_units and flight.friendly:
-                name = flight.departure.airfield_name
-                allied_flights_by_departure[name].append(flight)
-        for departure, flights in allied_flights_by_departure.items():
-            self.description += f"\nFrom {departure}\n"
-            self.description += "-" * 50 + "\n\n"
-            for flight in flights:
-                self.add_ally_flight_description(flight)
-
-        if self.comms:
-            self.description += "\n\nComms Frequencies:\n"
-            self.description += "=" * 15 + "\n"
-            for comm_info in self.comms:
-                self.description += f"{comm_info.name}: {comm_info.freq}\n"
-        self.description += ("-" * 50) + "\n"
-
-        for runway in self.dynamic_runways:
-            self.description += f"{runway.airfield_name}\n"
-            self.description += f"RADIO : {runway.atc}\n"
-            if runway.tacan is not None:
-                self.description += f"TACAN : {runway.tacan} {runway.tacan_callsign}\n"
-            if runway.icls is not None:
-                self.description += f"ICLS Channel : {runway.icls}\n"
-            self.description += "-" * 50 + "\n"
-
-
-        self.description += "JTACS [F-10 Menu] : \n"
-        self.description += "===================\n\n"
-        for jtac in self.jtacs:
-            self.description += f"{jtac.region} -- Code : {jtac.code}\n"
-
-        self.mission.set_description_text(self.description)
-
+        self.generate_allied_flights_by_departure()
+        self.mission.set_description_text(self.template.render(vars(self)))
+        ## TODO: Remove debug code
+        with open(r'C:\Users\walte\Documents\briefing.txt', 'w') as file:
+            file.write(self.template.render(vars(self)))
         self.mission.add_picture_blue(os.path.abspath(
             "./resources/ui/splash_screen.png"))
-
-
-    def generate_ongoing_war_text(self):
-
-        self.description += "Current situation:\n"
-        self.description += "=" * 15 + "\n\n"
-
-        conflict_number = 0
-
-        for front_line in self.game.theater.conflicts(from_player=True):
-            conflict_number = conflict_number + 1
-            player_base = front_line.control_point_a
-            enemy_base = front_line.control_point_b
-
-            has_numerical_superiority = player_base.base.total_armor > enemy_base.base.total_armor
-            self.description += self.__random_frontline_sentence(player_base.name, enemy_base.name)
-
-            if enemy_base.id in player_base.stances.keys():
-                stance = player_base.stances[enemy_base.id]
-
-                if player_base.base.total_armor == 0:
-                    self.description += "We do not have a single vehicle available to hold our position, the situation is critical, and we will lose ground inevitably.\n"
-                elif enemy_base.base.total_armor == 0:
-                    self.description += "The enemy forces have been crushed, we will be able to make significant progress toward " + enemy_base.name + ". \n"
-                if stance == CombatStance.AGGRESSIVE:
-                    if has_numerical_superiority:
-                        self.description += "On this location, our ground forces will try to make progress against the enemy"
-                        self.description += ". As the enemy is outnumbered, our forces should have no issue making progress.\n"
-                    else:
-                        self.description += "On this location, our ground forces will try an audacious assault against enemies in superior numbers. The operation is risky, and the enemy might counter attack.\n"
-                elif stance == CombatStance.ELIMINATION:
-                    if has_numerical_superiority:
-                        self.description += "On this location, our ground forces will focus on the destruction of enemy assets, before attempting to make progress toward " + enemy_base.name + ". "
-                        self.description += "The enemy is already outnumbered, and this maneuver might draw a final blow to their forces.\n"
-                    else:
-                        self.description += "On this location, our ground forces will try an audacious assault against enemies in superior numbers. The operation is risky, and the enemy might counter attack.\n"
-                elif stance == CombatStance.BREAKTHROUGH:
-                    if has_numerical_superiority:
-                        self.description += "On this location, our ground forces will focus on progression toward " + enemy_base.name + ".\n"
-                    else:
-                        self.description += "On this location, our ground forces have been ordered to rush toward " + enemy_base.name + ". Wish them luck... We are also expecting a counter attack.\n"
-                elif stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
-                    if has_numerical_superiority:
-                        self.description += "On this location, our ground forces will hold position. We are not expecting an enemy assault.\n"
-                    else:
-                        self.description += "On this location, our ground forces have been ordered to hold still, and defend against enemy attacks. An enemy assault might be iminent.\n"
-
-        if conflict_number == 0:
-            self.description += "There are currently no fights on the ground.\n"
-
-        self.description += "\n\n"
-
 
     def __random_frontline_sentence(self, player_base_name, enemy_base_name):
         templates = [
@@ -247,5 +147,55 @@ class BriefingGenerator(MissionInfoGenerator):
             "There is an active frontline between {} and {}. ",
         ]
         return random.choice(templates).format(player_base_name, enemy_base_name)
+
+    # TODO: refactor this, perhaps move to FrontLineInfo factory object? 
+    def generate_ongoing_war_text(self):
+        for front_line in self.game.theater.conflicts(from_player=True):
+            player_base = front_line.control_point_a
+            enemy_base = front_line.control_point_b
+            has_numerical_superiority = player_base.base.total_armor > enemy_base.base.total_armor
+            description = self.__random_frontline_sentence(player_base.name, enemy_base.name)
+            stance = player_base.stances[enemy_base.id]  ## Sometimes this contains enum value, sometimes it contains int.
+            if player_base.base.total_armor == 0:
+                player_zero = True
+                description += "We do not have a single vehicle available to hold our position, the situation is critical, and we will lose ground inevitably.\n"
+            elif enemy_base.base.total_armor == 0:
+                player_zero = False
+                description += "The enemy forces have been crushed, we will be able to make significant progress toward " + enemy_base.name + ". \n"
+            else: player_zero = False
+            if not player_zero:
+                if stance == CombatStance.AGGRESSIVE:
+                    if has_numerical_superiority:
+                        description += "On this location, our ground forces will try to make progress against the enemy"
+                        description += ". As the enemy is outnumbered, our forces should have no issue making progress.\n"
+                    else:
+                        description += "On this location, our ground forces will try an audacious assault against enemies in superior numbers. The operation is risky, and the enemy might counter attack.\n"
+                elif stance == CombatStance.ELIMINATION:
+                    if has_numerical_superiority:
+                        description += "On this location, our ground forces will focus on the destruction of enemy assets, before attempting to make progress toward " + enemy_base.name + ". "
+                        description += "The enemy is already outnumbered, and this maneuver might draw a final blow to their forces.\n"
+                    else:
+                        description += "On this location, our ground forces will try an audacious assault against enemies in superior numbers. The operation is risky, and the enemy might counter attack.\n"
+                elif stance == CombatStance.BREAKTHROUGH:
+                    if has_numerical_superiority:
+                        description += "On this location, our ground forces will focus on progression toward " + enemy_base.name + ".\n"
+                    else:
+                        description += "On this location, our ground forces have been ordered to rush toward " + enemy_base.name + ". Wish them luck... We are also expecting a counter attack.\n"
+                elif stance in [CombatStance.DEFENSIVE, CombatStance.AMBUSH]:
+                    if has_numerical_superiority:
+                        description += "On this location, our ground forces will hold position. We are not expecting an enemy assault.\n"
+                    else:
+                        description += "On this location, our ground forces have been ordered to hold still, and defend against enemy attacks. An enemy assault might be iminent.\n"
+            self.add_frontline(FrontLineInfo(description, enemy_base, player_base))
+    
+    # TODO: This should determine if runway is friendly through a method more robust than the existing string match
+    def generate_allied_flights_by_departure(self) -> None:
+        for flight in self.flights:
+            if not flight.client_units and flight.friendly: ## where else can we get this?
+                name = flight.departure.airfield_name
+                if name in self.allied_flights_by_departure.keys():  
+                    self.allied_flights_by_departure[name].append(flight) 
+                else:
+                    self.allied_flights_by_departure[name] = [flight]
 
 

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -234,8 +234,6 @@ class BriefingGenerator(MissionInfoGenerator):
 
     def __init__(self, mission: Mission, game: "Game"):
         super().__init__(mission, game)
-        self.title = ""
-        self.description = ""
         self.allied_flights_by_departure: Dict[str, List[FlightData]] = {}
         env = Environment(
             loader=FileSystemLoader("resources/briefing/templates"),

--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -159,7 +159,7 @@ class MissionInfoGenerator:
     Examples of subtypes include briefing generators, kneeboard generators, etc.
     """
 
-    def __init__(self, mission: Mission, game: Optional['Game'] = None) -> None:
+    def __init__(self, mission: Mission, game: 'Game') -> None:
         self.mission = mission
         self.game = game
         self.awacs: List[AwacsInfo] = []

--- a/gen/kneeboard.py
+++ b/gen/kneeboard.py
@@ -26,7 +26,7 @@ import datetime
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from PIL import Image, ImageDraw, ImageFont
 from dcs.mission import Mission
@@ -42,7 +42,8 @@ from .flights.flight import FlightWaypoint, FlightWaypointType
 from .radios import RadioFrequency
 from .runways import RunwayData
 
-
+if TYPE_CHECKING:
+    from game import Game
 class KneeboardPageWriter:
     """Creates kneeboard images."""
 
@@ -310,8 +311,8 @@ class BriefingPage(KneeboardPage):
 class KneeboardGenerator(MissionInfoGenerator):
     """Creates kneeboard pages for each client flight in the mission."""
 
-    def __init__(self, mission: Mission) -> None:
-        super().__init__(mission)
+    def __init__(self, mission: Mission, game: 'Game') -> None:
+        super().__init__(mission, game)
 
     def generate(self) -> None:
         """Generates a kneeboard per client flight."""

--- a/gen/kneeboard.py
+++ b/gen/kneeboard.py
@@ -311,7 +311,7 @@ class BriefingPage(KneeboardPage):
 class KneeboardGenerator(MissionInfoGenerator):
     """Creates kneeboard pages for each client flight in the mission."""
 
-    def __init__(self, mission: Mission, game: 'Game') -> None:
+    def __init__(self, mission: Mission, game: "Game") -> None:
         super().__init__(mission, game)
 
     def generate(self) -> None:

--- a/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
+++ b/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
@@ -14,8 +14,8 @@ class QGroundForcesStrategySelector(QComboBox):
             self.cp.stances[enemy_cp.id] = CombatStance.DEFENSIVE
 
         for i, stance in enumerate(CombatStance):
-            self.addItem(stance.name, userData=stance.value)
-            if self.cp.stances[enemy_cp.id] == stance.value:
+            self.addItem(stance.name, userData=stance)
+            if self.cp.stances[enemy_cp.id] == stance:
                 self.setCurrentIndex(i)
 
         self.currentTextChanged.connect(self.on_change)

--- a/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
+++ b/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
@@ -14,8 +14,8 @@ class QGroundForcesStrategySelector(QComboBox):
             self.cp.stances[enemy_cp.id] = CombatStance.DEFENSIVE
 
         for i, stance in enumerate(CombatStance):
-            self.addItem(stance.name, userData=CombatStance(i))
-            if self.cp.stances[enemy_cp.id] == CombatStance(i):
+            self.addItem(stance.name, userData=stance)
+            if self.cp.stances[enemy_cp.id] == stance:
                 self.setCurrentIndex(i)
 
         self.currentTextChanged.connect(self.on_change)

--- a/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
+++ b/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
@@ -14,8 +14,8 @@ class QGroundForcesStrategySelector(QComboBox):
             self.cp.stances[enemy_cp.id] = CombatStance.DEFENSIVE
 
         for i, stance in enumerate(CombatStance):
-            self.addItem(stance.name, userData=stance)
-            if self.cp.stances[enemy_cp.id] == stance:
+            self.addItem(stance.name, userData=CombatStance(i))
+            if self.cp.stances[enemy_cp.id] == CombatStance(i):
                 self.setCurrentIndex(i)
 
         self.currentTextChanged.connect(self.on_change)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tabulate~=0.8.7
 
 mypy==0.782
 mypy-extensions==0.4.3
+jinja2>=2.11.2

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -1,0 +1,48 @@
+DCS Liberation Turn {{ game.turn }}
+====================
+
+Most briefing information, including communications and flight plan information, can be found on your kneeboard.
+
+Current situation:
+====================
+{% if not frontlines  %}There are currently no fights on the ground.{% endif %}{% if frontlines %}{% for frontline in frontlines %}
+{{ frontline.description }}{% endfor %}{% endif %}
+
+Your flights:
+====================
+{% for flight in flights if flight.client_units %}
+--------------------------------------------------
+{{ flight.flight_type.name }} {{ flight.units[0].type }} x {{ flight.size }}, {{ flight.package.target.name}}
+{% for waypoint in flight.waypoints %}{{ loop.index }} -- {{waypoint.name}} : {{ waypoint.description}}
+{% endfor %}
+--------------------------------------------------{% endfor %}
+
+
+Planned ally flights:
+====================
+{% for dep in allied_flights_by_departure %}
+{{ dep }}
+---------------------------------------------------
+{% for flight in allied_flights_by_departure[dep] %}
+{{ flight.flight_type.name }} {{ flight.units[0].type }} x {{flight.size}}, departing in {{ flight.departure_delay_delta }}, {{ flight.package.target.name}}{% endfor %}
+{% endfor %}
+
+Carriers and FARPs:
+===================={% for runway in dynamic_runways %}
+--------------------------------------------------
+{{ runway.airfield_name}}
+RADIO : {{ runway.atc }}
+TACAN : {{ runway.tacan }} {{ runway.tacan_callsign }}
+{% if runway.icls %}ICLS Channel: {{ runway.icls }}{% endif %}
+{% endfor %}
+
+AWACS:
+====================
+{% for i in awacs %}{{ i.callsign }} -- Freq : {{i.freq.mhz}}
+{% endfor %}
+
+JTACS [F-10 Menu] : 
+====================
+{% for jtac in jtacs %}Frontline {{ jtac.region }} -- Code : {{ jtac.code }}
+{% endfor %}
+

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -6,7 +6,7 @@ Most briefing information, including communications and flight plan information,
 Current situation:
 ====================
 {% if not frontlines  %}There are currently no fights on the ground.{% endif %}{% if frontlines %}{% for frontline in frontlines %}
-{{ frontline.description }}{% endfor %}{% endif %}
+{{ frontline.brief }}{% endfor %}{% endif %}
 
 Your flights:
 ====================

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -6,7 +6,8 @@ Most briefing information, including communications and flight plan information,
 Current situation:
 ====================
 {% if not frontlines  %}There are currently no fights on the ground.{% endif %}{% if frontlines %}{% for frontline in frontlines %}
-{{ frontline.brief }}{% endfor %}{% endif %}
+{{ frontline.brief }}
+{% endfor %}{% endif %}
 
 Your flights:
 ====================


### PR DESCRIPTION
Complete rework of briefinggen module to try and make it more maintainable.  

Uses jinja2 for templating.

Creates a unified interface for kneeboards and briefing on the Operation class.  This may be better done by extending the pydcs Mission class, and generating the kneeboards and briefings as a pre-save hook on .miz save- but for now I've reworked it where it was being generated before.

Check my changes to qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategySelector.py
When "Defensive" was selected, it would set the frontline CombatStance to an instance of the CombatStance.DEFENSIVE enum, however for all other strategies it was setting strategy to the int value.  I searched and could not find any place where this is not appropriate, but it's possible I missed something.