### PR TITLE
Show total at top for economic intel

### DIFF
--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -26,11 +26,15 @@ class QHorizontalSeparationLine(QFrame):
 
 
 class FinancesLayout(QGridLayout):
-    def __init__(self, game: Game, player: bool) -> None:
+    def __init__(self, game: Game, player: bool, total_at_top: bool = False) -> None:
         super().__init__()
         self.row = itertools.count(0)
 
         income = Income(game, player)
+
+        if total_at_top:
+            self.add_total(game, income, player)
+            self.add_line()
 
         control_points = reversed(
             sorted(income.control_points, key=lambda c: c.income_per_turn)
@@ -44,18 +48,19 @@ class FinancesLayout(QGridLayout):
         for building in buildings:
             self.add_building(building)
 
-        self.add_line()
+        if not total_at_top:
+            self.add_line()
+            self.add_total(game, income, player)
 
+    def add_total(self, game, income, player):
         self.add_row(
             middle=f"Income multiplier: {income.multiplier:.1f}",
             right=f"<b>{income.total}M</b>",
         )
-
         if player:
             budget = game.budget
         else:
             budget = game.enemy_budget
-
         self.add_row(middle="Balance", right=f"<b>{budget}M</b>")
         self.setRowStretch(next(self.row), 1)
 

--- a/qt_ui/windows/intel.py
+++ b/qt_ui/windows/intel.py
@@ -45,7 +45,7 @@ class ScrollingFrame(QFrame):
 class EconomyIntelTab(ScrollingFrame):
     def __init__(self, game: Game, player: bool) -> None:
         super().__init__()
-        self.addLayout(FinancesLayout(game, player=player))
+        self.addLayout(FinancesLayout(game, player=player, total_at_top=True))
 
 
 class IntelTableLayout(QGridLayout):


### PR DESCRIPTION
Change for #1167, only applies when accessing view from intel, not via finances. Defaults to the bottom

(I wasn't sure if you actually wanted this implemented, so here's what it looks like)
![image](https://user-images.githubusercontent.com/22498360/122625381-d0b60f00-d09c-11eb-81ee-6b25f21b81fc.png)
