### PR TITLE
Carrier group threat rings move with the carrier.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ Saves from 2.3 are not compatible with 2.4.
 ## Fixes
 
 * **[Economy]** Pending unit orders at captured bases will be refunded.
+* **[UI]** Carrier group SAM threat rings now move with the carrier.
 * **[Units]** J-11A is no longer spawned with empty loadout.
 
 # 2.3.3

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -561,6 +561,8 @@ class ControlPoint(MissionTarget, ABC):
             # Move the linked unit groups
             for ground_object in self.ground_objects:
                 if isinstance(ground_object, GenericCarrierGroundObject):
+                    ground_object.position.x = ground_object.position.x + delta.x
+                    ground_object.position.y = ground_object.position.y + delta.y
                     for group in ground_object.groups:
                         for u in group.units:
                             u.position.x = u.position.x + delta.x


### PR DESCRIPTION
Previously, the individual units in the group were moved, but the ground_unit object was not.

Fixes: Khopa/dcs_liberation#735