### PR TITLE
Set default support flight size to one.

### DIFF
--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -95,6 +95,7 @@ class AircraftType(UnitType[FlyingType]):
     carrier_capable: bool
     lha_capable: bool
     always_keeps_gun: bool
+    max_group_size: int
     intra_flight_radio: Optional[Radio]
     channel_allocator: Optional[RadioChannelAllocator]
     channel_namer: Type[ChannelNamer]
@@ -141,6 +142,12 @@ class AircraftType(UnitType[FlyingType]):
 
     def channel_name(self, radio_id: int, channel_id: int) -> str:
         return self.channel_namer.channel_name(radio_id, channel_id)
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Update any existing models with new data on load.
+        updated = AircraftType.named(state["name"])
+        state.update(updated.__dict__)
+        self.__dict__.update(state)
 
     @classmethod
     def register(cls, aircraft_type: AircraftType) -> None:
@@ -206,6 +213,7 @@ class AircraftType(UnitType[FlyingType]):
                 carrier_capable=data.get("carrier_capable", False),
                 lha_capable=data.get("lha_capable", False),
                 always_keeps_gun=data.get("always_keeps_gun", False),
+                max_group_size=data.get("max_group_size", aircraft.group_size_max),
                 intra_flight_radio=radio_config.intra_flight,
                 channel_allocator=radio_config.channel_allocator,
                 channel_namer=radio_config.channel_namer,

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -261,25 +261,9 @@ class QFlightCreator(QDialog):
             )
 
     def update_max_size(self, available: int) -> None:
-        self.flight_size_spinner.setMaximum(min(available, 4))
-
-        chosen_aircraft = self.departure.aircraft.dcs_unit_type
-
-        # Default flight size.
-        flight_size = 2
-
-        if (
-            chosen_aircraft == KC130
-            or chosen_aircraft == KC135MPRS
-            or chosen_aircraft == KC_135
-            or chosen_aircraft == KC130
-            or chosen_aircraft == S_3B_Tanker
-            or chosen_aircraft == IL_78M
-            or chosen_aircraft == E_2C
-            or chosen_aircraft == E_3A
-            or chosen_aircraft == A_50
-        ):
-            flight_size = 1
+        self.flight_size_spinner.setMaximum(
+            min(available, self.departure.aircraft.dcs_unit_type.group_size_max)
+        )
 
         if self.flight_size_spinner.maximum() >= 2:
-            self.flight_size_spinner.setValue(flight_size)
+            self.flight_size_spinner.setValue(2)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional, Type
 
 from PySide2.QtCore import Qt, Signal
@@ -12,7 +11,6 @@ from PySide2.QtWidgets import (
     QLineEdit,
     QHBoxLayout,
 )
-from dcs.planes import A_50, E_2C, E_3A, IL_78M, KC130, KC135MPRS, KC_135, S_3B_Tanker
 from dcs.unittype import FlyingType
 
 from game import Game
@@ -261,9 +259,12 @@ class QFlightCreator(QDialog):
             )
 
     def update_max_size(self, available: int) -> None:
-        self.flight_size_spinner.setMaximum(
-            min(available, self.departure.aircraft.dcs_unit_type.group_size_max)
-        )
+        aircraft = self.aircraft_selector.currentData()
+        if aircraft is None:
+            self.flight_size_spinner.setMaximum(0)
+            return
+
+        self.flight_size_spinner.setMaximum(min(available, aircraft.max_group_size))
 
         if self.flight_size_spinner.maximum() >= 2:
             self.flight_size_spinner.setValue(2)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -12,6 +12,7 @@ from PySide2.QtWidgets import (
     QLineEdit,
     QHBoxLayout,
 )
+from dcs.planes import A_50, E_2C, E_3A, IL_78M, KC130, KC135MPRS, KC_135, S_3B_Tanker
 from dcs.unittype import FlyingType
 
 from game import Game
@@ -261,6 +262,23 @@ class QFlightCreator(QDialog):
 
     def update_max_size(self, available: int) -> None:
         self.flight_size_spinner.setMaximum(min(available, 4))
+
+        current_aircraft = self.departure.aircraft
+        default_size = 2
+
+        if (
+            current_aircraft == KC130
+            or current_aircraft == KC135MPRS
+            or current_aircraft == KC_135
+            or current_aircraft == KC130
+            or current_aircraft == S_3B_Tanker
+            or current_aircraft == IL_78M
+            or current_aircraft == E_2C
+            or current_aircraft == E_3A
+            or current_aircraft == A_50
+        ):
+            default_size = 1
+
         if self.flight_size_spinner.maximum() >= 2:
             if self.flight_size_spinner.value() < 2:
