### PR TITLE
handle empty/destroyed groups while generating mixed unit groups for convoys

### DIFF
--- a/game/transfers.py
+++ b/game/transfers.py
@@ -130,7 +130,10 @@ class TransferOrder:
     def kill_unit(self, unit_type: GroundUnitType) -> None:
         if unit_type not in self.units or not self.units[unit_type]:
             raise KeyError(f"{self} has no {unit_type} remaining")
-        self.units[unit_type] -= 1
+        if self.units[unit_type] == 1:
+            del self.units[unit_type]
+        else:
+            self.units[unit_type] -= 1
 
     @property
     def size(self) -> int:


### PR DESCRIPTION
There was a bug when the generator tried to generate a mixed group where all units of the first group were destroyed in the previous turn. This leads to an Error as pydcs can not generate a vehicle_group with group_size=0 (which came from the destroyed unit)

fixes the 2nd bug in #1409 