### PR TITLE
introduced recon unit type, adjusted ratios

### DIFF
--- a/game/data/doctrine.py
+++ b/game/data/doctrine.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
+from dcs.task import Reconnaissance
 
 from game.utils import Distance, feet, nautical_miles
 from game.data.groundunitclass import GroundUnitClass
@@ -92,12 +93,13 @@ MODERN_DOCTRINE = Doctrine(
     sweep_distance=nautical_miles(60),
     ground_unit_procurement_ratios=GroundUnitProcurementRatios(
         {
-            GroundUnitClass.Tank: 4,
-            GroundUnitClass.Atgm: 1,
+            GroundUnitClass.Tank: 3,
+            GroundUnitClass.Atgm: 2,
             GroundUnitClass.Apc: 2,
             GroundUnitClass.Ifv: 3,
             GroundUnitClass.Artillery: 1,
             GroundUnitClass.Shorads: 2,
+            GroundUnitClass.Recon: 2,
         }
     ),
 )
@@ -129,12 +131,13 @@ COLDWAR_DOCTRINE = Doctrine(
     sweep_distance=nautical_miles(40),
     ground_unit_procurement_ratios=GroundUnitProcurementRatios(
         {
-            GroundUnitClass.Tank: 4,
-            GroundUnitClass.Atgm: 1,
-            GroundUnitClass.Apc: 2,
-            GroundUnitClass.Ifv: 3,
+            GroundUnitClass.Tank: 3,
+            GroundUnitClass.Atgm: 2,
+            GroundUnitClass.Apc: 3,
+            GroundUnitClass.Ifv: 2,
             GroundUnitClass.Artillery: 1,
             GroundUnitClass.Shorads: 2,
+            GroundUnitClass.Recon: 2,
         }
     ),
 )
@@ -166,12 +169,12 @@ WWII_DOCTRINE = Doctrine(
     sweep_distance=nautical_miles(10),
     ground_unit_procurement_ratios=GroundUnitProcurementRatios(
         {
-            GroundUnitClass.Tank: 4,
-            GroundUnitClass.Atgm: 1,
-            GroundUnitClass.Apc: 2,
-            GroundUnitClass.Ifv: 3,
+            GroundUnitClass.Tank: 3,
+            GroundUnitClass.Atgm: 3,
+            GroundUnitClass.Apc: 3,
             GroundUnitClass.Artillery: 1,
-            GroundUnitClass.Shorads: 2,
+            GroundUnitClass.Shorads: 3,
+            GroundUnitClass.Recon: 2,
         }
     ),
 )

--- a/game/data/doctrine.py
+++ b/game/data/doctrine.py
@@ -137,7 +137,7 @@ COLDWAR_DOCTRINE = Doctrine(
             GroundUnitClass.Ifv: 2,
             GroundUnitClass.Artillery: 1,
             GroundUnitClass.Shorads: 2,
-            GroundUnitClass.Recon: 2,
+            GroundUnitClass.Recon: 1,
         }
     ),
 )
@@ -174,7 +174,7 @@ WWII_DOCTRINE = Doctrine(
             GroundUnitClass.Apc: 3,
             GroundUnitClass.Artillery: 1,
             GroundUnitClass.Shorads: 3,
-            GroundUnitClass.Recon: 2,
+            GroundUnitClass.Recon: 1,
         }
     ),
 )

--- a/game/data/doctrine.py
+++ b/game/data/doctrine.py
@@ -99,7 +99,7 @@ MODERN_DOCTRINE = Doctrine(
             GroundUnitClass.Ifv: 3,
             GroundUnitClass.Artillery: 1,
             GroundUnitClass.Shorads: 2,
-            GroundUnitClass.Recon: 2,
+            GroundUnitClass.Recon: 1,
         }
     ),
 )
