### PR TITLE
fixed AttributeError for AircraftType capability

### DIFF
--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -964,7 +964,10 @@ class Carrier(NavalControlPoint):
         return True
 
     def can_operate(self, aircraft: AircraftType) -> bool:
-        return aircraft.carrier_capable
+        try:
+            return aircraft.carrier_capable
+        except AttributeError:
+            return False
 
     @property
     def total_aircraft_parking(self) -> int:
@@ -998,7 +1001,10 @@ class Lha(NavalControlPoint):
         return True
 
     def can_operate(self, aircraft: AircraftType) -> bool:
-        return aircraft.lha_capable
+        try:
+            return aircraft.lha_capable
+        except AttributeError:
+            return False
 
     @property
     def total_aircraft_parking(self) -> int:


### PR DESCRIPTION
carrier_capable and lha_capable were throwing attribute errors. Maybe the problem sits in the `aircrafttype.py` as normaly it should (if i understand it correctly - sorry not so much time to analyze it into detail) init with False if it does not exists.

@DanAlbert