### PR TITLE
Inject mod plane weapons into pydcs

### DIFF
--- a/pydcs_extensions/a4ec/a4ec.py
+++ b/pydcs_extensions/a4ec/a4ec.py
@@ -4,6 +4,8 @@ from dcs import task
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
+from pydcs_extensions.weapon_injector import inject_weapons
+
 
 class WeaponsA4EC:
     AN_M57__2__TER_ = {
@@ -430,6 +432,9 @@ class WeaponsA4EC:
         "name": "Fuel_Tank_400_gallons__EMPTY",
         "weight": 108.86208,
     }
+
+
+inject_weapons(WeaponsA4EC)
 
 
 class A_4E_C(PlaneType):

--- a/pydcs_extensions/f22a/f22a.py
+++ b/pydcs_extensions/f22a/f22a.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from dcs import task
 from dcs.planes import PlaneType
-from dcs.weapons_data import Weapons, weapon_ids
+from dcs.weapons_data import Weapons
 
 from pydcs_extensions.weapon_injector import inject_weapons
 

--- a/pydcs_extensions/f22a/f22a.py
+++ b/pydcs_extensions/f22a/f22a.py
@@ -4,14 +4,15 @@ from dcs import task
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons, weapon_ids
 
+from pydcs_extensions.weapon_injector import inject_weapons
+
 
 class F22AWeapons:
     AIM_9XX = {"clsid": "{AIM-9XX}", "name": "AIM-9XX", "weight": 85}
     AIM_120D = {"clsid": "{AIM-120D}", "name": "AIM-120D", "weight": 152}
-    Weapons.AIM_9XX = AIM_9XX
-    Weapons.AIM_120D = AIM_120D
-    weapon_ids["{AIM-9XX}"] = AIM_9XX
-    weapon_ids["{AIM-120D}"] = AIM_120D
+
+
+inject_weapons(F22AWeapons)
 
 
 class F_22A(PlaneType):

--- a/pydcs_extensions/hercules/hercules.py
+++ b/pydcs_extensions/hercules/hercules.py
@@ -4,6 +4,8 @@ from dcs import task
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
+from pydcs_extensions.weapon_injector import inject_weapons
+
 
 class HerculesWeapons:
     GAU_23A_Chain_Gun__30mm_ = {
@@ -677,6 +679,9 @@ class HerculesWeapons:
         "name": "105mm Howitzer",
         "weight": 595.9426,
     }
+
+
+inject_weapons(HerculesWeapons)
 
 
 class Hercules(PlaneType):

--- a/pydcs_extensions/mb339/mb339.py
+++ b/pydcs_extensions/mb339/mb339.py
@@ -4,6 +4,8 @@ from dcs import task
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
+from pydcs_extensions.weapon_injector import inject_weapons
+
 
 class MB_339PAN_Weapons:
     ARF8M3_TP = {"clsid": "{ARF8M3_TP}", "name": "ARF8M3 TP", "weight": None}
@@ -105,6 +107,9 @@ class MB_339PAN_Weapons:
         "name": "Tip Fuel Tank Ellittici 320lt",
         "weight": 314.2,
     }
+
+
+inject_weapons(MB_339PAN_Weapons)
 
 
 class MB_339PAN(PlaneType):

--- a/pydcs_extensions/su57/su57.py
+++ b/pydcs_extensions/su57/su57.py
@@ -4,6 +4,8 @@ from dcs import task
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
+from pydcs_extensions.weapon_injector import inject_weapons
+
 
 class Su57Weapons:
     Kh_59MK2 = {"clsid": "{KH_59MK2}", "name": "Kh-59MK2", "weight": None}
@@ -16,6 +18,9 @@ class Su57Weapons:
         "name": "Su-57 Fuel Tank",
         "weight": 1561.421,
     }
+
+
+inject_weapons(Su57Weapons)
 
 
 class Su_57(PlaneType):

--- a/pydcs_extensions/weapon_injector.py
+++ b/pydcs_extensions/weapon_injector.py
@@ -6,7 +6,7 @@ from dcs.weapons_data import Weapons, weapon_ids
 def inject_weapons(weapon_class: Any) -> None:
     """
     Inject custom weapons from mods into pydcs weapons databases via introspection
-    :param weapon_class: The custom custom weapons class containing dictionaries with weapon info
+    :param weapon_class: The custom weapons class containing dictionaries with weapon info
     :return: None
     """
     for key, value in weapon_class.__dict__.items():

--- a/pydcs_extensions/weapon_injector.py
+++ b/pydcs_extensions/weapon_injector.py
@@ -8,6 +8,5 @@ def inject_weapons(weapon_class: Any) -> None:
         if key.startswith("__"):
             continue
         if isinstance(value, dict) and value.get("clsid"):
-            weapon_data = value
             setattr(Weapons, key, value)
-            weapon_ids[weapon_data["clsid"]] = value
+            weapon_ids[value["clsid"]] = value

--- a/pydcs_extensions/weapon_injector.py
+++ b/pydcs_extensions/weapon_injector.py
@@ -1,0 +1,13 @@
+from typing import List, Any
+
+from dcs.weapons_data import Weapons, weapon_ids
+
+
+def inject_weapons(weapon_class: Any) -> None:
+    for key, value in weapon_class.__dict__.items():
+        if key.startswith("__"):
+            continue
+        if isinstance(value, dict) and value.get("clsid"):
+            weapon_data = value
+            setattr(Weapons, key, value)
+            weapon_ids[weapon_data["clsid"]] = value

--- a/pydcs_extensions/weapon_injector.py
+++ b/pydcs_extensions/weapon_injector.py
@@ -4,6 +4,11 @@ from dcs.weapons_data import Weapons, weapon_ids
 
 
 def inject_weapons(weapon_class: Any) -> None:
+    """
+    Inject custom weapons from mods into pydcs weapons databases via introspection
+    :param weapon_class: The custom custom weapons class containing dictionaries with weapon info
+    :return: None
+    """
     for key, value in weapon_class.__dict__.items():
         if key.startswith("__"):
             continue


### PR DESCRIPTION
Adds a simple injector that iterates over attrs of an input class and injects things that look like custom weapons into pydcs's weapons classes.

Also updated all current mod aircraft configs to perform the injection.