### PR TITLE
Open and SaveAs use current Game's save path directory as first choice for dialog

### DIFF
--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -237,7 +237,7 @@ class QLiberationWindow(QMainWindow):
         file = QFileDialog.getOpenFileName(
             self,
             "Select game file to open",
-            dir=persistency._dcs_saved_game_folder,
+            dir=self.game.savepath if self.game else persistency._dcs_saved_game_folder,
             filter="*.liberation",
         )
         if file is not None and file[0] != "":
@@ -260,7 +260,7 @@ class QLiberationWindow(QMainWindow):
         file = QFileDialog.getSaveFileName(
             self,
             "Save As",
-            dir=persistency._dcs_saved_game_folder,
+            dir=self.game.savepath if self.game else persistency._dcs_saved_game_folder,
             filter="*.liberation",
         )
         if file is not None:


### PR DESCRIPTION
Tired of having to go to the spot where I save my campaigns every time... :D

as title suggests... Save As and Open should now go to the current game's save path, otherwise opens the _dcs_saved_game_folder_

looks like if you delete the directory the save game is in, it just goes to the closest parent, so 'redundant'?

Spur of the moment - feels good tho.