### PR TITLE
Making Sweep flight types have appropriate aircraft

### DIFF
--- a/gen/flights/ai_flight_planner_db.py
+++ b/gen/flights/ai_flight_planner_db.py
@@ -396,7 +396,7 @@ AEWC_CAPABLE = [
 
 
 def aircraft_for_task(task: FlightType) -> List[Type[FlyingType]]:
-    cap_missions = (FlightType.BARCAP, FlightType.TARCAP)
+    cap_missions = (FlightType.BARCAP, FlightType.TARCAP, FlightType.SWEEP)
     if task in cap_missions:
         return CAP_CAPABLE
     elif task == FlightType.ANTISHIP:


### PR DESCRIPTION
Now that the aircraft selection dialog uses `aircraft_for_task` from the `ai_flight_planner_db.py`, it needs to handle the `SWEEP` `FlightType`.