### PR TITLE
Explicit resources

### DIFF
--- a/gen/triggergen.py
+++ b/gen/triggergen.py
@@ -82,7 +82,13 @@ class TriggersGenerator:
                 airport.operating_level_air = 0
                 airport.operating_level_equipment = 0
                 airport.operating_level_fuel = 0
-
+        
+        for airport in self.mission.terrain.airport_list():
+            if airport.id not in cp_ids:
+                airport.unlimited_fuel = True
+                airport.unlimited_munitions = True
+                airport.unlimited_aircrafts = True
+        
         for cp in self.game.theater.controlpoints:
             if isinstance(cp, Airfield):
                 self.mission.terrain.airport_by_id(cp.at.id).set_coalition(cp.captured and player_coalition or enemy_coalition)


### PR DESCRIPTION
This fixes bug #559 by explicitly setting all CP airbases to have unlimited resources.  I don't think this has any unintended side effects, but let me know if there's a reason not to do this.

FWIW, I can't consistently reproduce generating missions that don't have resources at CP fields, but I did see it happen in the save game provided in #559 , and I keep hearing about this zero fuel thing happening to others.