### PR TITLE
Add Income values of buildings at GroundObjectMenu

### DIFF
--- a/qt_ui/windows/groundobject/QBuildingInfo.py
+++ b/qt_ui/windows/groundobject/QBuildingInfo.py
@@ -38,4 +38,3 @@ class QBuildingInfo(QGroupBox):
 
         footer = QHBoxLayout()
         self.setLayout(layout)
-

--- a/qt_ui/windows/groundobject/QBuildingInfo.py
+++ b/qt_ui/windows/groundobject/QBuildingInfo.py
@@ -2,7 +2,7 @@ import os
 
 from PySide2.QtGui import QPixmap
 from PySide2.QtWidgets import QGroupBox, QHBoxLayout, QVBoxLayout, QLabel
-
+from game.db import REWARDS
 
 class QBuildingInfo(QGroupBox):
 
@@ -28,6 +28,14 @@ class QBuildingInfo(QGroupBox):
         layout = QVBoxLayout()
         layout.addWidget(self.header)
         layout.addWidget(self.name)
+
+        if self.building.category in REWARDS.keys():
+            income_label_text = 'Value: ' + str(REWARDS[self.building.category]) + "M"
+            if self.building.is_dead:
+                income_label_text = '<s>' + income_label_text + '</s>'
+            self.reward = QLabel(income_label_text)
+            layout.addWidget(self.reward)
+
         footer = QHBoxLayout()
         self.setLayout(layout)
 

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -106,8 +106,8 @@ class QGroundObjectMenu(QDialog):
 
         self.buildingBox = QGroupBox("Buildings :")
         self.buildingsLayout = QGridLayout()
-        j = 0
 
+        j = 0
         total_income = 0
         received_income = 0
         for i, building in enumerate(self.buildings):
@@ -120,15 +120,10 @@ class QGroundObjectMenu(QDialog):
                 if not building.is_dead:
                     received_income = received_income + REWARDS[building.category]
 
-
         self.financesBox = QGroupBox("Finances: ")
         self.financesBoxLayout = QGridLayout()
-
-        str_total_income = 'Available: ' + str(total_income) + "M"
-        str_received_income = 'Receiving: ' + str(received_income) + "M"
-
-        self.financesBoxLayout.addWidget(QLabel(str_total_income), 2, 1)
-        self.financesBoxLayout.addWidget(QLabel(str_received_income), 2, 2)
+        self.financesBoxLayout.addWidget(QLabel("Available: " + str(total_income) + "M"), 2, 1)
+        self.financesBoxLayout.addWidget(QLabel("Receiving: " + str(received_income) + "M"), 2, 2)
 
         self.financesBox.setLayout(self.financesBoxLayout)
         self.buildingBox.setLayout(self.buildingsLayout)

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -125,10 +125,10 @@ class QGroundObjectMenu(QDialog):
         self.financesBoxLayout = QGridLayout()
 
         str_total_income = 'Available: ' + str(total_income) + "M"
-        str_percived_income = 'Receiving: ' + str(received_income) + "M"
+        str_received_income = 'Receiving: ' + str(received_income) + "M"
 
         self.financesBoxLayout.addWidget(QLabel(str_total_income), 2, 1)
-        self.financesBoxLayout.addWidget(QLabel(str_percived_income), 2, 2)
+        self.financesBoxLayout.addWidget(QLabel(str_received_income), 2, 2)
 
         self.financesBox.setLayout(self.financesBoxLayout)
         self.buildingBox.setLayout(self.buildingsLayout)

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -8,7 +8,7 @@ from dcs import Point
 
 from game import Game, db
 from game.data.building_data import FORTIFICATION_BUILDINGS
-from game.db import PRICES, unit_type_of, PinpointStrike
+from game.db import PRICES, REWARDS, unit_type_of, PinpointStrike
 from gen.defenses.armor_group_generator import generate_armor_group_of_type_and_size
 from gen.sam.sam_group_generator import get_faction_possible_sams_generator
 from qt_ui.uiconstants import EVENT_ICONS
@@ -51,6 +51,8 @@ class QGroundObjectMenu(QDialog):
             self.mainLayout.addWidget(self.intelBox)
         else:
             self.mainLayout.addWidget(self.buildingBox)
+            if self.cp.captured:
+                self.mainLayout.addWidget(self.financesBox)
 
         self.actionLayout = QHBoxLayout()
 
@@ -105,11 +107,30 @@ class QGroundObjectMenu(QDialog):
         self.buildingBox = QGroupBox("Buildings :")
         self.buildingsLayout = QGridLayout()
         j = 0
+
+        total_income = 0
+        received_income = 0
         for i, building in enumerate(self.buildings):
             if building.dcs_identifier not in FORTIFICATION_BUILDINGS:
                 self.buildingsLayout.addWidget(QBuildingInfo(building, self.ground_object), j/3, j%3)
                 j = j + 1
 
+            if building.category in REWARDS.keys():
+                total_income = total_income + REWARDS[building.category]
+                if not building.is_dead:
+                    received_income = received_income + REWARDS[building.category]
+
+
+        self.financesBox = QGroupBox("Finances: ")
+        self.financesBoxLayout = QGridLayout()
+
+        str_total_income = 'Available: ' + str(total_income) + "M"
+        str_percived_income = 'Receiving: ' + str(received_income) + "M"
+
+        self.financesBoxLayout.addWidget(QLabel(str_total_income), 2, 1)
+        self.financesBoxLayout.addWidget(QLabel(str_percived_income), 2, 2)
+
+        self.financesBox.setLayout(self.financesBoxLayout)
         self.buildingBox.setLayout(self.buildingsLayout)
         self.intelBox.setLayout(self.intelLayout)
 


### PR DESCRIPTION
This is just a QoL enhancement to the GroundObjectMenu Window:

![image](https://user-images.githubusercontent.com/373995/99791027-479a2200-2b25-11eb-9adb-33a5ca245c71.png)


FinancesBox only appears on captured emplacements.