### PR TITLE
replan opfor mission on sell or buy of tgos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[Mission Generation]** The legacy always-available tanker option no longer prevents mission creation.
 * **[Mission Generation]** Fix occasional KeyError preventing mission generation when all units of the same type in a convoy were killed.
 * **[UI]** Statistics window tick marks are now always integers.
+* **[UI]** Statistics window now shows the correct info for the turn
 * **[UI]** Toggling custom loadout for an aircraft with no preset loadouts no longer breaks the flight.
 
 # 4.0.0

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[Economy]** EWRs can now be bought and sold for the correct price and can no longer be used to generate money
 * **[Flight Planning]** Fixed potential issue with angles > 360° or < 0° being generated when summing two angles.
 * **[Mission Generation]** The lua data for other plugins is now generated correctly
+* **[Mission Generation]** Fixed problem with opfor planning missions against sold ground objects like SAMs
 * **[Mission Generation]** The legacy always-available tanker option no longer prevents mission creation.
 * **[Mission Generation]** Fix occasional KeyError preventing mission generation when all units of the same type in a convoy were killed.
 * **[UI]** Statistics window tick marks are now always integers.

--- a/game/game.py
+++ b/game/game.py
@@ -109,7 +109,6 @@ class Game:
         # NB: This is the *start* date. It is never updated.
         self.date = date(start_date.year, start_date.month, start_date.day)
         self.game_stats = GameStats()
-        self.game_stats.update(self)
         self.notes = ""
         self.ground_planners: dict[int, GroundPlanner] = {}
         self.informations = []

--- a/game/models/game_stats.py
+++ b/game/models/game_stats.py
@@ -43,6 +43,10 @@ class GameStats:
         :param game: Game we want to save the data about
         """
 
+        # Remove the current turn if its just an update for this turn
+        if 0 < game.turn < len(self.data_per_turn):
+            del self.data_per_turn[-1]
+
         turn_data = GameTurnMetadata()
 
         for cp in game.theater.controlpoints:

--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -124,7 +124,6 @@ class QBaseMenu2(QDialog):
         self.cp.capture(self.game_model.game, for_player=not self.cp.captured)
         # Reinitialized ground planners and the like. The ATO needs to be reset because
         # missions planned against the flipped base are no longer valid.
-        self.game_model.game.reset_ato()
         self.game_model.game.initialize_turn()
         GameUpdateSignal.get_instance().updateGame(self.game_model.game)
 

--- a/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategy.py
+++ b/qt_ui/windows/basemenu/ground_forces/QGroundForcesStrategy.py
@@ -56,6 +56,5 @@ class QGroundForcesStrategy(QGroupBox):
         self.cp.base.affect_strength(amount)
         enemy_point.base.affect_strength(-amount)
         # Clear the ATO to replan missions affected by the front line.
-        self.game.reset_ato()
         self.game.initialize_turn()
         GameUpdateSignal.get_instance().updateGame(self.game)

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -259,6 +259,14 @@ class QGroundObjectMenu(QDialog):
         self.update_total_value()
         self.game.budget = self.game.budget + self.total_value
         self.ground_object.groups = []
+
+        # Replan if the tgo was a target of the redfor
+        if any(
+            package.target == self.ground_object
+            for package in self.game.ato_for(player=False).packages
+        ):
+            self.game.initialize_turn(for_red=True, for_blue=False)
+
         self.do_refresh_layout()
         GameUpdateSignal.get_instance().updateGame(self.game)
 
@@ -439,6 +447,9 @@ class QBuyGroupForGroundObjectDialog(QDialog):
         )
         self.ground_object.groups = [group]
 
+        # Replan redfor missions
+        self.game.initialize_turn(for_red=True, for_blue=False)
+
         GameUpdateSignal.get_instance().updateGame(self.game)
 
     def buySam(self):
@@ -452,6 +463,9 @@ class QBuyGroupForGroundObjectDialog(QDialog):
 
         self.ground_object.groups = list(sam_generator.groups)
 
+        # Replan redfor missions
+        self.game.initialize_turn(for_red=True, for_blue=False)
+
         GameUpdateSignal.get_instance().updateGame(self.game)
 
     def buy_ewr(self):
@@ -464,6 +478,9 @@ class QBuyGroupForGroundObjectDialog(QDialog):
             self.game.budget -= price
 
         self.ground_object.groups = [ewr_generator.vg]
+
+        # Replan redfor missions
+        self.game.initialize_turn(for_red=True, for_blue=False)
 
         GameUpdateSignal.get_instance().updateGame(self.game)
 


### PR DESCRIPTION
fixes #641

also added an improvement for the statistics window which i encountered when i used the cheats. they will basicly recall the update statistics which will lead to multiple turn_data elements for the same data in the statistics stack. i solved this one with an easy "remove last item" thing