### PR TITLE
Update pydcs to use latest export.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pathspec==0.8.1
 pefile==2019.4.18
 Pillow==8.2.0
 pre-commit==2.10.1
--e git://github.com/pydcs/dcs@a459d8e1b0bd59bbd7f35390d7ad1bedc0caf76b#egg=pydcs
+-e git://github.com/pydcs/dcs@7dea4f516d943c1f48454a46043b5f38d42a35f0#egg=pydcs
 pyinstaller==4.3
 pyinstaller-hooks-contrib==2021.1
 pyparsing==2.4.7


### PR DESCRIPTION
Fixes https://github.com/dcs-liberation/dcs_liberation/issues/993