@@ -131,7 +131,7 @@ COLDWAR_DOCTRINE = Doctrine(
     sweep_distance=nautical_miles(40),
     ground_unit_procurement_ratios=GroundUnitProcurementRatios(
         {
-            GroundUnitClass.Tank: 3,
+            GroundUnitClass.Tank: 4,
             GroundUnitClass.Atgm: 2,
             GroundUnitClass.Apc: 3,
             GroundUnitClass.Ifv: 2,

--- a/game/data/groundunitclass.py
+++ b/game/data/groundunitclass.py
@@ -30,15 +30,18 @@ class GroundUnitClass(Enum):
             Armor.MBT_Merkava_IV,
             Armor.ZTZ_96B,
             # WW2
-            Armor.MT_Pz_Kpfw_V_Panther_Ausf_G,
+            # Axxis
             Armor.Tk_PzIV_H,
+            Armor.SPG_Sturmpanzer_IV_Brummbar,
+            Armor.MT_Pz_Kpfw_V_Panther_Ausf_G,
             Armor.HT_Pz_Kpfw_VI_Tiger_I,
             Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II,
+            # Allies
             Armor.Tk_M4_Sherman,
             Armor.CT_Centaur_IV,
             Armor.CT_Cromwell_IV,
             Armor.HIT_Churchill_VII,
-            Armor.SPG_Sturmpanzer_IV_Brummbar,
+
             # Mods
             frenchpack.DIM__TOYOTA_BLUE,
             frenchpack.DIM__TOYOTA_GREEN,
@@ -57,11 +60,15 @@ class GroundUnitClass(Enum):
             Armor.ATGM_Stryker,
             Armor.IFV_BMP_2,
             # WW2 (Tank Destroyers)
-            Armor.MT_M4A4_Sherman_Firefly,
+            # Axxis
+            Armor.SPG_StuG_III_Ausf__G,
             Armor.SPG_StuG_IV,
             Armor.SPG_Jagdpanzer_IV,
             Armor.SPG_Jagdpanther_G1,
+            Armor.SPG_Sd_Kfz_184_Elefant,
+            # Allies
             Armor.SPG_M10_GMC,
+            Armor.MT_M4A4_Sherman_Firefly,
             # Mods
             frenchpack.VBAE_CRAB_MMP,
             frenchpack.VAB_MEPHISTO,

--- a/game/data/groundunitclass.py
+++ b/game/data/groundunitclass.py
@@ -41,7 +41,6 @@ class GroundUnitClass(Enum):
             Armor.CT_Centaur_IV,
             Armor.CT_Cromwell_IV,
             Armor.HIT_Churchill_VII,
-
             # Mods
             frenchpack.DIM__TOYOTA_BLUE,
             frenchpack.DIM__TOYOTA_GREEN,

--- a/game/data/groundunitclass.py
+++ b/game/data/groundunitclass.py
@@ -29,27 +29,21 @@ class GroundUnitClass(Enum):
             Armor.MBT_M60A3_Patton,
             Armor.MBT_Merkava_IV,
             Armor.ZTZ_96B,
-            Armor.LT_PT_76,
             # WW2
             Armor.MT_Pz_Kpfw_V_Panther_Ausf_G,
             Armor.Tk_PzIV_H,
             Armor.HT_Pz_Kpfw_VI_Tiger_I,
             Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II,
             Armor.Tk_M4_Sherman,
-            Armor.MT_M4A4_Sherman_Firefly,
-            Armor.SPG_StuG_IV,
             Armor.CT_Centaur_IV,
             Armor.CT_Cromwell_IV,
             Armor.HIT_Churchill_VII,
-            Armor.LT_Mk_VII_Tetrarch,
             Armor.SPG_Sturmpanzer_IV_Brummbar,
             # Mods
             frenchpack.DIM__TOYOTA_BLUE,
             frenchpack.DIM__TOYOTA_GREEN,
             frenchpack.DIM__TOYOTA_DESERT,
             frenchpack.DIM__KAMIKAZE,
-            frenchpack.AMX_10RCR,
-            frenchpack.AMX_10RCR_SEPAR,
             frenchpack.AMX_30B2,
             frenchpack.Leclerc_Serie_XXI,
         ),
@@ -63,7 +57,8 @@ class GroundUnitClass(Enum):
             Armor.ATGM_Stryker,
             Armor.IFV_BMP_2,
             # WW2 (Tank Destroyers)
-            Unarmed.Carrier_M30_Cargo,
+            Armor.MT_M4A4_Sherman_Firefly,
+            Armor.SPG_StuG_IV,
             Armor.SPG_Jagdpanzer_IV,
             Armor.SPG_Jagdpanther_G1,
             Armor.SPG_M10_GMC,
@@ -82,18 +77,11 @@ class GroundUnitClass(Enum):
             Armor.IFV_BMP_1,
             Armor.IFV_Marder,
             Armor.IFV_Warrior,
-            Armor.IFV_LAV_25,
             Armor.SPG_Stryker_MGS,
-            Armor.IFV_Sd_Kfz_234_2_Puma,
             Armor.IFV_M2A2_Bradley,
             Armor.IFV_BMD_1,
             Armor.ZBD_04A,
-            # WW2
-            Armor.IFV_Sd_Kfz_234_2_Puma,
-            Armor.Car_M8_Greyhound_Armored,
-            Armor.Car_Daimler_Armored,
             # Mods
-            frenchpack.ERC_90,
             frenchpack.VBAE_CRAB,
             frenchpack.VAB_T20_13,
         ),
@@ -102,20 +90,14 @@ class GroundUnitClass(Enum):
     Apc = (
         "APC",
         (
-            Armor.Scout_HMMWV,
             Armor.IFV_M1126_Stryker_ICV,
             Armor.APC_M113,
             Armor.APC_BTR_80,
             Armor.IFV_BTR_82A,
             Armor.APC_MTLB,
-            Armor.APC_M2A1_Halftrack,
-            Armor.Scout_Cobra,
-            Armor.APC_Sd_Kfz_251_Halftrack,
             Armor.APC_AAV_7_Amphibious,
             Armor.APC_TPz_Fuchs,
-            Armor.Scout_BRDM_2,
             Armor.APC_BTR_RD,
-            Artillery.Grad_MRL_FDDM__FC,
             # WW2
             Armor.APC_M2A1_Halftrack,
             Armor.APC_Sd_Kfz_251_Halftrack,
@@ -129,6 +111,7 @@ class GroundUnitClass(Enum):
     Artillery = (
         "Artillery",
         (
+            Artillery.Grad_MRL_FDDM__FC,
             Artillery.MLRS_9A52_Smerch_HE_300mm,
             Artillery.SPH_2S1_Gvozdika_122mm,
             Artillery.SPH_2S3_Akatsia_152mm,
@@ -150,6 +133,7 @@ class GroundUnitClass(Enum):
     Logistics = (
         "Logistics",
         (
+            Unarmed.Carrier_M30_Cargo,
             Unarmed.Truck_M818_6x6,
             Unarmed.Truck_KAMAZ_43101,
             Unarmed.Truck_Ural_375,
@@ -168,6 +152,26 @@ class GroundUnitClass(Enum):
             # Mods
             frenchpack.VBL,
             frenchpack.VAB,
+        ),
+    )
+
+    Recon = (
+        "Recon",
+        (
+            Armor.Scout_HMMWV,
+            Armor.Scout_Cobra,
+            Armor.LT_PT_76,
+            Armor.IFV_LAV_25,
+            Armor.Scout_BRDM_2,
+            # WW2
+            Armor.LT_Mk_VII_Tetrarch,
+            Armor.IFV_Sd_Kfz_234_2_Puma,
+            Armor.Car_M8_Greyhound_Armored,
+            Armor.Car_Daimler_Armored,
+            # Mods
+            frenchpack.ERC_90,
+            frenchpack.AMX_10RCR,
+            frenchpack.AMX_10RCR_SEPAR,
         ),
     )
 

--- a/game/data/groundunitclass.py
+++ b/game/data/groundunitclass.py
@@ -30,7 +30,7 @@ class GroundUnitClass(Enum):
             Armor.MBT_Merkava_IV,
             Armor.ZTZ_96B,
             # WW2
-            # Axxis
+            # Axis
             Armor.Tk_PzIV_H,
             Armor.SPG_Sturmpanzer_IV_Brummbar,
             Armor.MT_Pz_Kpfw_V_Panther_Ausf_G,


### PR DESCRIPTION
New vehicle category: scout vehicles. Also Ratio was adjusted, vehicles in wrong categories adjusted, double entries removed.
Changing from money based to unit based will be done in different new branch. Same goes for Scout vehicles as JTAC, since I have currently no idea how to do this and the first fix is really easy.