### PR TITLE
Don't allow sub-second travel times.

### DIFF
--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -816,8 +816,7 @@ class AircraftConflictGenerator:
 
         activation_trigger = TriggerOnce(
             Event.NoEvent, f"FlightLateActivationTrigger{group.id}")
-        activation_trigger.add_condition(
-            TimeAfter(seconds=int(delay.total_seconds())))
+        activation_trigger.add_condition(TimeAfter(seconds=delay.seconds))
 
         self.prevent_spawn_at_hostile_airbase(flight, activation_trigger)
         activation_trigger.add_action(ActivateGroup(group.id))
@@ -830,8 +829,7 @@ class AircraftConflictGenerator:
 
         activation_trigger = TriggerOnce(Event.NoEvent,
                                          f"FlightStartTrigger{group.id}")
-        activation_trigger.add_condition(
-            TimeAfter(seconds=int(delay.total_seconds())))
+        activation_trigger.add_condition(TimeAfter(seconds=delay.seconds))
 
         self.prevent_spawn_at_hostile_airbase(flight, activation_trigger)
         group.add_trigger_action(StartCommand())

--- a/gen/flights/traveltime.py
+++ b/gen/flights/traveltime.py
@@ -83,7 +83,8 @@ class TravelTime:
     def between_points(a: Point, b: Point, speed: float) -> timedelta:
         error_factor = 1.1
         distance = meter_to_nm(a.distance_to_point(b))
-        return timedelta(hours=distance / speed * error_factor)
+        return timedelta(
+            seconds=timedelta(hours=distance / speed * error_factor).seconds)
 
 
 class TotEstimator:

--- a/qt_ui/widgets/ato.py
+++ b/qt_ui/widgets/ato.py
@@ -64,8 +64,7 @@ class FlightDelegate(QStyledItemDelegate):
         count = flight.count
         name = db.unit_type_name(flight.unit_type)
         estimator = TotEstimator(self.package)
-        delay = datetime.timedelta(
-            seconds=int(estimator.mission_start_time(flight).total_seconds()))
+        delay = estimator.mission_start_time(flight)
         return f"[{task}] {count} x {name} in {delay}"
 
     def second_row_text(self, index: QModelIndex) -> str:
@@ -329,9 +328,7 @@ class PackageDelegate(QStyledItemDelegate):
 
     def right_text(self, index: QModelIndex) -> str:
         package = self.package(index)
-        delay = datetime.timedelta(
-            seconds=int(package.time_over_target.total_seconds()))
-        return f"TOT T+{delay}"
+        return f"TOT T+{package.time_over_target}"
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem,
               index: QModelIndex) -> None:

--- a/qt_ui/widgets/map/QLiberationMap.py
+++ b/qt_ui/widgets/map/QLiberationMap.py
@@ -349,7 +349,6 @@ class QLiberationMap(QGraphicsView):
         if time is None:
             tot = ""
         else:
-            time = datetime.timedelta(seconds=int(time.total_seconds()))
             tot = f"{prefix} T+{time}"
 
         pen = QPen(QColor("black"), 0.3)

--- a/qt_ui/windows/mission/QFlightItem.py
+++ b/qt_ui/windows/mission/QFlightItem.py
@@ -22,8 +22,7 @@ class QFlightItem(QStandardItem):
             self.setIcon(icon)
         self.setEditable(False)
         estimator = TotEstimator(self.package)
-        delay = datetime.timedelta(
-            seconds=int(estimator.mission_start_time(flight).total_seconds()))
+        delay = estimator.mission_start_time(flight)
         self.setText("["+str(self.flight.flight_type.name[:6])+"] "
                      + str(self.flight.count) + " x " + db.unit_type_name(self.flight.unit_type)
                      + "   in " + str(delay))

--- a/qt_ui/windows/mission/flight/settings/QFlightDepartureDisplay.py
+++ b/qt_ui/windows/mission/flight/settings/QFlightDepartureDisplay.py
@@ -19,8 +19,7 @@ class QFlightDepartureDisplay(QGroupBox):
         layout.addLayout(departure_row)
 
         estimator = TotEstimator(package)
-        delay = datetime.timedelta(
-            seconds=int(estimator.mission_start_time(flight).total_seconds()))
+        delay = estimator.mission_start_time(flight)
 
         departure_row.addWidget(QLabel(
             f"Departing from <b>{flight.from_cp.name}</b>"


### PR DESCRIPTION
Doesn't happen on my machine, but it seems that sometimes we end up
with zeroish startup times rounding down to negative start times.
Since it doesn't happen on my machine I'm not sure, but this is a
guess at a fix.

I've also removed all of the rounding from the UI so that it might be
more obvious what's wrong when it happens.
