### PR TITLE
Merge ground strike and SAM location presets.

### DIFF
--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -90,7 +90,6 @@ class MizCampaignLoader:
     EWR_UNIT_TYPE = AirDefence.EWR_55G6.id
     SAM_UNIT_TYPE = AirDefence.SAM_SA_10_S_300PS_SR_64H6E.id
     GARRISON_UNIT_TYPE = AirDefence.SAM_SA_19_Tunguska_2S6.id
-    STRIKE_TARGET_UNIT_TYPE = Fortification.Workshop_A.id
     OFFSHORE_STRIKE_TARGET_UNIT_TYPE = Fortification.Oil_platform.id
     SHIP_UNIT_TYPE = USS_Arleigh_Burke_IIa.id
     MISSILE_SITE_UNIT_TYPE = MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M.id
@@ -204,12 +203,6 @@ class MizCampaignLoader:
                 yield group
 
     @property
-    def strike_targets(self) -> Iterator[StaticGroup]:
-        for group in self.blue.static_group:
-            if group.units[0].type == self.STRIKE_TARGET_UNIT_TYPE:
-                yield group
-
-    @property
     def offshore_strike_targets(self) -> Iterator[StaticGroup]:
         for group in self.blue.static_group:
             if group.units[0].type == self.OFFSHORE_STRIKE_TARGET_UNIT_TYPE:
@@ -319,15 +312,11 @@ class MizCampaignLoader:
             if distance < self.BASE_DEFENSE_RADIUS:
                 closest.preset_locations.base_air_defense.append(group.position)
             else:
-                closest.preset_locations.sams.append(group.position)
+                closest.preset_locations.strike_locations.append(group.position)
 
         for group in self.ewrs:
             closest, distance = self.objective_info(group)
             closest.preset_locations.ewrs.append(group.position)
-
-        for group in self.strike_targets:
-            closest, distance = self.objective_info(group)
-            closest.preset_locations.strike_locations.append(group.position)
 
         for group in self.offshore_strike_targets:
             closest, distance = self.objective_info(group)

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -80,9 +80,6 @@ class PresetLocations:
     #: Locations used by EWRs.
     ewrs: List[Point] = field(default_factory=list)
 
-    #: Locations used by SAMs outside of bases.
-    sams: List[Point] = field(default_factory=list)
-
     #: Locations used by non-carrier ships. Carriers and LHAs are not random.
     ships: List[Point] = field(default_factory=list)
 
@@ -129,7 +126,7 @@ class PresetLocations:
         if location_type == LocationType.OffshoreStrikeTarget:
             return self._random_from(self.offshore_strike_locations)
         if location_type == LocationType.Sam:
-            return self._random_from(self.sams)
+            return self._random_from(self.strike_locations)
         if location_type == LocationType.Ship:
             return self._random_from(self.ships)
         if location_type == LocationType.Shorad:


### PR DESCRIPTION
Locations that should always be SAMs should be done with fixed IADs
locations, so we don't need the separate type.

The generic "ground strike location" needs to be eventually split up
into more specific types, so eventually all of the non-base defense SAMs
will go away.
