### PR TITLE
Fix: Pass turn and take off btn enabled at startup

### DIFF
--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -48,12 +48,14 @@ class QTopPanel(QFrame):
         self.passTurnButton.setIcon(CONST.ICONS["PassTurn"])
         self.passTurnButton.setProperty("style", "btn-primary")
         self.passTurnButton.clicked.connect(self.passTurn)
+        if not self.game or self.game.turn == 0:
+            self.passTurnButton.setEnabled(False)
 
         self.proceedButton = QPushButton("Take off")
         self.proceedButton.setIcon(CONST.ICONS["Proceed"])
         self.proceedButton.setProperty("style", "start-button")
         self.proceedButton.clicked.connect(self.launch_mission)
-        if self.game and self.game.turn == 0:
+        if not self.game or self.game.turn == 0:
             self.proceedButton.setEnabled(False)
 
         self.factionsInfos = QFactionsInfos(self.game)
@@ -100,6 +102,8 @@ class QTopPanel(QFrame):
         self.turnCounter.setCurrentTurn(game.turn, game.conditions)
         self.budgetBox.setGame(game)
         self.factionsInfos.setGame(game)
+
+        self.passTurnButton.setEnabled(True)
 
         if game and game.turn == 0:
             self.proceedButton.setEnabled(False)

--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -48,7 +48,7 @@ class QTopPanel(QFrame):
         self.passTurnButton.setIcon(CONST.ICONS["PassTurn"])
         self.passTurnButton.setProperty("style", "btn-primary")
         self.passTurnButton.clicked.connect(self.passTurn)
-        if not self.game or self.game.turn == 0:
+        if not self.game:
             self.passTurnButton.setEnabled(False)
 
         self.proceedButton = QPushButton("Take off")


### PR DESCRIPTION
When no game is loaded Pass turn and Take Off Buttons are enabled and raises exception on click.