### PR TITLE
past debriefings made available in game.debriefings

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -141,6 +141,8 @@ class Game:
 
         self.transfers = PendingTransfers(self)
 
+        self.debriefings: Debriefing = []  # where index is turn number
+
         self.sanitize_sides()
 
         self.blue_faker = Faker(self.player_faction.locales)
@@ -167,6 +169,9 @@ class Game:
         self.__dict__.update(state)
         # Regenerate any state that was not persisted.
         self.on_load()
+
+    def newAttr(self, debriefings: List[Debriefing]) -> None:
+        setattr(self, debriefings, debriefings)
 
     def ato_for(self, player: bool) -> AirTaskingOrder:
         if player:

--- a/game/game.py
+++ b/game/game.py
@@ -141,7 +141,8 @@ class Game:
 
         self.transfers = PendingTransfers(self)
 
-        self.debriefings: Optional[Debriefing] = []  # where index is turn number
+        self.debriefings: Optional[Debriefing]
+        self.debriefings = []  # where index is turn number
 
         self.sanitize_sides()
 

--- a/game/game.py
+++ b/game/game.py
@@ -141,8 +141,7 @@ class Game:
 
         self.transfers = PendingTransfers(self)
 
-        self.debriefings: Optional[Debriefing]
-        self.debriefings = []  # where index is turn number
+        self.debriefings: List[Debriefing] = []  # where index is turn number
 
         self.sanitize_sides()
 

--- a/game/game.py
+++ b/game/game.py
@@ -5,7 +5,7 @@ import random
 import sys
 from datetime import date, datetime, timedelta
 from enum import Enum
-from typing import Any, List
+from typing import Any, List, Optional
 
 from dcs.action import Coalition
 from dcs.mapping import Point
@@ -141,7 +141,7 @@ class Game:
 
         self.transfers = PendingTransfers(self)
 
-        self.debriefings: Debriefing = []  # where index is turn number
+        self.debriefings: Optional[Debriefing] = []  # where index is turn number
 
         self.sanitize_sides()
 

--- a/game/game.py
+++ b/game/game.py
@@ -170,9 +170,6 @@ class Game:
         # Regenerate any state that was not persisted.
         self.on_load()
 
-    def newAttr(self, debriefings: List[Debriefing]) -> None:
-        setattr(self, debriefings, debriefings)
-
     def ato_for(self, player: bool) -> AirTaskingOrder:
         if player:
             return self.blue_ato

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -296,10 +296,10 @@ class QLiberationWindow(QMainWindow):
             self.liberation_map.set_game(game)
 
             if "debriefings" not in vars(game):
+                logging.debug("Adding debriefings attribute to old save game")
                 setattr(
                     game, "debriefings", [None for i in range(self.game.turn)]
                 )  # adding a debriefing attr to old games
-                print("attr added")
         except AttributeError:
             logging.exception("Incompatible save game")
             QMessageBox.critical(

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -349,9 +349,9 @@ class QLiberationWindow(QMainWindow):
         self.dialog = QStatsWindow(self.game)
         self.dialog.show()
 
-    def onDebriefing(self):
+    def onDebriefing(self, debrief: Debriefing):
         logging.info("On Debriefing")
-        self.debriefing = QDebriefingWindow(self.game.debriefings[-1])
+        self.debriefing = QDebriefingWindow(debrief)
         self.debriefing.show()
 
     def closeEvent(self, event: QCloseEvent) -> None:

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -294,6 +294,12 @@ class QLiberationWindow(QMainWindow):
                 self.info_panel.setGame(game)
             self.game_model.set(self.game)
             self.liberation_map.set_game(game)
+
+            if "debriefings" not in vars(game):
+                setattr(
+                    game, "debriefings", [None for i in range(self.game.turn)]
+                )  # adding a debriefing attr to old games
+                print("attr added")
         except AttributeError:
             logging.exception("Incompatible save game")
             QMessageBox.critical(
@@ -343,9 +349,9 @@ class QLiberationWindow(QMainWindow):
         self.dialog = QStatsWindow(self.game)
         self.dialog.show()
 
-    def onDebriefing(self, debrief: Debriefing):
+    def onDebriefing(self):
         logging.info("On Debriefing")
-        self.debriefing = QDebriefingWindow(debrief)
+        self.debriefing = QDebriefingWindow(self.game.debriefings[-1])
         self.debriefing.show()
 
     def closeEvent(self, event: QCloseEvent) -> None:

--- a/qt_ui/windows/QWaitingForMissionResultWindow.py
+++ b/qt_ui/windows/QWaitingForMissionResultWindow.py
@@ -213,9 +213,9 @@ class QWaitingForMissionResultWindow(QDialog):
             while (
                 len(self.game.debriefings) < self.game.turn - 1
             ):  # catching debriefings up if there were passed turns
-                self.game.append_debriefing(None)
+                self.game.debriefings.append(None)
 
-            self.game.append_debriefing(self.debriefing)
+            self.game.debriefings.append(self.debriefing)
 
             GameUpdateSignal.get_instance().sendDebriefing(self.debriefing)
             GameUpdateSignal.get_instance().updateGame(self.game)

--- a/qt_ui/windows/QWaitingForMissionResultWindow.py
+++ b/qt_ui/windows/QWaitingForMissionResultWindow.py
@@ -210,6 +210,13 @@ class QWaitingForMissionResultWindow(QDialog):
             self.game.finish_event(event=self.gameEvent, debriefing=self.debriefing)
             self.game.pass_turn()
 
+            while (
+                len(self.game.debriefings) < self.game.turn - 1
+            ):  # catching debriefings up if there were passed turns
+                self.game.append_debriefing(None)
+
+            self.game.append_debriefing(self.debriefing)
+
             GameUpdateSignal.get_instance().sendDebriefing(self.debriefing)
             GameUpdateSignal.get_instance().updateGame(self.game)
         self.close()


### PR DESCRIPTION
https://github.com/dcs-liberation/dcs_liberation/issues/659

debriefings are stored in a list with passed turns stored as None, so turn 0 to 1, debriefings[0] will be None, after turn 1 mission, debriefings[1] will be that Debrief, as far as I can tell the turn logic has not been broken by messing with the debriefing objects

as for compatibility with old saves, upon setGame, it's checking if debriefings is an attribute in the Game, if not, adding it, and setting None for the past turns, so a current Save on turn 4, would end up with 4 Nones [0-1, 1-2, 2-3, 3-4] (x-y; turn x to y) in the list ready for turn 4 for the 5th element/index 4

still to come is implementing this into the UI, first idea was gonna put a button up in the misc box?
![image](https://user-images.githubusercontent.com/47610393/123343413-53b0ec80-d517-11eb-8bc3-89717ed156eb.png)
but probably best we tackle the 'enhanced debriefing' with this also, so a bit of a redesign may be in order with the debriefing window

tbh not sure if this warranted a PR or not, but I suppose given it's new data available, it does warrant one?