### PR TITLE
Fixing broken group generation.

### DIFF
--- a/gen/sam/group_generator.py
+++ b/gen/sam/group_generator.py
@@ -77,7 +77,7 @@ class VehicleGroupGenerator(
         super().__init__(
             game,
             ground_object,
-            unitgroup.VehicleGroup(self.game.next_group_id(), self.go.group_name),
+            unitgroup.VehicleGroup(game.next_group_id(), ground_object.group_name),
         )
         wp = self.vg.add_waypoint(self.position, PointAction.OffRoad, 0)
         wp.ETA_locked = True


### PR DESCRIPTION
This bit of code tries to use instance attributes before the `__init()__` chain has been completed.  Fortunately the information required can be obtained from `__init()__` param values.