### PR TITLE
Corrected Silkworm launcher name

### DIFF
--- a/gen/coastal/silkworm.py
+++ b/gen/coastal/silkworm.py
@@ -23,7 +23,7 @@ class SilkwormGenerator(GroupGenerator):
         # Launchers
         for i, p in enumerate(positions):
             self.add_unit(
-                MissilesSS.Silkworm_SR,
+                MissilesSS.Hy_launcher,
                 "Missile#" + str(i),
                 p[0],
                 p[1],


### PR DESCRIPTION
SRs were accidentally assigned as launchers in the generator. Fixes #1393 