### PR TITLE
Correct prices for ewr and sam

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,10 +19,12 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[UI]** Hovering over the weather information now dispalys the cloud base (meters and feet).
 * **[UI]** Google search link added to unit information when there is no information provided.
 * **[UI]** Control point name displayed with ground object group name on map.
+* **[UI]** Buy or Replace will now show the correct price for generated ground objects like sams.
 
 ## Fixes
 
 * **[Campaign]** Fixed the Silkworm generator to include launchers and not all radars.
+* **[Economy]** EWRs can now be bought and sold for the correct price and can no longer be used to generate money
 * **[Flight Planning]** Fixed potential issue with angles > 360° or < 0° being generated when summing two angles.
 * **[Mission Generation]** The lua data for other plugins is now generated correctly
 * **[UI]** Statistics window tick marks are now always integers.

--- a/gen/sam/aaa_bofors.py
+++ b/gen/sam/aaa_bofors.py
@@ -14,7 +14,6 @@ class BoforsGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Bofors AAA"
-    price = 75
 
     def generate(self):
 

--- a/gen/sam/aaa_flak.py
+++ b/gen/sam/aaa_flak.py
@@ -23,7 +23,6 @@ class FlakGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Flak Site"
-    price = 135
 
     def generate(self):
         index = 0

--- a/gen/sam/aaa_flak18.py
+++ b/gen/sam/aaa_flak18.py
@@ -14,7 +14,6 @@ class Flak18Generator(AirDefenseGroupGenerator):
     """
 
     name = "WW2 Flak Site"
-    price = 40
 
     def generate(self):
 

--- a/gen/sam/aaa_ks19.py
+++ b/gen/sam/aaa_ks19.py
@@ -13,7 +13,6 @@ class KS19Generator(AirDefenseGroupGenerator):
     """
 
     name = "KS-19 AAA Site"
-    price = 98
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/aaa_ww2_ally_flak.py
+++ b/gen/sam/aaa_ww2_ally_flak.py
@@ -14,7 +14,6 @@ class AllyWW2FlakGenerator(AirDefenseGroupGenerator):
     """
 
     name = "WW2 Ally Flak Site"
-    price = 140
 
     def generate(self):
 

--- a/gen/sam/aaa_zsu57.py
+++ b/gen/sam/aaa_zsu57.py
@@ -12,7 +12,6 @@ class ZSU57Generator(AirDefenseGroupGenerator):
     """
 
     name = "ZSU-57-2 Group"
-    price = 60
 
     def generate(self):
         num_launchers = 4

--- a/gen/sam/aaa_zu23_insurgent.py
+++ b/gen/sam/aaa_zu23_insurgent.py
@@ -14,7 +14,6 @@ class ZU23InsurgentGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Zu-23 Site"
-    price = 56
 
     def generate(self):
         index = 0

--- a/gen/sam/airdefensegroupgenerator.py
+++ b/gen/sam/airdefensegroupgenerator.py
@@ -43,8 +43,6 @@ class AirDefenseGroupGenerator(GroupGenerator, ABC):
     This is the base for all SAM group generators
     """
 
-    price: int
-
     def __init__(self, game: Game, ground_object: SamGroundObject) -> None:
         super().__init__(game, ground_object)
 

--- a/gen/sam/cold_war_flak.py
+++ b/gen/sam/cold_war_flak.py
@@ -17,7 +17,6 @@ class EarlyColdWarFlakGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Early Cold War Flak Site"
-    price = 74
 
     def generate(self):
 
@@ -90,7 +89,6 @@ class ColdWarFlakGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Cold War Flak Site"
-    price = 72
 
     def generate(self):
 

--- a/gen/sam/ewrs.py
+++ b/gen/sam/ewrs.py
@@ -13,11 +13,6 @@ class EwrGenerator(GroupGenerator):
     def name(cls) -> str:
         return cls.unit_type.name
 
-    @staticmethod
-    def price() -> int:
-        # TODO: Differentiate sites.
-        return 20
-
     def generate(self) -> None:
         self.add_unit(
             self.unit_type, "EWR", self.position.x, self.position.y, self.heading

--- a/gen/sam/freya_ewr.py
+++ b/gen/sam/freya_ewr.py
@@ -12,7 +12,6 @@ class FreyaGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Freya EWR Site"
-    price = 60
 
     def generate(self):
 

--- a/gen/sam/sam_avenger.py
+++ b/gen/sam/sam_avenger.py
@@ -14,7 +14,6 @@ class AvengerGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Avenger Group"
-    price = 62
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_chaparral.py
+++ b/gen/sam/sam_chaparral.py
@@ -14,7 +14,6 @@ class ChaparralGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Chaparral Group"
-    price = 66
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_gepard.py
+++ b/gen/sam/sam_gepard.py
@@ -14,7 +14,6 @@ class GepardGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Gepard Group"
-    price = 50
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_hawk.py
+++ b/gen/sam/sam_hawk.py
@@ -16,7 +16,6 @@ class HawkGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Hawk Site"
-    price = 115
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_hq7.py
+++ b/gen/sam/sam_hq7.py
@@ -16,7 +16,6 @@ class HQ7Generator(AirDefenseGroupGenerator):
     """
 
     name = "HQ-7 Site"
