### PR TITLE
Base defense packages (Fixes #268)

### DIFF
--- a/qt_ui/dialogs.py
+++ b/qt_ui/dialogs.py
@@ -34,12 +34,13 @@ class Dialog:
         cls.game_model = game_model
 
     @classmethod
-    def open_new_package_dialog(cls, mission_target: MissionTarget):
+    def open_new_package_dialog(cls, mission_target: MissionTarget, parent=None):
         """Opens the dialog to create a new package with the given target."""
         cls.new_package_dialog = QNewPackageDialog(
             cls.game_model,
             cls.game_model.ato_model,
-            mission_target
+            mission_target,
+            parent=parent
         )
         cls.new_package_dialog.show()
 

--- a/qt_ui/widgets/map/QMapControlPoint.py
+++ b/qt_ui/widgets/map/QMapControlPoint.py
@@ -90,3 +90,10 @@ class QMapControlPoint(QMapObject):
         # Reinitialized ground planners and the like.
         self.game_model.game.initialize_turn()
         GameUpdateSignal.get_instance().updateGame(self.game_model.game)
+    
+    def open_new_package_dialog(self) -> None:
+        """Extends the default packagedialog to redirect to base menu for red air base."""
+        if not self.control_point.captured:
+            self.on_click()
+        else:
+            super(QMapControlPoint, self).open_new_package_dialog()

--- a/qt_ui/windows/basemenu/QBaseMenuTabs.py
+++ b/qt_ui/windows/basemenu/QBaseMenuTabs.py
@@ -16,11 +16,11 @@ class QBaseMenuTabs(QTabWidget):
         if cp:
 
             if not cp.captured:
-                self.intel = QIntelInfo(cp, game_model.game)
-                self.addTab(self.intel, "Intel")
                 if not cp.is_carrier:
                     self.base_defenses_hq = QBaseDefensesHQ(cp, game_model.game)
                     self.addTab(self.base_defenses_hq, "Base Defenses")
+                self.intel = QIntelInfo(cp, game_model.game)
+                self.addTab(self.intel, "Intel")
             else:
                 if cp.has_runway():
                     self.airfield_command = QAirfieldCommand(cp, game_model)

--- a/qt_ui/windows/basemenu/base_defenses/QBaseDefenseGroupInfo.py
+++ b/qt_ui/windows/basemenu/base_defenses/QBaseDefenseGroupInfo.py
@@ -1,6 +1,7 @@
 from PySide2.QtCore import Qt
 from PySide2.QtWidgets import QGridLayout, QLabel, QGroupBox, QPushButton, QVBoxLayout
 
+from qt_ui.dialogs import Dialog
 from qt_ui.uiconstants import VEHICLES_ICONS
 from qt_ui.windows.groundobject.QGroundObjectMenu import QGroundObjectMenu
 from theater import ControlPoint, TheaterGroundObject
@@ -23,12 +24,17 @@ class QBaseDefenseGroupInfo(QGroupBox):
     def init_ui(self):
 
         self.buildLayout()
+        self.main_layout.addLayout(self.unit_layout)
+        if not self.cp.captured:
+            attack_button = QPushButton("Attack")
+            attack_button.setProperty("style", "btn-danger")
+            attack_button.setMaximumWidth(180)
+            attack_button.clicked.connect(self.onAttack)
+            self.main_layout.addWidget(attack_button, 0, Qt.AlignLeft)
         manage_button = QPushButton("Manage")
         manage_button.setProperty("style", "btn-success")
         manage_button.setMaximumWidth(180)
         manage_button.clicked.connect(self.onManage)
-
-        self.main_layout.addLayout(self.unit_layout)
         self.main_layout.addWidget(manage_button, 0, Qt.AlignLeft)
 
         self.setLayout(self.main_layout)
@@ -66,6 +72,9 @@ class QBaseDefenseGroupInfo(QGroupBox):
 
 
         self.setLayout(self.main_layout)
+    
+    def onAttack(self):
+        Dialog.open_new_package_dialog(self.ground_object, parent=self.window())
 
     def onManage(self):
         self.edition_menu = QGroundObjectMenu(self.window(), self.ground_object, self.buildings, self.cp, self.game)

--- a/qt_ui/windows/mission/QEditFlightDialog.py
+++ b/qt_ui/windows/mission/QEditFlightDialog.py
@@ -15,8 +15,8 @@ from qt_ui.windows.mission.flight.QFlightPlanner import QFlightPlanner
 class QEditFlightDialog(QDialog):
     """Dialog window for editing flight plans and loadouts."""
 
-    def __init__(self, game_model: GameModel, package: Package, flight: Flight) -> None:
-        super().__init__()
+    def __init__(self, game_model: GameModel, package: Package, flight: Flight, parent=None) -> None:
+        super().__init__(parent=parent)
 
         self.game_model = game_model
 

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -36,8 +36,8 @@ class QPackageDialog(QDialog):
     #: Emitted when a change is made to the package.
     package_changed = Signal()
 
-    def __init__(self, game_model: GameModel, model: PackageModel) -> None:
-        super().__init__()
+    def __init__(self, game_model: GameModel, model: PackageModel, parent=None) -> None:
+        super().__init__(parent)
         self.game_model = game_model
         self.package_model = model
         self.add_flight_dialog: Optional[QFlightCreator] = None
@@ -156,7 +156,8 @@ class QPackageDialog(QDialog):
     def on_add_flight(self) -> None:
         """Opens the new flight dialog."""
         self.add_flight_dialog = QFlightCreator(self.game,
-                                                self.package_model.package)
+                                                self.package_model.package,
+                                                parent=self.window())
         self.add_flight_dialog.created.connect(self.add_flight)
         self.add_flight_dialog.show()
 
@@ -189,8 +190,8 @@ class QNewPackageDialog(QPackageDialog):
     """
 
     def __init__(self, game_model: GameModel, model: AtoModel,
-                 target: MissionTarget) -> None:
-        super().__init__(game_model, PackageModel(Package(target)))
+                 target: MissionTarget, parent=None) -> None:
+        super().__init__(game_model, PackageModel(Package(target)), parent=parent)
         self.ato_model = model
 
         self.save_button = QPushButton("Save")

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -23,8 +23,8 @@ from theater import ControlPoint
 class QFlightCreator(QDialog):
     created = Signal(Flight)
 
-    def __init__(self, game: Game, package: Package) -> None:
-        super().__init__()
+    def __init__(self, game: Game, package: Package, parent=None) -> None:
+        super().__init__(parent=parent)
 
         self.game = game
         self.package = package


### PR DESCRIPTION
This PR adds a new Attack button to the Base Defenses tab of enemy base info window.
![image](https://user-images.githubusercontent.com/37820425/97935372-012f7f80-1d3e-11eb-886c-5447c61fd26c.png)

Clicking the attack button opens the existing new package dialog.

Clicking "New Package" context menu on red air base now redirects to the base menu.  No change to context menu function for blue.

Red base info tab order was rearranged, as I thought if a user used the context manager to arrive at the base menu, they would be rightly confused as to what was going on in the intel tab, where it's pretty obvious how to plan your package in the base defense tab.