### PR TITLE
Made separate russia 1975 for hind-f

### DIFF
--- a/resources/factions/russia_1975 (Mi-24P).json
+++ b/resources/factions/russia_1975 (Mi-24P).json
@@ -1,13 +1,14 @@
 {
   "country": "Russia",
-  "name": "Russia 1975",
+  "name": "Russia 1975 (Mi-24P)",
   "authors": "Khopa",
-  "description": "<p>Soviet army in the late 70s, using their prototype Mig-29A.</p>",
+  "description": "<p>Soviet army in the late 70s, using their prototype Mig-29A and Mi-24P.</p>",
   "locales": [
     "ru_RU"
   ],
   "aircrafts": [
     "Mi-24V Hind-E",
+    "Mi-24P Hind-F",
     "Mi-8MTV2 Hip",
     "MiG-21bis Fishbed-N",
     "MiG-23MLD Flogger-K",


### PR DESCRIPTION
Technically not in service in 75, but realised the Mig-29A wouldn't be either, hence "prototype". Might not be worth the faction clutter in this case. 

Did get me thinking that mayeb there should be an option for an airframe to be "player only" in a faction, so that we can fly it, but the AI won't buy/use it themselves?