### PR TITLE
Strengthen SA-10, add point defense.

### DIFF
--- a/gen/sam/group_generator.py
+++ b/gen/sam/group_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import math
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type
 
 from dcs import unitgroup
 from dcs.point import PointAction
@@ -38,7 +38,7 @@ class GroupGenerator:
     def get_generated_group(self) -> unitgroup.VehicleGroup:
         return self.vg
 
-    def add_unit(self, unit_type: VehicleType, name: str, pos_x: float,
+    def add_unit(self, unit_type: Type[VehicleType], name: str, pos_x: float,
                  pos_y: float, heading: int) -> Vehicle:
         unit = Vehicle(self.game.next_unit_id(),
                        f"{self.go.group_name}|{name}", unit_type.id)

--- a/gen/sam/sam_group_generator.py
+++ b/gen/sam/sam_group_generator.py
@@ -40,7 +40,11 @@ from gen.sam.sam_linebacker import LinebackerGenerator
 from gen.sam.sam_patriot import PatriotGenerator
 from gen.sam.sam_rapier import RapierGenerator
 from gen.sam.sam_roland import RolandGenerator
-from gen.sam.sam_sa10 import SA10Generator
+from gen.sam.sam_sa10 import (
+    SA10Generator,
+    Tier2SA10Generator,
+    Tier3SA10Generator,
+)
 from gen.sam.sam_sa11 import SA11Generator
 from gen.sam.sam_sa13 import SA13Generator
 from gen.sam.sam_sa15 import SA15Generator
@@ -79,6 +83,8 @@ SAM_MAP = {
     "SA8Generator": SA8Generator,
     "SA9Generator": SA9Generator,
     "SA10Generator": SA10Generator,
+    "Tier2SA10Generator": Tier2SA10Generator,
+    "Tier3SA10Generator": Tier3SA10Generator,
     "SA11Generator": SA11Generator,
     "SA13Generator": SA13Generator,
     "SA15Generator": SA15Generator,
@@ -95,6 +101,8 @@ SAM_MAP = {
 LONG_RANGE_SAMS = {
     "SA10Generator",
     "PatriotGenerator",
+    "Tier2SA10Generator",
+    "Tier3SA10Generator",
 }
 
 #: Used to fill the medium-range required SAM location in the campaign.

--- a/gen/sam/sam_sa10.py
+++ b/gen/sam/sam_sa10.py
@@ -11,7 +11,7 @@ class SA10Generator(GenericSamGroupGenerator):
     """
 
     name = "SA-10/S-300PS Battery"
-    price = 450
+    price = 550
 
     def generate(self):
         # Search Radar
@@ -38,15 +38,51 @@ class SA10Generator(GenericSamGroupGenerator):
             else:
                 self.add_unit(AirDefence.SAM_SA_10_S_300PS_LN_5P85D, "LN#" + str(i), position[0], position[1], position[2])
 
-        # Then let's add short range protection to this high value site
-        # Sa-13 Strela are great for that
-        num_launchers = random.randint(2, 4)
-        positions = self.get_circular_position(num_launchers, launcher_distance=140, coverage=360)
-        for i, position in enumerate(positions):
-            self.add_unit(AirDefence.SAM_SA_13_Strela_10M3_9A35M3, "IR#" + str(i), position[0], position[1], position[2])
+        self.generate_defensive_groups()
 
-        # And even some AA
+    def generate_defensive_groups(self) -> None:
+        # AAA for defending against close targets.
         num_launchers = random.randint(6, 8)
-        positions = self.get_circular_position(num_launchers, launcher_distance=210, coverage=360)
+        positions = self.get_circular_position(
+            num_launchers, launcher_distance=210, coverage=360)
         for i, position in enumerate(positions):
-            self.add_unit(AirDefence.SPAAA_ZSU_23_4_Shilka, "AA#" + str(i), position[0], position[1], position[2])
+            self.add_unit(AirDefence.SPAAA_ZSU_23_4_Shilka, "AA#" + str(i),
+                          position[0], position[1], position[2])
+
+
+class Tier2SA10Generator(SA10Generator):
+    def generate_defensive_groups(self) -> None:
+        # SA-15 for both shorter range targets and point defense.
+        num_launchers = random.randint(2, 4)
+        positions = self.get_circular_position(
+            num_launchers, launcher_distance=140, coverage=360)
+        for i, position in enumerate(positions):
+            self.add_unit(AirDefence.SAM_SA_15_Tor_9A331, "PD#" + str(i),
+                          position[0], position[1], position[2])
+
+        # AAA for defending against close targets.
+        num_launchers = random.randint(6, 8)
+        positions = self.get_circular_position(
+            num_launchers, launcher_distance=210, coverage=360)
+        for i, position in enumerate(positions):
+            self.add_unit(AirDefence.SPAAA_ZSU_23_4_Shilka, "AA#" + str(i),
+                          position[0], position[1], position[2])
+
+
+class Tier3SA10Generator(SA10Generator):
+    def generate_defensive_groups(self) -> None:
+        # SA-15 for both shorter range targets and point defense.
+        num_launchers = random.randint(2, 4)
+        positions = self.get_circular_position(
+            num_launchers, launcher_distance=140, coverage=360)
+        for i, position in enumerate(positions):
+            self.add_unit(AirDefence.SAM_SA_15_Tor_9A331, "PD#" + str(i),
+                          position[0], position[1], position[2])
+
+        # AAA for defending against close targets.
+        num_launchers = random.randint(6, 8)
+        positions = self.get_circular_position(
+            num_launchers, launcher_distance=210, coverage=360)
+        for i, position in enumerate(positions):
+            self.add_unit(AirDefence.SAM_SA_19_Tunguska_2S6, "AA#" + str(i),
+                          position[0], position[1], position[2])

--- a/resources/factions/china_2010.json
+++ b/resources/factions/china_2010.json
@@ -45,8 +45,10 @@
   ],
   "sams": [
     "HQ7Generator",
+    "SA6Generator",
     "SA10Generator",
-    "SA6Generator"
+    "Tier2SA10Generator",
+    "SA11Generator"
   ],
   "ewrs": [
     "BoxSpringGenerator",

--- a/resources/factions/pakistan_2015.json
+++ b/resources/factions/pakistan_2015.json
@@ -44,8 +44,9 @@
     "ZU23Generator"
   ],
   "sams": [
+    "SA2Generator",
     "SA10Generator",
-    "SA2Generator"
+    "SA11Generator"
   ],
   "ewrs": [
     "BoxSpringGenerator",

--- a/resources/factions/russia_2010.json
+++ b/resources/factions/russia_2010.json
@@ -53,10 +53,12 @@
     "SA13Generator"
   ],
   "sams": [
-    "SA11Generator",
-    "SA10Generator",
     "SA6Generator",
-    "SA19Generator"
+    "SA8Generator",
+    "SA10Generator",
+    "SA11Generator",
+    "Tier2SA10Generator",
+    "Tier3SA10Generator"
   ],
   "ewrs": [
     "BoxSpringGenerator",

--- a/resources/factions/russia_2020.json
+++ b/resources/factions/russia_2020.json
@@ -51,9 +51,11 @@
     "SA19Generator"
   ],
   "sams": [
-    "SA11Generator",
+    "SA8Generator",
     "SA10Generator",
-    "SA19Generator"
+    "SA11Generator",
+    "Tier2SA10Generator",
+    "Tier3SA10Generator"
   ],
   "ewrs": [
     "BoxSpringGenerator",

--- a/resources/factions/syria_2011.json
+++ b/resources/factions/syria_2011.json
@@ -60,8 +60,11 @@
     "SA2Generator",
     "SA3Generator",
     "SA6Generator",
+    "SA8Generator",
     "SA10Generator",
-    "SA11Generator"
+    "SA11Generator",
+    "Tier2SA10Generator",
+    "Tier3SA10Generator"
   ],
   "ewrs": [
     "BoxSpringGenerator",

--- a/resources/factions/ukraine_2010.json
+++ b/resources/factions/ukraine_2010.json
@@ -45,8 +45,12 @@
   ],
   "sams": [
     "SA3Generator",
+    "SA6Generator",
+    "SA8Generator",
     "SA10Generator",
-    "SA11Generator"
+    "SA11Generator",
+    "Tier2SA10Generator",
+    "Tier3SA10Generator"
   ],
   "ewrs": [
     "BigBirdGenerator"


### PR DESCRIPTION
Fixes https://github.com/Khopa/dcs_liberation/issues/417, though the
notes on that bug about this being non-optimal for skynet are still
true. This doesn't make skynet behavior any worse though, and does
improve it some compared to not having PD.

Adds two new SA-10 generator variants:

* Tier 2, with SA-15 for point defense
* Tier 3, with SA-15 for point defense and the Shilka upgraded to a
  Tunguska.

Updated factions that are capable of those systems, added missing SAMs
to those factions, and removed use of SA-19 as an independent SAM from
those factions. Will do a larger audit of faction SAMs later.
