### PR TITLE
FIX: Purchase from airfield or anywhere allows negative budget

### DIFF
--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -178,6 +178,10 @@ class QRecruitBehaviour:
             return
 
         price = db.PRICES[unit_type]
+        if self.budget < price:
+            logging.info(f"Not enough cash to buy")
+            return
+
         self.pending_deliveries.order({unit_type: 1})
         self.budget -= price
         self._update_count_label(unit_type)

--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -178,10 +178,6 @@ class QRecruitBehaviour:
             return
 
         price = db.PRICES[unit_type]
-        if self.budget < price:
-            logging.info(f"Not enough cash to buy")
-            return
-
         self.pending_deliveries.order({unit_type: 1})
         self.budget -= price
         self._update_count_label(unit_type)

--- a/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
@@ -93,6 +93,8 @@ class QAircraftRecruitmentMenu(QFrame, QRecruitBehaviour):
         self.setLayout(main_layout)
 
     def enable_purchase(self, unit_type: Type[UnitType]) -> bool:
+        if not super().enable_purchase(unit_type):
+            return False
         if not issubclass(unit_type, FlyingType):
             return False
         if not self.cp.can_operate(unit_type):


### PR DESCRIPTION
This should fix the issue (https://github.com/Khopa/dcs_liberation/issues/1032). It's not probably the most desirable way because I think the user must be informed that he runs out of cash somehow using a throw and capturing the bubble at the top showing a message or something.

BTW: This is my first pull request on this project I would like to have some feedback on the way you do pull-requests if needed.