### PR TITLE
Stop the time spinner from breaking the TOT.

### DIFF
--- a/gen/flights/traveltime.py
+++ b/gen/flights/traveltime.py
@@ -122,9 +122,10 @@ class TotEstimator:
         return tot - travel_time - self.HOLD_TIME
 
     def earliest_tot(self) -> timedelta:
-        return max((
+        tots = [
             self.earliest_tot_for_flight(f) for f in self.package.flights
-        )) + self.HOLD_TIME
+        ]
+        return max(tots) + self.HOLD_TIME
 
     def earliest_tot_for_flight(self, flight: Flight) -> timedelta:
         """Estimate fastest time from mission start to the target position.

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -146,7 +146,17 @@ class QPackageDialog(QDialog):
         else:
             self.package_model.update_tot(
                 TotEstimator(self.package_model.package).earliest_tot())
-        self.tot_spinner.setTime(self.tot_qtime())
+
+        # Block signals while setting the auto computed TOT. The actual TOT will
+        # have resolution down to the microsecond, but the QTimeEdit is not
+        # capable of displaying that, so when we set the rounded value it saves
+        # that back to the package with less precision. Block signals so we only
+        # update the UI and not the package's value.
+        self.tot_spinner.blockSignals(True)
+        try:
+            self.tot_spinner.setTime(self.tot_qtime())
+        finally:
+            self.tot_spinner.blockSignals(False)
 
     def on_selection_changed(self, selected: QItemSelection,
                              _deselected: QItemSelection) -> None:


### PR DESCRIPTION
The actual TOT will have resolution down to the microsecond, but the
QTimeEdit is not capable of displaying that, so when we set the
rounded value it saves that back to the package with less precision.
Block signals so we only update the UI and not the package's value.
