### PR TITLE
Operation refactor

### DIFF
--- a/game/event/airwar.py
+++ b/game/event/airwar.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from .event import Event
+
+if TYPE_CHECKING:
+    from game.theater import ConflictTheater
+
+
+class AirWarEvent(Event):
+    """An Event centered on the overall Air War"""
+
+    def __str__(self):
+        return "Frontline attack"

--- a/game/event/airwar.py
+++ b/game/event/airwar.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 class AirWarEvent(Event):
-    """An Event centered on the overall Air War"""
+    """Event handler for the air battle"""
 
     def __str__(self):
-        return "Frontline attack"
+        return "AirWar"

--- a/game/event/event.py
+++ b/game/event/event.py
@@ -38,7 +38,6 @@ class Event:
     location = None  # type: Point
     from_cp = None  # type: ControlPoint
     to_cp = None  # type: ControlPoint
-
     operation = Operation
     difficulty = 1  # type: int
     BONUS_BASE = 5
@@ -63,8 +62,6 @@ class Event:
         return int(math.log(self.to_cp.importance + 1, DIFFICULTY_LOG_BASE) * self.BONUS_BASE)
 
     def generate(self) -> UnitMap:
-        self.operation.ca_slots = self.ca_slots
-
         self.operation.prepare(self.game)
         unit_map = self.operation.generate()
         self.operation.current_mission.save(

--- a/game/event/event.py
+++ b/game/event/event.py
@@ -38,7 +38,6 @@ class Event:
     location = None  # type: Point
     from_cp = None  # type: ControlPoint
     to_cp = None  # type: ControlPoint
-    operation = Operation
     difficulty = 1  # type: int
     BONUS_BASE = 5
 
@@ -62,9 +61,9 @@ class Event:
         return int(math.log(self.to_cp.importance + 1, DIFFICULTY_LOG_BASE) * self.BONUS_BASE)
 
     def generate(self) -> UnitMap:
-        self.operation.prepare(self.game)
-        unit_map = self.operation.generate()
-        self.operation.current_mission.save(
+        Operation.prepare(self.game)
+        unit_map = Operation.generate()
+        Operation.current_mission.save(
             persistency.mission_path_for("liberation_nextturn.miz"))
         return unit_map
 

--- a/game/event/frontlineattack.py
+++ b/game/event/frontlineattack.py
@@ -1,42 +1,11 @@
-from typing import List, Type
-
-from dcs.task import CAP, CAS, Task
-from game.operation.operation import Operation
-
-from ..debriefing import Debriefing
 from .event import Event
 
 
 class FrontlineAttackEvent(Event):
-
-    @property
-    def tasks(self) -> List[Type[Task]]:
-        if self.is_player_attacking:
-            return [CAS, CAP]
-        else:
-            return [CAP]
-
-    @property
-    def global_cp_available(self) -> bool:
-        return True
-
+    """
+    An event centered on a FrontLine Conflict.
+    Currently the same as its parent, but here for legacy compatibility as well as to allow for
+    future unique Event handling
+    """
     def __str__(self):
         return "Frontline attack"
-
-    def is_successful(self, debriefing: Debriefing):
-        attackers_success = True
-        if self.from_cp.captured:
-            return attackers_success
-        else:
-            return not attackers_success
-
-    def commit(self, debriefing: Debriefing):
-        super(FrontlineAttackEvent, self).commit(debriefing)
-
-    def skip(self):
-        if self.to_cp.captured:
-            self.to_cp.base.affect_strength(-0.1)
-
-    def player_attacking(self):
-        assert self.departure_cp is not None
-        self.operation = Operation(departure_cp=self.departure_cp,)

--- a/game/game.py
+++ b/game/game.py
@@ -193,7 +193,7 @@ class Game:
         if isinstance(event, Event):
             return event and event.attacker_name and event.attacker_name == self.player_name
         else:
-            raise RuntimeError(f"{event} was passed when an expected")
+            raise RuntimeError(f"{event} was passed when an Event type was expected")
 
     def on_load(self) -> None:
         LuaPluginManager.load_settings(self.settings)

--- a/game/game.py
+++ b/game/game.py
@@ -182,8 +182,7 @@ class Game:
     def finish_event(self, event: Event, debriefing: Debriefing):
         logging.info("Finishing event {}".format(event))
         event.commit(debriefing)
-        if event.is_successful(debriefing):
-            self.budget += event.bonus()
+        self.budget += event.bonus()
 
         if event in self.events:
             self.events.remove(event)
@@ -194,7 +193,7 @@ class Game:
         if isinstance(event, Event):
             return event and event.attacker_name and event.attacker_name == self.player_name
         else:
-            return event and event.name and event.name == self.player_name
+            raise RuntimeError(f"{event} was passed when an expected")
 
     def on_load(self) -> None:
         LuaPluginManager.load_settings(self.settings)

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -14,9 +14,7 @@ from dcs.lua.parse import loads
 from dcs.mapping import Point
 from dcs.translation import String
 from dcs.triggers import TriggerStart
-from dcs.unittype import UnitType
 from game.plugins import LuaPluginManager
-from game.theater import ControlPoint
 from gen import Conflict, FlightType, VisualGenerator
 from gen.aircraft import AIRCRAFT_DATA, AircraftConflictGenerator, FlightData
 from gen.airfields import AIRFIELD_DATA
@@ -59,8 +57,7 @@ class Operation:
     player_awacs_enabled = True
     #  TODO: #436 Generate Air Support for red
     enemy_awacs_enabled = True
-    is_awacs_enabled = False
-    ca_slots = 0
+    ca_slots = 1
     unit_map: UnitMap
     jtacs: List[JtacInfo] = []
     plugin_scripts: List[str] = []

--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -5,7 +5,7 @@ import logging
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING, Type
 
 from game.settings import Settings
 
@@ -22,7 +22,7 @@ class LuaPluginWorkOrder:
         self.mnemonic = mnemonic
         self.disable = disable
 
-    def work(self, operation: Operation) -> None:
+    def work(self, operation: Type[Operation]) -> None:
         if self.disable:
             operation.bypass_plugin_script(self.mnemonic)
         else:
@@ -144,11 +144,11 @@ class LuaPlugin(PluginSettings):
         for option in self.definition.options:
             option.set_settings(self.settings)
 
-    def inject_scripts(self, operation: Operation) -> None:
+    def inject_scripts(self, operation: Type[Operation]) -> None:
         for work_order in self.definition.work_orders:
             work_order.work(operation)
 
-    def inject_configuration(self, operation: Operation) -> None:
+    def inject_configuration(self, operation: Type[Operation]) -> None:
         # inject the plugin options
         if self.options:
             option_decls = []

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -485,6 +485,7 @@ class ConflictTheater:
                     dist = cp.position.distance_to_point(control_point.position)
                     if not closest_distance:
                         closest_distance = dist
+                        distances[cp.id] = dist
                     if dist < closest_distance:
                         distances[cp.id] = dist
             closest_cp_id = min(distances, key=distances.get)  # type: ignore

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -470,6 +470,40 @@ class ConflictTheater:
                 closest = control_point
                 closest_distance = distance
         return closest
+    
+    def closest_opposing_control_points(self) -> Tuple[ControlPoint]:
+        """
+        Returns a tuple of the two nearest opposing ControlPoints in theater.
+        (player_cp, enemy_cp)
+        """
+        all_cp_min_distances = {}
+        for idx, control_point in enumerate(self.controlpoints):
+            distances = {}
+            closest_distance = None
+            for i, cp in enumerate(self.controlpoints):
+                if i != idx and cp.captured is not control_point.captured:
+                    dist = cp.position.distance_to_point(control_point.position)
+                    if not closest_distance:
+                        closest_distance = dist
+                    if dist < closest_distance:
+                        distances[cp.id] = dist
+            closest_cp = min(distances, key=distances.get)
+            all_cp_min_distances[(control_point.id, closest_cp)] = distances[closest_cp]
+        closest_opposing_cps = [
+            self.find_control_point_by_id(i)
+            for i 
+            in min(all_cp_min_distances, key=all_cp_min_distances.get)
+          ]  # type: List[ControlPoint]
+        if closest_opposing_cps[0].captured:
+            return tuple(closest_opposing_cps)
+        else:
+            return tuple(reversed(closest_opposing_cps))
+
+    def find_control_point_by_id(self, id: int) -> ControlPoint:
+        for i in self.controlpoints:
+            if i.id == id:
+                return i
+        raise RuntimeError(f"Cannot find ControlPoint with ID {id}")
 
     def add_json_cp(self, theater, p: dict) -> ControlPoint:
         cp: ControlPoint

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -488,13 +488,13 @@ class ConflictTheater:
                         distances[cp.id] = dist
                     if dist < closest_distance:
                         distances[cp.id] = dist
-            closest_cp_id = min(distances, key=distances.get)  # type: ignore
+            closest_cp_id = min(distances, key=distances.get)
 
             all_cp_min_distances[(control_point.id, closest_cp_id)] = distances[closest_cp_id]
         closest_opposing_cps = [
             self.find_control_point_by_id(i)
             for i
-            in min(all_cp_min_distances, key=all_cp_min_distances.get)  # type: ignore
+            in min(all_cp_min_distances, key=all_cp_min_distances.get)
           ]  # type: List[ControlPoint]
         assert len(closest_opposing_cps) == 2
         if closest_opposing_cps[0].captured:

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from itertools import tee
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 from dcs import Mission
 from dcs.countries import (
@@ -471,7 +471,7 @@ class ConflictTheater:
                 closest_distance = distance
         return closest
     
-    def closest_opposing_control_points(self) -> Tuple[ControlPoint]:
+    def closest_opposing_control_points(self) -> Tuple[ControlPoint, ControlPoint]:
         """
         Returns a tuple of the two nearest opposing ControlPoints in theater.
         (player_cp, enemy_cp)
@@ -487,17 +487,19 @@ class ConflictTheater:
                         closest_distance = dist
                     if dist < closest_distance:
                         distances[cp.id] = dist
-            closest_cp = min(distances, key=distances.get)
-            all_cp_min_distances[(control_point.id, closest_cp)] = distances[closest_cp]
+            closest_cp_id = min(distances, key=distances.get)  # type: ignore
+
+            all_cp_min_distances[(control_point.id, closest_cp_id)] = distances[closest_cp_id]
         closest_opposing_cps = [
             self.find_control_point_by_id(i)
-            for i 
-            in min(all_cp_min_distances, key=all_cp_min_distances.get)
+            for i
+            in min(all_cp_min_distances, key=all_cp_min_distances.get)  # type: ignore
           ]  # type: List[ControlPoint]
+        assert len(closest_opposing_cps) == 2
         if closest_opposing_cps[0].captured:
-            return tuple(closest_opposing_cps)
+            return cast(Tuple[ControlPoint, ControlPoint], tuple(closest_opposing_cps))
         else:
-            return tuple(reversed(closest_opposing_cps))
+            return cast(Tuple[ControlPoint, ControlPoint], tuple(reversed(closest_opposing_cps)))
 
     def find_control_point_by_id(self, id: int) -> ControlPoint:
         for i in self.controlpoints:

--- a/gen/airsupportgen.py
+++ b/gen/airsupportgen.py
@@ -14,7 +14,6 @@ from dcs.task import (
 )
 
 from game import db
-from game.operation.operation import Operation
 from .naming import namegen
 from .callsigns import callsign_for_support_unit
 from .conflictgen import Conflict
@@ -122,9 +121,10 @@ class AirSupportConflictGenerator:
 
             self.air_support.tankers.append(TankerInfo(str(tanker_group.name), callsign, variant, freq, tacan))
 
-        try:
+        awacs_unit = db.find_unittype(AWACS, self.conflict.attackers_side)[0]
+        if awacs_unit:
             freq = self.radio_registry.alloc_uhf()
-            awacs_unit = db.find_unittype(AWACS, self.conflict.attackers_side)[0]
+            
             awacs_flight = self.mission.awacs_flight(
                 country=self.mission.country(self.game.player_country),
                 name=namegen.next_awacs_name(self.mission.country(self.game.player_country)),
@@ -142,6 +142,5 @@ class AirSupportConflictGenerator:
 
             self.air_support.awacs.append(AwacsInfo(
                 str(awacs_flight.name), callsign_for_support_unit(awacs_flight), freq))
-        except:
-            Operation.player_awacs_enabled = False
+        else:
             logging.warning("No AWACS for faction")

--- a/gen/conflictgen.py
+++ b/gen/conflictgen.py
@@ -8,37 +8,8 @@ from dcs.mapping import Point
 from game.theater.conflicttheater import ConflictTheater, FrontLine
 from game.theater.controlpoint import ControlPoint
 
-AIR_DISTANCE = 40000
-
-CAPTURE_AIR_ATTACKERS_DISTANCE = 25000
-CAPTURE_AIR_DEFENDERS_DISTANCE = 60000
-STRIKE_AIR_ATTACKERS_DISTANCE = 45000
-STRIKE_AIR_DEFENDERS_DISTANCE = 25000
-
-CAP_CAS_DISTANCE = 10000, 120000
-
-GROUND_INTERCEPT_SPREAD = 5000
-GROUND_DISTANCE_FACTOR = 1.4
-GROUND_DISTANCE = 2000
-
-GROUND_ATTACK_DISTANCE = 25000, 13000
-
-TRANSPORT_FRONTLINE_DIST = 1800
-
-INTERCEPT_ATTACKERS_HEADING = -45, 45
-INTERCEPT_DEFENDERS_HEADING = -10, 10
-INTERCEPT_CONFLICT_DISTANCE = 50000
-INTERCEPT_ATTACKERS_DISTANCE = 100000
-INTERCEPT_MAX_DISTANCE = 160000
-INTERCEPT_MIN_DISTANCE = 100000
-
-NAVAL_INTERCEPT_DISTANCE_FACTOR = 1
-NAVAL_INTERCEPT_DISTANCE_MAX = 40000
-NAVAL_INTERCEPT_STEP = 5000
 
 FRONTLINE_LENGTH = 80000
-FRONTLINE_MIN_CP_DISTANCE = 5000
-FRONTLINE_DISTANCE_STRENGTH_FACTOR = 0.7
 
 
 def _opposite_heading(h):
@@ -97,10 +68,6 @@ class Conflict:
     @property
     def opposite_heading(self) -> int:
         return _heading_sum(self.heading, 180)
-
-    @property
-    def to_size(self):
-        return self.to_cp.size * GROUND_DISTANCE_FACTOR
 
     def find_ground_position(self, at: Point, heading: int, max_distance: int = 40000) -> Point:
         return Conflict._find_ground_position(at, max_distance, heading, self.theater)

--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -10,7 +10,7 @@ from PySide2.QtWidgets import (
 
 import qt_ui.uiconstants as CONST
 from game import Game
-from game.event import CAP, CAS, FrontlineAttackEvent
+from game.event.airwar import AirWarEvent
 from gen.ato import Package
 from gen.flights.traveltime import TotEstimator
 from qt_ui.models import GameModel
@@ -214,26 +214,14 @@ class QTopPanel(QFrame):
         if negative_starts:
             if not self.confirm_negative_start_time(negative_starts):
                 return
-
-        # TODO: Refactor this nonsense.
-        game_event = None
-        for event in self.game.events:
-            if isinstance(event,
-                          FrontlineAttackEvent) and event.is_player_attacking:
-                game_event = event
-        # TODO: Why does this exist?
-        if game_event is None:
-            game_event = FrontlineAttackEvent(
-                self.game,
-                self.game.theater.controlpoints[0],
-                self.game.theater.controlpoints[1],
-                self.game.theater.controlpoints[1].position,
-                self.game.player_name,
-                self.game.enemy_name)
-        game_event.is_awacs_enabled = True
-        game_event.ca_slots = 1
-        game_event.departure_cp = self.game.theater.controlpoints[0]
-        game_event.player_attacking()
+        closest_cps = self.game.theater.closest_opposing_control_points()
+        game_event = AirWarEvent(
+            self.game,
+            closest_cps[0],
+            closest_cps[1],
+            self.game.theater.controlpoints[0].position,
+            self.game.player_name,
+            self.game.enemy_name)
 
         unit_map = self.game.initiate_event(game_event)
         waiting = QWaitingForMissionResultWindow(game_event, self.game,


### PR DESCRIPTION
Changes `Operation` to a static class

Remove dead code from `conflictgen.py`

Uses new `AirWarEvent` type created from the nearest opposing control points to create the game event on mission launch, rather than an arbitrary `FrontLineAttackEvent`.

Also fixes bug #431 , although that could easily be fixed separately as well.