### PR TITLE
Allow user to set empty dcs_install_dir to disable MissionScripting replacement

### DIFF
--- a/qt_ui/liberation_install.py
+++ b/qt_ui/liberation_install.py
@@ -112,7 +112,7 @@ def replace_mission_scripting_file():
     )
     liberation_scripting_path = "./resources/scripts/MissionScripting.lua"
     backup_scripting_path = "./resources/scripts/MissionScripting.original.lua"
-    if os.path.isfile(mission_scripting_path):
+    if install_dir != "" and os.path.isfile(mission_scripting_path):
         with open(mission_scripting_path, "r") as ms:
             current_file_content = ms.read()
         with open(liberation_scripting_path, "r") as libe_ms:
@@ -133,5 +133,9 @@ def restore_original_mission_scripting():
     )
     backup_scripting_path = "./resources/scripts/MissionScripting.original.lua"
 
-    if os.path.isfile(backup_scripting_path) and os.path.isfile(mission_scripting_path):
+    if (
+        install_dir != ""
+        and os.path.isfile(backup_scripting_path)
+        and os.path.isfile(mission_scripting_path)
+    ):
         copyfile(backup_scripting_path, mission_scripting_path)

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -95,6 +95,22 @@ def run_ui(game: Optional[Game]) -> None:
     uiconstants.load_aircraft_banners()
     uiconstants.load_vehicle_banners()
 
+    # Show warning if no DCS Installation directory was set
+    if liberation_install.get_dcs_install_directory() == "":
+        QtWidgets.QMessageBox.warning(
+            splash,
+            "No DCS installation directory.",
+            "The DCS Installation directory is not set correctly. "
+            "This will prevent DCS Liberation to work properly as the MissionScripting "
+            "file will not be modified."
+            "<br/><br/>To solve this problem, you can set the Installation directory "
+            "within the preferences menu. You can also manually edit or replace the "
+            "following file:"
+            "<br/><br/><strong>&lt;dcs_installation_directory&gt;/Scripts/MissionScripting.lua</strong>"
+            "<br/><br/>The easiest way to do it is to replace the original file with the file in dcs-liberation distribution (&lt;dcs_liberation_installation&gt;/resources/scripts/MissionScripting.lua)."
+            "<br/><br/>You can find more information on how to manually change this file in the Liberation Wiki (Page: Dedicated Server Guide) on GitHub.</p>",
+            QtWidgets.QMessageBox.StandardButton.Ok,
+        )
     # Replace DCS Mission scripting file to allow DCS Liberation to work
     try:
         liberation_install.replace_mission_scripting_file()

--- a/qt_ui/windows/preferences/QLiberationFirstStartWindow.py
+++ b/qt_ui/windows/preferences/QLiberationFirstStartWindow.py
@@ -58,6 +58,12 @@ class QLiberationFirstStartWindow(QDialog):
         
         <p>As you click on the button below, the file will be replaced in your DCS installation directory.</p>
         
+        <br/>
+        <p>If you leave the DCS Installation Directory empty, DCS Liberation can not automatically replace the MissionScripting.lua and will therefore not work correctly!
+        In this case, you need to edit the file yourself. The easiest way to do it is to replace the original file with the file in dcs-liberation distribution (&lt;dcs_liberation_installation&gt;/resources/scripts/MissionScripting.lua).
+        <br/><br/>You can find more information on how to manually change this file in the Liberation Wiki (Page: Dedicated Server Guide) on GitHub.</p>
+
+        
         <br/><br/>
         
         <strong>Thank you for reading !</strong>

--- a/qt_ui/windows/preferences/QLiberationPreferences.py
+++ b/qt_ui/windows/preferences/QLiberationPreferences.py
@@ -22,6 +22,7 @@ class QLiberationPreferences(QFrame):
         super(QLiberationPreferences, self).__init__()
         self.saved_game_dir = ""
         self.dcs_install_dir = ""
+        self.install_dir_ignore_warning = False
 
         self.dcs_install_dir = liberation_install.get_dcs_install_directory()
         self.saved_game_dir = liberation_install.get_saved_game_dir()
@@ -102,17 +103,38 @@ class QLiberationPreferences(QFrame):
             error_dialog.exec_()
             return False
 
-        if not os.path.isdir(self.dcs_install_dir):
+        if self.install_dir_ignore_warning and self.dcs_install_dir == "":
+            warning_dialog = QMessageBox.warning(
+                self,
+                "The DCS Installation directory was not set",
+                "You set an empty DCS Installation directory! "
+                "<br/><br/>Without this directory, DCS Liberation can not replace the MissionScripting.lua for you and will not work properly. "
+                "In this case, you need to edit the MissionScripting.lua yourself. The easiest way to do it is to replace the original file (&lt;dcs_installation_directory&gt;/Scripts/MissionScripting.lua) with the file in dcs-liberation distribution (&lt;dcs_liberation_installation&gt;/resources/scripts/MissionScripting.lua)."
+                "<br/><br/>You can find more information on how to manually change this file in the Liberation Wiki (Page: Dedicated Server Guide) on GitHub.</p>"
+                "<br/><br/>Are you sure that you want to leave the installation directory empty?"
+                "<br/><br/><strong>This is only recommended for expert users!</strong>",
+                QMessageBox.StandardButton.Yes,
+                QMessageBox.StandardButton.No,
+            )
+            if warning_dialog == QMessageBox.No:
+                return False
+        elif not os.path.isdir(self.dcs_install_dir):
             error_dialog = QMessageBox.critical(
                 self,
                 "Wrong DCS installation directory.",
-                self.dcs_install_dir + " is not a valid directory",
+                self.dcs_install_dir
+                + " is not a valid directory. DCS Liberation requires the installation directory to replace the MissionScripting.lua"
+                "<br/><br/>If you ignore this Error, DCS Liberation can not work properly and needs your attention. "
+                "In this case, you need to edit the MissionScripting.lua yourself. The easiest way to do it is to replace the original file (&lt;dcs_installation_directory&gt;/Scripts/MissionScripting.lua) with the file in dcs-liberation distribution (&lt;dcs_liberation_installation&gt;/resources/scripts/MissionScripting.lua)."
+                "<br/><br/>You can find more information on how to manually change this file in the Liberation Wiki (Page: Dedicated Server Guide) on GitHub.</p>"
+                "<br/><br/><strong>This is only recommended for expert users!</strong>",
+                QMessageBox.StandardButton.Ignore,
                 QMessageBox.StandardButton.Ok,
             )
-            error_dialog.exec_()
+            if error_dialog == QMessageBox.Ignore:
+                self.install_dir_ignore_warning = True
             return False
-
-        if not os.path.isdir(
+        elif not os.path.isdir(
             os.path.join(self.dcs_install_dir, "Scripts")
         ) and os.path.isfile(os.path.join(self.dcs_install_dir, "bin", "DCS.exe")):
             error_dialog = QMessageBox.critical(


### PR DESCRIPTION
This will allow expert users to disable the automatic MissionScripting.lua replacement. There are many warnings and errors which have to be ignored to achieve this because DCS Liberation will not work with unmodified MissionScripting.lua

Why i did this? Because if you run a dedicated server (which is on a different machine) the automatic changing of the MissionScripting.lua makes no sense for my main DCS Install. I even do not want that this file gets replaced everytime.

As this is only for experts there are really many of warnings and errors which have to be ignored by intention (install_dir_ignore_warning will be set to true). Only if they were ignored the dir can be set as empty. Then the user will get a popup on every liberation start as well.