### PR TITLE
Rework the AirDefense TGO

### DIFF
--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -40,7 +40,7 @@ from gen.fleet.ship_group_generator import (
 from gen.missiles.missiles_group_generator import generate_missile_group
 from gen.sam.airdefensegroupgenerator import AirDefenseRange
 from gen.sam.ewr_group_generator import generate_ewr_group
-from gen.sam.sam_group_generator import generate_anti_air_group
+from gen.sam.sam_group_generator import generate_anti_air_ground_object
 from . import (
     ConflictTheater,
     ControlPoint,
@@ -423,22 +423,23 @@ class AirbaseGroundObjectGenerator(ControlPointGroundObjectGenerator):
     ) -> None:
         group_id = self.game.next_group_id()
 
-        g = SamGroundObject(
+        ground_object = generate_anti_air_ground_object(
+            self.game,
             namegen.random_objective_name(),
             group_id,
             position,
             self.control_point,
+            self.faction,
+            ranges,
         )
-        groups = generate_anti_air_group(self.game, g, self.faction, ranges)
-        if not groups:
+        if not ground_object:
             logging.error(
                 "Could not generate air defense group for %s at %s",
-                g.name,
+                group_id,
                 self.control_point,
             )
             return
-        g.groups = groups
-        self.control_point.connected_objectives.append(g)
+        self.control_point.connected_objectives.append(ground_object)
 
     def generate_ewr_at(self, position: PointWithHeading) -> None:
         group_id = self.game.next_group_id()

--- a/gen/groundobjectsgen.py
+++ b/gen/groundobjectsgen.py
@@ -85,7 +85,7 @@ class GenericGroundObjectGenerator:
         if self.culled:
             return
 
-        for group in self.ground_object.groups:
+        for group_index, group in enumerate(self.ground_object.groups):
             if not group.units:
                 logging.warning(f"Found empty group in {self.ground_object}")
                 continue
@@ -94,14 +94,9 @@ class GenericGroundObjectGenerator:
             if unit_type is None:
                 raise RuntimeError(f"Unrecognized unit type: {group.units[0].type}")
 
-            if isinstance(self.ground_object, SamGroundObject):
-                group_name = self.ground_object.groups_name(group)
-            else:
-                group_name = group.name
-
             vg = self.m.vehicle_group(
                 self.country,
-                group_name,
+                self.ground_object.single_group_name(group_index),
                 unit_type,
                 position=group.position,
                 heading=group.units[0].heading,

--- a/gen/groundobjectsgen.py
+++ b/gen/groundobjectsgen.py
@@ -42,6 +42,7 @@ from game.theater.theatergroundobject import (
     ShipGroundObject,
     MissileSiteGroundObject,
     SceneryGroundObject,
+    SamGroundObject,
 )
 from game.unitmap import UnitMap
 from game.utils import feet, knots, mps
@@ -93,9 +94,14 @@ class GenericGroundObjectGenerator:
             if unit_type is None:
                 raise RuntimeError(f"Unrecognized unit type: {group.units[0].type}")
 
+            if isinstance(self.ground_object, SamGroundObject):
+                group_name = self.ground_object.groups_name(group)
+            else:
+                group_name = group.name
+
             vg = self.m.vehicle_group(
                 self.country,
-                group.name,
+                group_name,
                 unit_type,
                 position=group.position,
                 heading=group.units[0].heading,

--- a/gen/sam/airdefensegroupgenerator.py
+++ b/gen/sam/airdefensegroupgenerator.py
@@ -5,15 +5,8 @@ from typing import Iterator, List
 from dcs.unitgroup import VehicleGroup
 
 from game import Game
-from game.theater.theatergroundobject import SamGroundObject
+from game.theater.theatergroundobject import SamGroundObject, AirDefenseRange
 from gen.sam.group_generator import GroupGenerator
-
-
-class AirDefenseRange(Enum):
-    AAA = "AAA"
-    Short = "short"
-    Medium = "medium"
-    Long = "long"
 
 
 class AirDefenseGroupGenerator(GroupGenerator, ABC):
@@ -24,16 +17,17 @@ class AirDefenseGroupGenerator(GroupGenerator, ABC):
     price: int
 
     def __init__(self, game: Game, ground_object: SamGroundObject) -> None:
-        ground_object.skynet_capable = True
         super().__init__(game, ground_object)
 
         self.auxiliary_groups: List[VehicleGroup] = []
+        self.auxiliary_ranges: List[AirDefenseRange] = []
 
-    def add_auxiliary_group(self, name_suffix: str) -> VehicleGroup:
+    def add_auxiliary_group(self, aa_range: AirDefenseRange) -> VehicleGroup:
         group = VehicleGroup(
-            self.game.next_group_id(), "|".join([self.go.group_name, name_suffix])
+            self.game.next_group_id(), "|".join([self.go.group_name, aa_range.value])
         )
         self.auxiliary_groups.append(group)
+        self.auxiliary_ranges.append(aa_range)
         return group
 
     def get_generated_group(self) -> VehicleGroup:
@@ -47,6 +41,11 @@ class AirDefenseGroupGenerator(GroupGenerator, ABC):
     def groups(self) -> Iterator[VehicleGroup]:
         yield self.vg
         yield from self.auxiliary_groups
+
+    @property
+    def ranges(self) -> Iterator[AirDefenseRange]:
+        yield self.range()
+        yield from self.auxiliary_ranges
 
     @classmethod
     @abstractmethod

--- a/gen/sam/sam_hawk.py
+++ b/gen/sam/sam_hawk.py
@@ -41,7 +41,7 @@ class HawkGenerator(AirDefenseGroupGenerator):
         )
 
         # Triple A for close range defense
-        aa_group = self.add_auxiliary_group("AA")
+        aa_group = self.add_auxiliary_group(AirDefenseRange.AAA)
         self.add_unit_to_group(
             aa_group,
             AirDefence.Vulcan,

--- a/gen/sam/sam_hq7.py
+++ b/gen/sam/sam_hq7.py
@@ -34,7 +34,7 @@ class HQ7Generator(AirDefenseGroupGenerator):
         )
 
         # Triple A for close range defense
-        aa_group = self.add_auxiliary_group("AA")
+        aa_group = self.add_auxiliary_group(AirDefenseRange.AAA)
         self.add_unit_to_group(
             aa_group,
             AirDefence.Ural_375_ZU_23,

--- a/gen/sam/sam_patriot.py
+++ b/gen/sam/sam_patriot.py
@@ -69,7 +69,7 @@ class PatriotGenerator(AirDefenseGroupGenerator):
             )
 
         # Short range protection for high value site
-        aa_group = self.add_auxiliary_group("AA")
+        aa_group = self.add_auxiliary_group(AirDefenseRange.AAA)
         num_launchers = random.randint(3, 4)
         positions = self.get_circular_position(
             num_launchers, launcher_distance=200, coverage=360

--- a/gen/sam/sam_sa10.py
+++ b/gen/sam/sam_sa10.py
@@ -76,7 +76,7 @@ class SA10Generator(AirDefenseGroupGenerator):
 
     def generate_defensive_groups(self) -> None:
         # AAA for defending against close targets.
-        aa_group = self.add_auxiliary_group("AA")
+        aa_group = self.add_auxiliary_group(AirDefenseRange.AAA)
         num_launchers = random.randint(6, 8)
         positions = self.get_circular_position(
             num_launchers, launcher_distance=210, coverage=360
@@ -101,7 +101,7 @@ class Tier2SA10Generator(SA10Generator):
         super().generate_defensive_groups()
 
         # SA-15 for both shorter range targets and point defense.
-        pd_group = self.add_auxiliary_group("PD")
+        pd_group = self.add_auxiliary_group(AirDefenseRange.Short)
         num_launchers = random.randint(2, 4)
         positions = self.get_circular_position(
             num_launchers, launcher_distance=140, coverage=360
@@ -123,7 +123,7 @@ class Tier3SA10Generator(SA10Generator):
 
     def generate_defensive_groups(self) -> None:
         # AAA for defending against close targets.
-        aa_group = self.add_auxiliary_group("AA")
+        aa_group = self.add_auxiliary_group(AirDefenseRange.AAA)
         num_launchers = random.randint(6, 8)
         positions = self.get_circular_position(
             num_launchers, launcher_distance=210, coverage=360
@@ -138,7 +138,7 @@ class Tier3SA10Generator(SA10Generator):
             )
 
         # SA-15 for both shorter range targets and point defense.
-        pd_group = self.add_auxiliary_group("PD")
+        pd_group = self.add_auxiliary_group(AirDefenseRange.Short)
         num_launchers = random.randint(2, 4)
         positions = self.get_circular_position(
             num_launchers, launcher_distance=140, coverage=360

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -446,7 +446,7 @@ class QBuyGroupForGroundObjectDialog(QDialog):
         # Generate SAM
         generator = sam_generator(self.game, self.ground_object)
         generator.generate()
-        self.ground_object.groups = list(generator.groups)
+        self.ground_object.set_groups(list(generator.groups), list(generator.ranges))
 
         GameUpdateSignal.get_instance().updateGame(self.game)
 


### PR DESCRIPTION
This is a preparation task for the planned changes to optimize the Skynet behaviour and to improve the SAM generation. These changes modify the SamGroundObject class (i would recommend to rename this one to AirDefenseGroundObject - but this breaks the save game compatibility so i reverted the change).

- refactored SamGroundObject to now have an attribute which gives information about the AirDefenseRange of each unit_group which is part of the TGO. This allows for individual handling (e.g. make Skynet feature complete #324)
- Improved GroupName handling for AA Ground Objects to support future skynet improvements like point defence and long range radar
- Improved handling and group naming of auxiliary_groups from large SAM systems like the SA-10

As V4 already hit the preview i added some try/excepts to make this change save game compatible between different saves which do not have the new attributes in the savegame file.