### PR TITLE
Add EWR objects to predefined waypoints (#1251)

### DIFF
--- a/qt_ui/widgets/combos/QPredefinedWaypointSelectionComboBox.py
+++ b/qt_ui/widgets/combos/QPredefinedWaypointSelectionComboBox.py
@@ -109,9 +109,9 @@ class QPredefinedWaypointSelectionComboBox(QFilteredComboBox):
                     self.include_friendly and cp.captured
                 ):
                     for ground_object in cp.ground_objects:
-                        if (
-                            not ground_object.is_dead
-                            and ground_object.dcs_identifier == "AA"
+                        if not ground_object.is_dead and (
+                            ground_object.dcs_identifier == "AA"
+                            or ground_object.dcs_identifier == "EWR"
                         ):
                             for g in ground_object.groups:
                                 for j, u in enumerate(g.units):


### PR DESCRIPTION
Updated the `QPredefinedWaypointSelectionComboBox.py` so that also ground objects with dcs_identifier == EWR will be added as unit to the predefined waypoint list as described in #1251. 
On current development it looks good.