### PR TITLE
Air/Ground Intel Prettification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ resources/tools/a.miz
 # User-specific stuff
 .idea/
 .env
+env/
 
 /kneeboards
 /liberation_preferences.json

--- a/qt_ui/windows/intel.py
+++ b/qt_ui/windows/intel.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import Optional
 
 from PySide2.QtWidgets import (
     QCheckBox,
@@ -63,10 +64,11 @@ class IntelTableLayout(QGridLayout):
             0,
         )
 
-    def add_row(self, text: str, count: int) -> None:
+    def add_row(self, text: str, count: Optional[int] = None) -> None:
         row = next(self.row)
         self.addWidget(QLabel(text), row, 0)
-        self.addWidget(QLabel(str(count)), row, 1)
+        if count is not None:  # optional count for blank rows
+            self.addWidget(QLabel(str(count)), row, 1)
 
 
 class AircraftIntelLayout(IntelTableLayout):
@@ -80,14 +82,16 @@ class AircraftIntelLayout(IntelTableLayout):
             if not base.total_aircraft:
                 continue
 
-            self.add_header(control_point.name)
-            for airframe, count in base.aircraft.items():
+            self.add_header(f"{control_point.name} ({base.total_aircraft})")
+            for airframe in sorted(base.aircraft, key=lambda k: k.name):
+                count = base.aircraft[airframe]
                 if not count:
                     continue
-                self.add_row(airframe.name, count)
+                self.add_row(f"    {airframe.name}", count)
+            self.add_row("")
 
-        self.add_spacer()
         self.add_row("<b>Total</b>", total)
+        self.add_spacer()
 
 
 class AircraftIntelTab(ScrollingFrame):
@@ -107,14 +111,16 @@ class ArmyIntelLayout(IntelTableLayout):
             if not base.total_armor:
                 continue
 
-            self.add_header(control_point.name)
-            for vehicle, count in base.armor.items():
+            self.add_header(f"{control_point.name} ({base.total_armor})")
+            for vehicle in sorted(base.armor, key=lambda k: k.name):
+                count = base.armor[vehicle]
                 if not count:
                     continue
-                self.add_row(vehicle.name, count)
+                self.add_row(f"    {vehicle.name}", count)
+            self.add_row("")
 
-        self.add_spacer()
         self.add_row("<b>Total</b>", total)
+        self.add_spacer()
 
 
 class ArmyIntelTab(ScrollingFrame):


### PR DESCRIPTION
This...
![image](https://user-images.githubusercontent.com/47610393/122666219-b26e1300-d171-11eb-9b94-266df85652ae.png)

to this...
![image](https://user-images.githubusercontent.com/47610393/122666234-c3b71f80-d171-11eb-85d9-a45ecf96e09f.png)

![image](https://user-images.githubusercontent.com/47610393/122666299-0c6ed880-d172-11eb-8e4d-3ec660674309.png)


aircraft/vehicles are sorted alphabetically (looks like the bases are sorted left to right by default? so left em 'unsorted'), also spaced to the right by 4 spaces (needed another way to separate it from the base header besides font style), and included totals for each base in the base header, considered puttin em under the listed aircraft but i think this looks cleaner, also switched the .add_spacer to be after the Total line, space above the Total line looked whacker than having space under it


*gaining confidence* 👀 maybe i'll actually do something to affect the gameplay one day :D