-    price = 120
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_linebacker.py
+++ b/gen/sam/sam_linebacker.py
@@ -14,7 +14,6 @@ class LinebackerGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Linebacker Group"
-    price = 75
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_patriot.py
+++ b/gen/sam/sam_patriot.py
@@ -14,7 +14,6 @@ class PatriotGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Patriot Battery"
-    price = 240
 
     def generate(self):
         # Command Post

--- a/gen/sam/sam_rapier.py
+++ b/gen/sam/sam_rapier.py
@@ -15,7 +15,6 @@ class RapierGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Rapier AA Site"
-    price = 50
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_roland.py
+++ b/gen/sam/sam_roland.py
@@ -13,7 +13,6 @@ class RolandGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Roland Site"
-    price = 40
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_sa10.py
+++ b/gen/sam/sam_sa10.py
@@ -17,7 +17,6 @@ class SA10Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-10/S-300PS Battery - With ZSU-23"
-    price = 550
 
     def __init__(self, game: Game, ground_object: SamGroundObject):
         super().__init__(game, ground_object)
@@ -89,7 +88,6 @@ class SA10Generator(AirDefenseGroupGenerator):
 class Tier2SA10Generator(SA10Generator):
 
     name = "SA-10/S-300PS Battery - With SA-15 PD"
-    price = 650
 
     def generate_defensive_groups(self) -> None:
         # Create AAA the way the main group does.
@@ -114,7 +112,6 @@ class Tier2SA10Generator(SA10Generator):
 class Tier3SA10Generator(SA10Generator):
 
     name = "SA-10/S-300PS Battery - With SA-15 PD & SA-19 SHORAD"
-    price = 750
 
     def generate_defensive_groups(self) -> None:
         # AAA for defending against close targets.
@@ -150,7 +147,6 @@ class Tier3SA10Generator(SA10Generator):
 
 class SA10BGenerator(Tier3SA10Generator):
 
-    price = 700
     name = "SA-10B/S-300PS Battery"
 
     def __init__(self, game: Game, ground_object: SamGroundObject):
@@ -166,7 +162,6 @@ class SA10BGenerator(Tier3SA10Generator):
 
 class SA12Generator(Tier3SA10Generator):
 
-    price = 750
     name = "SA-12/S-300V Battery"
 
     def __init__(self, game: Game, ground_object: SamGroundObject):
@@ -182,7 +177,6 @@ class SA12Generator(Tier3SA10Generator):
 
 class SA20Generator(Tier3SA10Generator):
 
-    price = 800
     name = "SA-20/S-300PMU-1 Battery"
 
     def __init__(self, game: Game, ground_object: SamGroundObject):
@@ -198,7 +192,6 @@ class SA20Generator(Tier3SA10Generator):
 
 class SA20BGenerator(Tier3SA10Generator):
 
-    price = 850
     name = "SA-20B/S-300PMU-2 Battery"
 
     def __init__(self, game: Game, ground_object: SamGroundObject):
