### PR TITLE
fix AI always buying more transport aircraft on every turn

### DIFF
--- a/game/squadrons.py
+++ b/game/squadrons.py
@@ -368,9 +368,9 @@ class AirWing:
     def squadrons_for(self, aircraft: AircraftType) -> Sequence[Squadron]:
         return self.squadrons[aircraft]
 
-    def squadrons_for_task(self, task: FlightType) -> Iterator[Squadron]:
+    def auto_assignable_for_task(self, task: FlightType) -> Iterator[Squadron]:
         for squadron in self.iter_squadrons():
-            if task in squadron.mission_types:
+            if squadron.can_auto_assign(task):
                 yield squadron
 
     def auto_assignable_for_task_with_type(

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -600,16 +600,14 @@ class PendingTransfers:
 
     def current_airlift_capacity(self, control_point: ControlPoint) -> int:
         inventory = self.game.aircraft_inventory.for_control_point(control_point)
-        squadrons = self.game.air_wing_for(control_point.captured).squadrons_for_task(
-            FlightType.TRANSPORT
-        )
-        unit_types = {s.aircraft.dcs_unit_type for s in squadrons}.intersection(
-            TRANSPORT_CAPABLE
-        )
+        squadrons = self.game.air_wing_for(
+            control_point.captured
+        ).auto_assignable_for_task(FlightType.TRANSPORT)
+        unit_types = {s.aircraft for s in squadrons}
         return sum(
             count
             for unit_type, count in inventory.all_aircraft
-            if unit_type.dcs_unit_type in unit_types
+            if unit_type in unit_types
         )
 
     def order_airlift_assets_at(self, control_point: ControlPoint) -> None:

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -603,11 +603,13 @@ class PendingTransfers:
         squadrons = self.game.air_wing_for(control_point.captured).squadrons_for_task(
             FlightType.TRANSPORT
         )
-        unit_types = {s.aircraft for s in squadrons}.intersection(TRANSPORT_CAPABLE)
+        unit_types = {s.aircraft.dcs_unit_type for s in squadrons}.intersection(
+            TRANSPORT_CAPABLE
+        )
         return sum(
             count
             for unit_type, count in inventory.all_aircraft
-            if unit_type in unit_types
+            if unit_type.dcs_unit_type in unit_types
         )
 
     def order_airlift_assets_at(self, control_point: ControlPoint) -> None:


### PR DESCRIPTION
I noticed that the AI is continuously buying new transport aircraft each turn. This is because `game.PendingTransfers.current_airlift_capacity` is comparing `Squadron.aircraft` against the contents of `TRANSPORT_CAPABLE`, which are not matching classes: `Squadron.aircraft` is of type `AircraftType`, while `TRANSPORT_CAPABLE` is a list of `DcsUnitTypes`. This means the intersection is always empty, so the function always returns 0.

This is fixed by using the `dcs_unit_type` attribute of `Squadron.aircraft`.