### PR TITLE
Fix purchase groups

### DIFF
--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -76,7 +76,7 @@ class PurchaseGroup(QGroupBox):
 class QRecruitBehaviour:
     game_model: GameModel
     cp: ControlPoint
-    purchase_groups: dict[UnitType, PurchaseGroup] = {}
+    purchase_groups: dict[UnitType, PurchaseGroup]
     existing_units_labels = None
     maximum_units = -1
     BUDGET_FORMAT = "Available Budget: <b>${:.2f}M</b>"

--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -83,6 +83,7 @@ class QRecruitBehaviour:
 
     def __init__(self) -> None:
         self.existing_units_labels = {}
+        self.purchase_groups = {}
         self.update_available_budget()
 
     @property

--- a/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
@@ -26,7 +26,7 @@ class QAircraftRecruitmentMenu(QFrame, QRecruitBehaviour):
         QFrame.__init__(self)
         self.cp = cp
         self.game_model = game_model
-
+        self.purchase_groups = {}
         self.bought_amount_labels = {}
         self.existing_units_labels = {}
 

--- a/qt_ui/windows/basemenu/ground_forces/QArmorRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/ground_forces/QArmorRecruitmentMenu.py
@@ -18,7 +18,7 @@ class QArmorRecruitmentMenu(QFrame, QRecruitBehaviour):
         QFrame.__init__(self)
         self.cp = cp
         self.game_model = game_model
-
+        self.purchase_groups = {}
         self.bought_amount_labels = {}
         self.existing_units_labels = {}
 


### PR DESCRIPTION
The new class `PurchaseGroup` coming in with commit 9bb986cff9c9865c5687ac4fc170316a8a035a75 was not initiallized correctly.

This causes the bug that the update function is not working when you for example open the AircraftRecruitmentMenu press "+" or "-", close the dialog and then open ArmorRecruitmentMenu. If you then want to buy or sell the update function will raise an error "Internal C++ Object Already Deleted".