@@ -214,7 +207,6 @@ class SA20BGenerator(Tier3SA10Generator):
 
 class SA23Generator(Tier3SA10Generator):
 
-    price = 950
     name = "SA-23/S-300VM Battery"
 
     def __init__(self, game: Game, ground_object: SamGroundObject):

--- a/gen/sam/sam_sa11.py
+++ b/gen/sam/sam_sa11.py
@@ -14,7 +14,6 @@ class SA11Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-11 Buk Battery"
-    price = 180
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_sa13.py
+++ b/gen/sam/sam_sa13.py
@@ -14,7 +14,6 @@ class SA13Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-13 Strela Group"
-    price = 50
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_sa15.py
+++ b/gen/sam/sam_sa15.py
@@ -12,7 +12,6 @@ class SA15Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-15 Tor Group"
-    price = 55
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_sa17.py
+++ b/gen/sam/sam_sa17.py
@@ -13,7 +13,6 @@ class SA17Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-17 Grizzly Battery"
-    price = 180
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_sa19.py
+++ b/gen/sam/sam_sa19.py
@@ -14,7 +14,6 @@ class SA19Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-19 Tunguska Group"
-    price = 90
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_sa2.py
+++ b/gen/sam/sam_sa2.py
@@ -14,7 +14,6 @@ class SA2Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-2/S-75 Site"
-    price = 74
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_sa3.py
+++ b/gen/sam/sam_sa3.py
@@ -14,7 +14,6 @@ class SA3Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-3/S-125 Site"
-    price = 80
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_sa6.py
+++ b/gen/sam/sam_sa6.py
@@ -14,7 +14,6 @@ class SA6Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-6 Kub Site"
-    price = 102
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_sa8.py
+++ b/gen/sam/sam_sa8.py
@@ -12,7 +12,6 @@ class SA8Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-8 OSA Site"
-    price = 55
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_sa9.py
+++ b/gen/sam/sam_sa9.py
@@ -14,7 +14,6 @@ class SA9Generator(AirDefenseGroupGenerator):
     """
 
     name = "SA-9 Group"
-    price = 40
 
     def generate(self):
         self.add_unit(

--- a/gen/sam/sam_vulcan.py
+++ b/gen/sam/sam_vulcan.py
@@ -14,7 +14,6 @@ class VulcanGenerator(AirDefenseGroupGenerator):
     """
 
     name = "Vulcan Group"
-    price = 25
 
     def generate(self):
         num_launchers = 2

--- a/gen/sam/sam_zsu23.py
+++ b/gen/sam/sam_zsu23.py
@@ -14,7 +14,6 @@ class ZSU23Generator(AirDefenseGroupGenerator):
     """
 
     name = "ZSU-23 Group"
-    price = 50
 
     def generate(self):
         num_launchers = 4

--- a/gen/sam/sam_zu23.py
+++ b/gen/sam/sam_zu23.py
@@ -14,7 +14,6 @@ class ZU23Generator(AirDefenseGroupGenerator):
     """
 
     name = "ZU-23 Group"
-    price = 54
 
     def generate(self):
         index = 0

--- a/gen/sam/sam_zu23_ural.py
+++ b/gen/sam/sam_zu23_ural.py
@@ -14,7 +14,6 @@ class ZU23UralGenerator(AirDefenseGroupGenerator):
     """
 
     name = "ZU-23 Ural Group"
-    price = 64
 
     def generate(self):
         num_launchers = 4

--- a/gen/sam/sam_zu23_ural_insurgent.py
+++ b/gen/sam/sam_zu23_ural_insurgent.py
@@ -14,7 +14,6 @@ class ZU23UralInsurgentGenerator(AirDefenseGroupGenerator):
     """
 
     name = "ZU-23 Ural Insurgent Group"
-    price = 64
 
     def generate(self):
         num_launchers = 4


### PR DESCRIPTION
Updated the group generator to calculate the price of the whole group by looking up the price using the GroundUnitType wrapper during the generation so that is has not to be set in the generator manually.

The prices are now correct when you open the buy/sell menu of a tgo like SAM or EWR

This also fixes #1163 as this will also calculate the real price of the EWR instead of using the dummy "20" as price per EWR