-                self.flight_size_spinner.setValue(2)
+                self.flight_size_spinner.setValue(default_size)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -263,22 +263,23 @@ class QFlightCreator(QDialog):
     def update_max_size(self, available: int) -> None:
         self.flight_size_spinner.setMaximum(min(available, 4))
 
-        current_aircraft = self.departure.aircraft
-        default_size = 2
+        chosen_aircraft = self.departure.aircraft.dcs_unit_type
+
+        # Default flight size.
+        flight_size = 2
 
         if (
-            current_aircraft == KC130
-            or current_aircraft == KC135MPRS
-            or current_aircraft == KC_135
-            or current_aircraft == KC130
-            or current_aircraft == S_3B_Tanker
-            or current_aircraft == IL_78M
-            or current_aircraft == E_2C
-            or current_aircraft == E_3A
-            or current_aircraft == A_50
+            chosen_aircraft == KC130
+            or chosen_aircraft == KC135MPRS
+            or chosen_aircraft == KC_135
+            or chosen_aircraft == KC130
+            or chosen_aircraft == S_3B_Tanker
+            or chosen_aircraft == IL_78M
+            or chosen_aircraft == E_2C
+            or chosen_aircraft == E_3A
+            or chosen_aircraft == A_50
         ):
-            default_size = 1
+            flight_size = 1
 
         if self.flight_size_spinner.maximum() >= 2:
-            if self.flight_size_spinner.value() < 2:
-                self.flight_size_spinner.setValue(default_size)
+            self.flight_size_spinner.setValue(flight_size)

--- a/resources/units/aircraft/A-50.yaml
+++ b/resources/units/aircraft/A-50.yaml
@@ -1,4 +1,5 @@
 description: The A-50 is an AWACS plane.
+max_group_size: 1
 price: 50
 variants:
   A-50: null

--- a/resources/units/aircraft/E-2C.yaml
+++ b/resources/units/aircraft/E-2C.yaml
@@ -1,5 +1,7 @@
 carrier_capable: true
-description: The Northrop Grumman E-2 Hawkeye is an American all-weather, carrier-capable
+max_group_size: 1
+description:
+  The Northrop Grumman E-2 Hawkeye is an American all-weather, carrier-capable
   tactical airborne early warning (AEW) aircraft.
 introduced: 1973
 manufacturer: Northrop Grumman

--- a/resources/units/aircraft/E-3A.yaml
+++ b/resources/units/aircraft/E-3A.yaml
@@ -1,4 +1,5 @@
 description: The E-3A is a AWACS aicraft.
 price: 50
+max_group_size: 1
 variants:
   E-3A: null

--- a/resources/units/aircraft/IL-78M.yaml
+++ b/resources/units/aircraft/IL-78M.yaml
@@ -1,3 +1,4 @@
 price: 20
+max_group_size: 1
 variants:
   IL-78M: null

--- a/resources/units/aircraft/KC-135.yaml
+++ b/resources/units/aircraft/KC-135.yaml
@@ -1,6 +1,9 @@
-description: The Boeing KC-135 Stratotanker is a military aerial refueling aircraft
-  that was developed from the Boeing 367-80 prototype, alongside the Boeing 707 airliner.
+description:
+  The Boeing KC-135 Stratotanker is a military aerial refueling aircraft that
+  was developed from the Boeing 367-80 prototype, alongside the Boeing 707
+  airliner.
 introduced: 1957
+max_group_size: 1
 manufacturer: Beoing
 origin: USA
 price: 25

--- a/resources/units/aircraft/S-3B.yaml
+++ b/resources/units/aircraft/S-3B.yaml
@@ -1,5 +1,6 @@
 carrier_capable: true
-description: The Lockheed S-3 Viking is a 4-crew, twin-engine turbofan-powered jet
+description:
+  The Lockheed S-3 Viking is a 4-crew, twin-engine turbofan-powered jet
   aircraft that was used by the U.S. Navy (USN) primarily for anti-submarine warfare.
   In the late 1990s, the S-3B's mission focus shifted to surface warfare and aerial
   refueling. The Viking also provided electronic warfare and surface surveillance
@@ -14,6 +15,7 @@ introduced: 1984
 manufacturer: Lockheed
 origin: USA
 price: 10
+max_group_size: 1
 role: Carrier-based Attack
 variants:
   S-3B Viking: {}


### PR DESCRIPTION
Default flight size should now be one.

Was unsure whether to restrict support flight sizes to a maximum of one or not.  I left the `setMaximum(...)` as it's current behavior.