### PR TITLE
Appending the file name to the window title

### DIFF
--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -50,7 +50,7 @@ class QLiberationWindow(QMainWindow):
         self.liberation_map = QLiberationMap(self.game_model, self)
 
         self.setGeometry(300, 100, 270, 100)
-        self.updateWindowTitle(None)
+        self.updateWindowTitle()
         self.setWindowIcon(QIcon("./resources/icon.png"))
         self.statusBar().showMessage("Ready")
 

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -50,7 +50,7 @@ class QLiberationWindow(QMainWindow):
         self.liberation_map = QLiberationMap(self.game_model, self)
 
         self.setGeometry(300, 100, 270, 100)
-        self.setWindowTitle(f"DCS Liberation - v{VERSION}")
+        self.updateWindowTitle(None)
         self.setWindowIcon(QIcon("./resources/icon.png"))
         self.statusBar().showMessage("Ready")
 
@@ -244,7 +244,7 @@ class QLiberationWindow(QMainWindow):
             game = persistency.load_game(file[0])
             GameUpdateSignal.get_instance().game_loaded.emit(game)
 
-            self.updateWindowTitle(file)
+            self.updateWindowTitle(file[0])
 
     def saveGame(self):
         logging.info("Saving game")
@@ -269,15 +269,17 @@ class QLiberationWindow(QMainWindow):
             liberation_install.setup_last_save_file(self.game.savepath)
             liberation_install.save_config()
 
-            self.updateWindowTitle(file)
+            self.updateWindowTitle(file[0])
 
-    def updateWindowTitle(self, file):
-        file_name = (
-            file[0].split("/")[-1].split(".liberation")[0]
-        )  # file is a tuple (path, extension)
-        self.setWindowTitle(
-            f"{self.windowTitle()} - {file_name}"
-        )  # append file name to end of existing title
+    def updateWindowTitle(self, save_path: Optional[str] = None) -> None:
+        """
+        to DCS Liberation - vX.X.X - file_name
+        """
+        window_title = f"DCS Liberation - v{VERSION}"
+        if save_path:  # appending the file name to title as it is updated
+            file_name = save_path.split("/")[-1].split(".liberation")[0]
+            window_title = f"{window_title} - {file_name}"
+        self.setWindowTitle(window_title)
 
     def onGameGenerated(self, game: Game):
         logging.info("On Game generated")

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -71,6 +71,7 @@ class QLiberationWindow(QMainWindow):
                     logging.info("Loading last saved game : " + str(last_save_file))
                     game = persistency.load_game(last_save_file)
                     self.onGameGenerated(game)
+                    self.updateWindowTitle(last_save_file)
                 except:
                     logging.info("Error loading latest save game")
             else:
@@ -243,6 +244,8 @@ class QLiberationWindow(QMainWindow):
             game = persistency.load_game(file[0])
             GameUpdateSignal.get_instance().game_loaded.emit(game)
 
+            self.updateWindowTitle(file)
+
     def saveGame(self):
         logging.info("Saving game")
 
@@ -265,6 +268,16 @@ class QLiberationWindow(QMainWindow):
             persistency.save_game(self.game)
             liberation_install.setup_last_save_file(self.game.savepath)
             liberation_install.save_config()
+
+            self.updateWindowTitle(file)
+
+    def updateWindowTitle(self, file):
+        file_name = (
+            file[0].split("/")[-1].split(".liberation")[0]
+        )  # file is a tuple (path, extension)
+        self.setWindowTitle(
+            f"{self.windowTitle()} - {file_name}"
+        )  # append file name to end of existing title
 
     def onGameGenerated(self, game: Game):
         logging.info("On Game generated")


### PR DESCRIPTION
Updating the title to include the current save file name, separated by a '-' so DCS Liberation - v3.0.0 - {file_name}

couldn't decide whether or not to include the full path or just the file name, so it's just the file name atm without the .liberation extension

:eyes: kinda just a trialing the process of implementing a change. really kick-ass application yall got here, and wicked that it's open to the public for changes

This is Mo#9991 on discord