### PR TITLE
Improve TOT planning.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * **[Units]** Support for newly added BTR-82A, T-72B3
 * **[Units]** Added ZSU-57 AAA sites
 * **[Culling]** BARCAP missions no longer create culling exclusion zones.
+* **[Flight Planner]** Improved TOT planning. Negative start times no longer occur with TARCAPs and hold times no longer affect planning for flight plans without hold points.
 
 ## Fixes:
 * **[Mission Generator]** Fix mission generation error when there are too many radio frequency to setup for the Mig-21

--- a/gen/aircraft.py
+++ b/gen/aircraft.py
@@ -20,20 +20,20 @@ from dcs.planes import (
     B_17G,
     B_52H,
     Bf_109K_4,
-    C_101EB,
     C_101CC,
+    C_101EB,
     FW_190A8,
     FW_190D9,
     F_14B,
     I_16,
     JF_17,
     Ju_88A4,
-    PlaneType,
     P_47D_30,
     P_47D_30bl1,
     P_47D_40,
     P_51D,
     P_51D_30_NA,
+    PlaneType,
     SpitfireLFMkIX,
     SpitfireLFMkIXCW,
     Su_33,
@@ -59,16 +59,15 @@ from dcs.task import (
     OptReactOnThreat,
     OptRestrictJettison,
     OrbitAction,
+    PinpointStrike,
     RunwayAttack,
     SEAD,
     StartCommand,
     Targets,
     Task,
     WeaponType,
-    PinpointStrike,
 )
 from dcs.terrain.terrain import Airport, NoParkingSlotError
-from dcs.translation import String
 from dcs.triggers import Event, TriggerOnce, TriggerRule
 from dcs.unitgroup import FlyingGroup, ShipGroup, StaticGroup
 from dcs.unittype import FlyingType, UnitType
@@ -99,7 +98,6 @@ from gen.flights.flight import (
 )
 from gen.radios import MHz, Radio, RadioFrequency, RadioRegistry, get_radio
 from gen.runways import RunwayData
-from .conflictgen import Conflict
 from .flights.flightplan import (
     CasFlightPlan,
     LoiterFlightPlan,
@@ -108,7 +106,6 @@ from .flights.flightplan import (
 )
 from .flights.traveltime import GroundSpeed, TotEstimator
 from .naming import namegen
-from .runways import RunwayAssigner
 
 if TYPE_CHECKING:
     from game import Game
@@ -1349,7 +1346,7 @@ class AircraftConflictGenerator:
 
         # And setting *our* waypoint TOT causes the takeoff time to show up in
         # the player's kneeboard.
-        waypoint.tot = estimator.takeoff_time_for_flight(flight)
+        waypoint.tot = flight.flight_plan.takeoff_time()
         # And finally assign it to the FlightData info so it shows correctly in
         # the briefing.
         self.flights[-1].departure_delay = start_time

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
@@ -7,7 +7,6 @@ from PySide2.QtWidgets import QHeaderView, QTableView
 from game.utils import meter_to_feet
 from gen.ato import Package
 from gen.flights.flight import Flight, FlightWaypoint, FlightWaypointType
-from gen.flights.traveltime import TotEstimator
 from qt_ui.windows.mission.flight.waypoints.QFlightWaypointItem import \
     QWaypointItem
 
@@ -74,9 +73,9 @@ class QFlightWaypointList(QTableView):
         time = timedelta(seconds=int(time.total_seconds()))
         return f"{prefix}T+{time}"
 
-    def takeoff_text(self, flight: Flight) -> str:
-        estimator = TotEstimator(self.package)
-        takeoff_time = estimator.takeoff_time_for_flight(flight)
+    @staticmethod
+    def takeoff_text(flight: Flight) -> str:
+        takeoff_time = flight.flight_plan.takeoff_time()
         # Handle custom flight plans where we can't estimate the takeoff time.
         if takeoff_time is None:
             takeoff_time = timedelta()


### PR DESCRIPTION
Moves all TOT planning into the FlightPlan to clean up specialized
behavior and improve planning characteristics.

The important part of this change is that flights are now planning to
the mission time for their flight rather than the package as a whole.
For example, a TARCAP is planned based on the time from startup to the
patrol point, a sweep is planned based on the time from startup to the
sween end point, and a strike flight is planned based on the time from
startup to the target location. TOT offsets can be handled within the
flight plan.

As another benefit of theis cleanup, flights without hold points no
longer account for the hold time in their planning, so those flights are
planned to reach their targets sooner.

As a follow up TotEstimator can be removed, but I want to keep this low
impact for 2.3.2.

Fixes https://github.com/Khopa/dcs_liberation/issues/593
