### PR TITLE
Removing Unused Help buttons

### DIFF
--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from PySide2 import QtWidgets
+from PySide2.QtCore import Qt
 from PySide2.QtGui import QPixmap
 from PySide2.QtWidgets import QApplication, QSplashScreen
 from dcs.payloads import PayloadDirectories
@@ -61,6 +62,8 @@ def inject_custom_payloads(user_path: Path) -> None:
 def run_ui(game: Optional[Game]) -> None:
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"  # Potential fix for 4K screens
     app = QApplication(sys.argv)
+
+    app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
 
     # init the theme and load the stylesheet based on the theme index
     liberation_theme.init()


### PR DESCRIPTION
avoiding confusion for fellers that try and get help but no help is given, you'd click it and it'd make ur mouse a 'no entry icon', was very odd, maybe could add em back if help things were added, like click it in the ground forces tab and you can see the descriptions for front line stances, or in general, it just sends ya to the wiki? idk

![image](https://user-images.githubusercontent.com/47610393/123674779-9e788000-d807-11eb-857e-2b57443f866c.png)

poof

![image](https://user-images.githubusercontent.com/47610393/123674906-c36cf300-d807-11eb-9293-68038fb7453f.png)
