### PR TITLE
Adds a 2005-ish Greece faction.

### DIFF
--- a/resources/factions/greece_2005.json
+++ b/resources/factions/greece_2005.json
@@ -1,0 +1,51 @@
+{
+  "country": "Greece",
+  "name": "Greece 2005",
+  "authors": "SimonC6R",
+  "description": "<p>Hellenic army in the mid/late 2000s.</p>",
+  "aircrafts": [
+    "F_16C_50",
+    "F_4E",
+    "M_2000C",
+    "Mirage_2000_5",
+    "UH_1H",
+    "AH_64A"
+  ],
+  "tankers": [
+    "KC130"
+  ],
+  "frontline_units": [
+    "MBT_Leopard_2",
+    "MBT_Leopard_1A3",
+    "MBT_M60A3_Patton",
+    "APC_M1043_HMMWV_Armament",
+    "ATGM_M1045_HMMWV_TOW",
+    "APC_M113",
+    "IFV_BMP_1"
+  ],
+  "artillery_units": [
+    "SPH_M109_Paladin",
+    "MLRS_M270"
+  ],
+  "logistics_units": [
+    "Transport_M818"
+  ],
+  "infantry_units": [
+    "Infantry_M4",
+    "Soldier_M249",
+    "Stinger_MANPADS"
+  ],
+  "air_defenses": [
+    "HawkGenerator",
+    "SA8Generator",
+    "SA10Generator",
+    "SA15Generator",
+    "ZU23Generator"
+  ],
+  "ewrs": [
+    "HawkEwrGenerator",
+    "FlatFaceGenerator"
+  ],
+  "has_jtac": true,
+  "jtac_unit": "MQ_9_Reaper"
+}


### PR DESCRIPTION
The Leopard 2 had just entered Greek service in 2005, so may be too new for this faction.
The Avenger is a stand-in for the ASRAD-HELLAS system.
Similarly, the Mirage 2000C is a stand-in for the Mirage 2000EG.

Given that Cyprus will be added to the Syria map soon, Greece seems like a reasonable faction to add.