### PR TITLE
fictional Korean War factions 1950

### DIFF
--- a/resources/factions/dprk_1950_fictional.json
+++ b/resources/factions/dprk_1950_fictional.json
@@ -1,0 +1,59 @@
+{
+  "country": "North Korea",
+  "name": "North Korea 1950, fictional",
+  "authors": "BenBenBeartrax",
+  "description": "<p>Fictional DPRK (North Korea) army around 1955, during the Korean War, with some WW2 planes added in place of their post-war counterparts.</p>",
+  "aircrafts": [
+    "MiG_15bis",
+    "I_16",
+    "FW_190A8",
+    "FW_190D9",
+    "Bf_109K_4"
+  ],
+  "awacs": [
+  ],
+  "tankers": [
+  ],
+  "frontline_units": [
+    "ARV_BRDM_2",
+    "FDDM_Grad",
+    "APC_MTLB",
+    "MBT_T_55",
+    "AAA_ZU_23_on_Ural_375",
+    "AAA_8_8cm_Flak_18"
+  ],
+  "artillery_units": [
+    "MLRS_BM_21_Grad"
+  ],
+  "logistics_units": [
+    "Transport_Ural_375",
+    "Transport_UAZ_469"
+  ],
+  "infantry_units": [
+    "Infantry_Soldier_Rus",
+    "Soldier_RPG"
+  ],
+  "air_defenses": [
+    "FlakGenerator",
+    "EarlyColdWarFlakGenerator"
+  ],
+  "aircraft_carrier": [
+  ],
+  "helicopter_carrier": [
+  ],
+  "helicopter_carrier_names": [
+  ],
+  "destroyers": [
+  ],
+  "cruisers": [
+  ],
+  "requirements": {
+    "WW2 Asset Pack": "https://www.digitalcombatsimulator.com/en/products/other/wwii_assets_pack/"
+  },
+  "carrier_names": [
+  ],
+  "navy_generators": [
+  ],
+  "has_jtac": false,
+  "doctrine": "ww2"
+}

--- a/resources/factions/unc_1950_fictional.json
+++ b/resources/factions/unc_1950_fictional.json
@@ -1,0 +1,41 @@
+{
+  "country": "USA",
+  "name": "United Nations Command 1950, fictional",
+  "authors": "BenBenBeartrax",
+  "description": "<p>Fictional United Nations Command around 1955 during the Korean War, with some WW2 planes added in place of their post-war counterparts.</p>",
+  "aircrafts": [
+    "F_86F_Sabre",
+    "P_51D",
+    "P_51D_30_NA",
+    "B_17G",
+    "A_20G",
+    "P_47D_40"
+  ],
+  "frontline_units": [
+    "MT_M4_Sherman",
+    "MBT_M60A3_Patton",
+    "APC_M2A1",
+    "LAC_M8_Greyhound",
+    "AAA_Bofors_40mm"
+  ],
+  "artillery_units": [
+    "M12_GMC"
+  ],
+  "logistics_units": [
+    "Transport_M818"
+  ],
+  "infantry_units": [
+    "Infantry_M4"
+  ],
+  "air_defenses": [
+    "AllyWW2FlakGenerator",
+    "BoforsGenerator",
+    "EarlyColdWarFlakGenerator"
+  ],
+  "has_jtac": false,
+  "doctrine": "ww2",
+  "building_set": "ww2ally",
+  "requirements": {
+      "WW2 Asset Pack": "https://www.digitalcombatsimulator.com/en/products/other/wwii_assets_pack/"
+  }
+}


### PR DESCRIPTION
Fictional Redfor and Bluefor Korean War 1950 factions (United Nations Command and DPRK/KPA).
Based on the existing 1955 USA and Russia factions with some added WW2 prop planes. This is done to mimic the older generation planes of that conflict and give both sides more diversity, more ground attack capability and both sides more player options to fly. Bluefor has more bombing capability with the B-17 and A-20 and Redfor can do the Mig-15 bread-and-butter mission of bomber interceptor.
WW2 asset pack required.