### PR TITLE
Prevent empty transfers

### DIFF
--- a/qt_ui/windows/basemenu/NewUnitTransferDialog.py
+++ b/qt_ui/windows/basemenu/NewUnitTransferDialog.py
@@ -288,6 +288,7 @@ class NewUnitTransferDialog(QDialog):
         self.submit_button = QPushButton("Create Transfer Order", parent=self)
         self.submit_button.clicked.connect(self.on_submit)
         self.submit_button.setProperty("style", "start-button")
+        self.submit_button.setDisabled(True)
         layout.addWidget(self.submit_button)
 
     def on_submit(self) -> None:

--- a/qt_ui/windows/basemenu/NewUnitTransferDialog.py
+++ b/qt_ui/windows/basemenu/NewUnitTransferDialog.py
@@ -288,7 +288,6 @@ class NewUnitTransferDialog(QDialog):
         self.submit_button = QPushButton("Create Transfer Order", parent=self)
         self.submit_button.clicked.connect(self.on_submit)
         self.submit_button.setProperty("style", "start-button")
-        self.submit_button.setDisabled(True)
         layout.addWidget(self.submit_button)
 
     def on_submit(self) -> None:


### PR DESCRIPTION
Disables the 'create transfer order' button in the unit transfer dialog if no units are actually selected for transfer (including when the dialog is first loaded).