### PR TITLE
[WIP] Rerun planner with UI Button and allow to limit assigned aircrafts

### DIFF
--- a/game/commander/tasks/compound/attackbuildings.py
+++ b/game/commander/tasks/compound/attackbuildings.py
@@ -3,11 +3,13 @@ from collections import Iterator
 from game.commander.tasks.primitive.strike import PlanStrike
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
+from game.theater import TheaterGroundObject
 
 
 class AttackBuildings(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
         for building in state.strike_targets:
+            assert isinstance(building, TheaterGroundObject)
             # Ammo depots are targeted based on the needs of the front line by
             # ReduceEnemyFrontLineCapacity. No reason to target them before that front
             # line is active.

--- a/game/commander/tasks/compound/frontlinedefense.py
+++ b/game/commander/tasks/compound/frontlinedefense.py
@@ -3,9 +3,11 @@ from collections import Iterator
 from game.commander.tasks.primitive.cas import PlanCas
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
+from game.theater import FrontLine
 
 
 class FrontLineDefense(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
         for front_line in state.vulnerable_front_lines:
+            assert isinstance(front_line, FrontLine)
             yield [PlanCas(front_line)]

--- a/game/commander/tasks/compound/protectairspace.py
+++ b/game/commander/tasks/compound/protectairspace.py
@@ -3,10 +3,12 @@ from collections import Iterator
 from game.commander.tasks.primitive.barcap import PlanBarcap
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
+from game.theater import ControlPoint
 
 
 class ProtectAirSpace(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
         for cp, needed in state.barcaps_needed.items():
+            assert isinstance(cp, ControlPoint)
             if needed > 0:
                 yield [PlanBarcap(cp)]

--- a/game/game.py
+++ b/game/game.py
@@ -539,3 +539,13 @@ class Game:
             )
         elif turn_state is TurnState.LOSS:
             self.message("Game Over, you lose. Start a new campaign to continue.")
+
+    def assignable_aircraft_count_for(self, player: bool) -> int:
+        if self.settings.perf_limit_aircraft:
+            already_assigned = 0
+            for package in self.blue.ato.packages if player else self.red.ato.packages:
+                for planned_flight in package.flights:
+                    already_assigned += planned_flight.count
+
+            return self.settings.perf_limit_aircraft_amount - already_assigned
+        return -1  # Unlimited

--- a/game/settings.py
+++ b/game/settings.py
@@ -74,6 +74,10 @@ class Settings:
     perf_destroyed_units: bool = True
     reserves_procurement_target: int = 10
 
+    # Limit amount of assigned aircraft
+    perf_limit_aircraft: bool = False
+    perf_limit_aircraft_amount: int = 64
+
     # Performance culling
     perf_culling: bool = False
     perf_culling_distance: int = 100


### PR DESCRIPTION
This one is a WIP and needs more work.

This PR will allow the user to re-run the TheaterCommander to fill up unassigned aircrafts or recreate missing packages. This PR also will allow the user to setup a limit of aircrafts which should be assigned for tasking so that users optimize the mission on theire own to regain some performance if many aircrafts are available.

This addresses #799 and #643

TODOs:

- [ ] TOT (Later planned things dont have a good TOT assigned)
- [ ] OCA (Differentiate between runway and aircraft)
- [ ] Garrisons
- [ ] NavalGroundObjects
- [ ] Stances will be overwritten by CaptureBase & DefendBase
- [ ] Assignable_aircraft not implemented yet for the Commander
- [ ] UI Implemention for Aircraft Count and Button are just draft and will not update correctly