### PR TITLE
Updated Budget and Intel

### DIFF
--- a/qt_ui/widgets/QBudgetBox.py
+++ b/qt_ui/widgets/QBudgetBox.py
@@ -14,14 +14,6 @@ class QBudgetBox(QGroupBox):
         super(QBudgetBox, self).__init__("Budget")
 
         self.game = game
-        # self.money_icon = QLabel()
-        # self.money_icon.setPixmap(CONST.ICONS["Money"])
-        # self.money_amount = QLabel()
-
-        # self.finances = QPushButton("Details")
-        # self.finances.setDisabled(True)
-        # self.finances.setProperty("style", "btn-primary")
-        # self.finances.clicked.connect(self.openFinances)
 
         self.finances = QPushButton()
         self.finances.setDisabled(True)
@@ -30,8 +22,6 @@ class QBudgetBox(QGroupBox):
         self.finances.clicked.connect(self.openFinances)
 
         self.layout = QHBoxLayout()
-        # self.layout.addWidget(self.money_icon)
-        # self.layout.addWidget(self.money_amount)
         self.layout.addWidget(self.finances)
         self.setLayout(self.layout)
 

--- a/qt_ui/widgets/QBudgetBox.py
+++ b/qt_ui/widgets/QBudgetBox.py
@@ -14,18 +14,24 @@ class QBudgetBox(QGroupBox):
         super(QBudgetBox, self).__init__("Budget")
 
         self.game = game
-        self.money_icon = QLabel()
-        self.money_icon.setPixmap(CONST.ICONS["Money"])
-        self.money_amount = QLabel()
+        # self.money_icon = QLabel()
+        # self.money_icon.setPixmap(CONST.ICONS["Money"])
+        # self.money_amount = QLabel()
 
-        self.finances = QPushButton("Details")
+        # self.finances = QPushButton("Details")
+        # self.finances.setDisabled(True)
+        # self.finances.setProperty("style", "btn-primary")
+        # self.finances.clicked.connect(self.openFinances)
+
+        self.finances = QPushButton()
         self.finances.setDisabled(True)
         self.finances.setProperty("style", "btn-primary")
+        self.finances.setIcon(CONST.ICONS["Money"])
         self.finances.clicked.connect(self.openFinances)
 
         self.layout = QHBoxLayout()
-        self.layout.addWidget(self.money_icon)
-        self.layout.addWidget(self.money_amount)
+        # self.layout.addWidget(self.money_icon)
+        # self.layout.addWidget(self.money_amount)
         self.layout.addWidget(self.finances)
         self.setLayout(self.layout)
 
@@ -35,7 +41,7 @@ class QBudgetBox(QGroupBox):
         :param budget: Current money available
         :param reward: Planned reward for next turn
         """
-        self.money_amount.setText(
+        self.finances.setText(
             str(round(budget, 2)) + "M (+" + str(round(reward, 2)) + "M)"
         )
 

--- a/qt_ui/widgets/QIntelBox.py
+++ b/qt_ui/widgets/QIntelBox.py
@@ -25,7 +25,6 @@ class QIntelBox(QGroupBox):
 
         summary = QGridLayout()
         summary.setContentsMargins(5, 5, 5, 5)
-        # columns.addLayout(summary)
 
         air_superiority = QLabel("Air superiority:")
         summary.addWidget(air_superiority, 0, 0)
@@ -51,7 +50,6 @@ class QIntelBox(QGroupBox):
         self.ground_strength.setStyleSheet(button_text_style)
         self.economic_strength.setStyleSheet(button_text_style)
 
-        # details = QPushButton("Details")
         self.details = QPushButton()
         self.details.setMinimumHeight(50)
         self.details.setMinimumWidth(210)

--- a/qt_ui/widgets/QIntelBox.py
+++ b/qt_ui/widgets/QIntelBox.py
@@ -24,23 +24,41 @@ class QIntelBox(QGroupBox):
         self.setLayout(columns)
 
         summary = QGridLayout()
-        columns.addLayout(summary)
+        summary.setContentsMargins(5, 5, 5, 5)
+        # columns.addLayout(summary)
 
-        summary.addWidget(QLabel("Air superiority:"), 0, 0)
+        air_superiority = QLabel("Air superiority:")
+        summary.addWidget(air_superiority, 0, 0)
         self.air_strength = QLabel()
         summary.addWidget(self.air_strength, 0, 1)
 
-        summary.addWidget(QLabel("Front line:"), 1, 0)
+        front_line = QLabel("Front line:")
+        summary.addWidget(front_line, 1, 0)
         self.ground_strength = QLabel()
         summary.addWidget(self.ground_strength, 1, 1)
 
-        summary.addWidget(QLabel("Economic strength:"), 2, 0)
+        economy = QLabel("Economic strength:")
+        summary.addWidget(economy, 2, 0)
         self.economic_strength = QLabel()
         summary.addWidget(self.economic_strength, 2, 1)
 
-        details = QPushButton("Details")
-        columns.addWidget(details)
-        details.clicked.connect(self.open_details_window)
+        # some dirty styling to make the labels show up well on the button
+        button_text_style = "background-color: rgba(0,0,0,0%); color: white;"
+        air_superiority.setStyleSheet(button_text_style)
+        front_line.setStyleSheet(button_text_style)
+        economy.setStyleSheet(button_text_style)
+        self.air_strength.setStyleSheet(button_text_style)
+        self.ground_strength.setStyleSheet(button_text_style)
+        self.economic_strength.setStyleSheet(button_text_style)
+
+        # details = QPushButton("Details")
+        self.details = QPushButton()
+        self.details.setMinimumHeight(50)
+        self.details.setMinimumWidth(210)
+        self.details.setLayout(summary)
+        columns.addWidget(self.details)
+        self.details.clicked.connect(self.open_details_window)
+        self.details.setEnabled(False)
 
         self.update_summary()
 
@@ -48,6 +66,7 @@ class QIntelBox(QGroupBox):
 
     def set_game(self, game: Optional[Game]) -> None:
         self.game = game
+        self.details.setEnabled(True)
         self.update_summary()
 
     @staticmethod


### PR DESCRIPTION
Budget and Intel panels now house a single button instead of separate Details buttons. Makes the top bar more compact and can fit in a 1080p monitor now.
![image](https://user-images.githubusercontent.com/3486419/115820687-35fbc580-a3b6-11eb-95be-5e8b1f15776d.png)
