### PR TITLE
Adds a 2010-ish Poland faction.

### DIFF
--- a/game/db.py
+++ b/game/db.py
@@ -415,6 +415,7 @@ PRICES = {
     Artillery.MLRS_BM_21_Grad: 15,
     Artillery.MLRS_9K57_Uragan_BM_27: 50,
     Artillery.MLRS_9A52_Smerch: 40,
+    Artillery.SpGH_Dana: 26,
 
     Unarmed.Transport_UAZ_469: 3,
     Unarmed.Transport_Ural_375: 3,
@@ -849,6 +850,7 @@ UNIT_BY_TASK = {
         Artillery.MLRS_BM_21_Grad,
         Artillery.MLRS_9K57_Uragan_BM_27,
         Artillery.MLRS_9A52_Smerch,
+        Artillery.SpGH_Dana,
         Artillery.M12_GMC,
         Artillery.Sturmpanzer_IV_Brummbär,
 

--- a/resources/factions/poland_2010.json
+++ b/resources/factions/poland_2010.json
@@ -1,5 +1,5 @@
 {
-  "country": "Poland",
+  "country": "Combined Joint Task Forces Blue",
   "name": "Poland 2010",
   "authors": "SimonC6R",
   "description": "<p>Polish army in the 2010s.</p>",
@@ -15,6 +15,7 @@
   "frontline_units": [
     "APC_M1043_HMMWV_Armament",
     "ATGM_M1045_HMMWV_TOW",
+    "APC_M1126_Stryker_ICV",
     "ARV_BRDM_2",
     "IFV_BMP_1",
     "APC_MTLB",
@@ -29,6 +30,12 @@
   "logistics_units": [
     "Transport_Ural_375",
     "Transport_UAZ_469"
+  ],
+  "infantry_units": [
+    "Paratrooper_AKS",
+    "Infantry_Soldier_Rus",
+    "Soldier_RPG",
+    "SAM_SA_18_Igla_S_MANPADS"
   ],
   "air_defenses": [
     "SA6Generator",

--- a/resources/factions/poland_2010.json
+++ b/resources/factions/poland_2010.json
@@ -1,0 +1,50 @@
+{
+  "country": "Poland",
+  "name": "Poland 2010",
+  "authors": "SimonC6R",
+  "description": "<p>Polish army in the 2010s.</p>",
+  "aircrafts": [
+    "Su_17M4",
+    "MiG_29A",
+    "F_16C_50",
+    "Mi_8MT"
+  ],
+  "tankers": [
+    "KC130"
+  ],
+  "frontline_units": [
+    "APC_M1043_HMMWV_Armament",
+    "ATGM_M1045_HMMWV_TOW",
+    "ARV_BRDM_2",
+    "IFV_BMP_1",
+    "APC_MTLB",
+    "MBT_Leopard_2",
+    "MBT_T_72B3"
+  ],
+  "artillery_units": [
+    "MLRS_BM_21_Grad",
+    "SPH_2S1_Gvozdika",
+    "SpGH_Dana"
+  ],
+  "logistics_units": [
+    "Transport_Ural_375",
+    "Transport_UAZ_469"
+  ],
+  "air_defenses": [
+    "SA6Generator",
+    "SA8Generator",
+    "ZSU23Generator",
+    "ZU23Generator",
+    "ZU23UralGenerator"
+  ],
+  "ewrs": [
+    "BigBirdGenerator"
+  ],
+  "requirements": {},
+  "carrier_names": [],
+  "navy_generators": [
+    "MolniyaGroupGenerator",
+    "KiloSubGroupGenerator",
+    "OliverHazardPerryGroupGenerator"
+  ]
+}


### PR DESCRIPTION
The SU-17M4 represents the remaining Su-22s that Poland still flies.
I've used the Stryker as a replacement for the KTO Rosomak, which was in service as far back as 2007.
There were a few Molniyas still in service as of 2010, namely the Metalowiec and Rolnik, as well as a singular Kilo class.

I think Poland presents an interesting mix of East/West tech, and thus a worthy addition to DCS Liberation.