### PR TITLE
refresh budget after purchase from sub-dialog

### DIFF
--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -170,3 +170,10 @@ class QBaseMenu2(QDialog):
 
     def new_package(self) -> None:
         Dialog.open_new_package_dialog(self.cp, parent=self.window())
+
+    def update_dialogue_budget(self, budget):
+        GameUpdateSignal.get_instance().updateBudget(self.game_model.game)
+        for child in self.children():
+            if child.objectName() == "budgetField":
+                child.setText(
+                    QRecruitBehaviour.BUDGET_FORMAT.format(budget))

--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -171,7 +171,7 @@ class QBaseMenu2(QDialog):
     def new_package(self) -> None:
         Dialog.open_new_package_dialog(self.cp, parent=self.window())
 
-    def update_dialogue_budget(self, budget):
+    def update_dialogue_budget(self, budget: int):
         GameUpdateSignal.get_instance().updateBudget(self.game_model.game)
         for child in self.children():
             if child.objectName() == "budgetField":

--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -125,10 +125,7 @@ class QRecruitBehaviour:
         parent = self.parent()
         while parent.objectName != "menuDialogue":
             parent = parent.parent()
-        for child in parent.children():
-            if child.objectName() == "budgetField":
-                child.setText(
-                    QRecruitBehaviour.BUDGET_FORMAT.format(self.budget))
+        parent.update_dialogue_budget(self.budget)
 
     def buy(self, unit_type: Type[UnitType]):
         price = db.PRICES[unit_type]

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -190,6 +190,7 @@ class QGroundObjectMenu(QDialog):
             group.units_losts = [u for u in group.units_losts if u.id != unit.id]
             group.units.append(unit)
             GameUpdateSignal.get_instance().updateGame(self.game)
+            self.parent().update_dialogue_budget(self.game.budget)
 
             # Remove destroyed units in the vicinity
             destroyed_units = self.game.get_destroyed_units()
@@ -209,6 +210,7 @@ class QGroundObjectMenu(QDialog):
         self.ground_object.groups = []
         self.do_refresh_layout()
         GameUpdateSignal.get_instance().updateBudget(self.game)
+        self.parent().update_dialogue_budget(self.game.budget)
 
     def buy_group(self):
         self.subwindow = QBuyGroupForGroundObjectDialog(self, self.ground_object, self.cp, self.game, self.total_value)
@@ -333,6 +335,7 @@ class QBuyGroupForGroundObjectDialog(QDialog):
         self.ground_object.groups = [group]
 
         GameUpdateSignal.get_instance().updateBudget(self.game)
+        self.parent().parent().update_dialogue_budget(self.game.budget)
 
         self.changed.emit()
         self.close()
@@ -353,6 +356,7 @@ class QBuyGroupForGroundObjectDialog(QDialog):
         self.ground_object.groups = [generated_group]
 
         GameUpdateSignal.get_instance().updateBudget(self.game)
+        self.parent().parent().update_dialogue_budget(self.game.budget)
 
         self.changed.emit()
         self.close()


### PR DESCRIPTION
fixes https://github.com/Khopa/dcs_liberation/issues/221

turns out the original fix to budget updates was a little naïve on my part, though it did provide a more prominent budget status outside of that in the main window.

this fixes the current update bug, but should use `GameUpdateSignal.get_instance().updateBudget(self.game)` as the update mechanism. The current mechanism has introduced duplicate behaviour and as shown by recent updates is at risk of further breakages.

Two options:

1.  remove the added dialogue "Available Budget" field and fallback to live update of main-window budget field.

1. keep the dialog budget field, but shift the code up to the root and dispatch to the dialog upon changes to the budget within the model.