### PR TITLE
Display the default loadout in the payload UI.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Saves from 2.3 are not compatible with 2.4.
 * **[Economy]** Sales of aircraft and ground vehicles can now be cancelled before the next turn begins.
 * **[UI]** Multi-SAM objectives now show threat and detection rings per group.
 * **[UI]** Unit names are now prettier and more accurate, and can now be set per-country for added historical flavour.
+* **[UI]** Default loadout is now shown for flights with no custom loadout selected.
 * **[Factions]** Added option for date-based loadout restriction. Active radar homing missiles are handled, patches welcome for the other thousand weapons.
 * **[Factions]** Added Poland 2010 faction.
 * **[Factions]** Added Greece 2005 faction.

--- a/game/db.py
+++ b/game/db.py
@@ -1020,6 +1020,29 @@ COMMON_OVERRIDE = {
     RunwayAttack: "RUNWAY_ATTACK"
 }
 
+"""
+This is a list of mappings from the FlightType of a Flight to the type of payload defined in the
+resources/payloads/UNIT_TYPE.lua file. A Flight has no concept of a PyDCS task, so COMMON_OVERRIDE cannot be
+used here. This is used in the payload editor, for setting the default loadout of an object.
+The left element is the FlightType name, and the right element is what is used in the lua file. 
+"""
+
+EXPANDED_TASK_PAYLOAD_OVERRIDE = {
+    "TARCAP": "CAP",
+    "BARCAP": "CAP",
+    "CAS": "CAS",
+    "INTERCEPTION": "CAP",
+    "STRIKE": "STRIKE",    
+    "ANTISHIP": "ANTISHIP",
+    "SEAD": "SEAD",
+    "DEAD": "SEAD",
+    "ESCORT": "CAP",
+    "BAI": "CAS",
+    "SWEEP": "CAP",
+    "OCA_RUNWAY": "STRIKE",
+    "OCA_AIRCRAFT": "CAS"
+}
+
 PLANE_PAYLOAD_OVERRIDES: Dict[Type[PlaneType], Dict[Type[Task], str]] = {
 
     B_1B: COMMON_OVERRIDE,

--- a/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
@@ -39,5 +39,14 @@ class QLoadoutEditor(QGroupBox):
 
     def on_toggle(self):
         self.flight.use_custom_loadout = self.isChecked()
-
-
+        if not self.isChecked():
+            for i in self.findChildren(QPylonEditor):
+                for j in enumerate(Pylon.iter_pylons(self.flight.unit_type)):
+                    # Only change the text in the pylon selector, not any actual data.
+                    i.default_loadout(j[0])
+        else:
+            for i in self.findChildren(QPylonEditor):
+                # Clear the loadout so that the user has select it themself.
+                # If we don't do this, the user may end up leaving an entry as the default,
+                # which is just text, not actual data, meaning they'd have an empty pylon.
+                i.clear_loadout()

--- a/qt_ui/windows/mission/flight/payload/QPylonEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QPylonEditor.py
@@ -4,9 +4,10 @@ from typing import Optional
 
 from PySide2.QtWidgets import QComboBox
 
-from game import Game
+from game import Game, db
 from game.data.weapons import Pylon, Weapon
 from gen.flights.flight import Flight
+from dcs import weapons_data
 
 
 class QPylonEditor(QComboBox):
@@ -29,6 +30,7 @@ class QPylonEditor(QComboBox):
             if current == weapon:
                 self.setCurrentIndex(i + 1)
 
+        self.default_loadout(self.pylon)
         self.currentIndexChanged.connect(self.on_pylon_change)
 
     def on_pylon_change(self):
@@ -40,3 +42,18 @@ class QPylonEditor(QComboBox):
         else:
             logging.debug(
                 f"Pylon {self.pylon.number} changed to {selected.name}")
+
+    def default_loadout(self, pylon: Pylon) -> None:
+        self.flight.unit_type.load_payloads()
+        loadout = self.flight.unit_type.loadout_by_name(db.EXPANDED_TASK_PAYLOAD_OVERRIDE.get(self.flight.flight_type.name))
+        pylon_default_weapon = None
+        for i in loadout:
+            if i[0] == self.pylon.number:
+                pylon_default_weapon = i[1]["clsid"]
+        if pylon_default_weapon is not None:
+            self.setCurrentText(weapons_data.weapon_ids.get(pylon_default_weapon).get("name"))
+        else:
+            self.setCurrentText("None")
+
+    def clear_loadout(self) -> None:
+        self.setCurrentIndex(0)


### PR DESCRIPTION
The default loadout is now displayed whenever the custom loadout checkbox is unchecked.

The custom loadout is reset when the custom loadout is checked, to force the user to be prescriptive about the loadout.

Contributes-to: Khopa/dcs_liberation#725