### PR TITLE
calculate heading to center of conflict for sams

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[Campaign]** Air defense sites now generate a fixed number of launchers per type.
 * **[Campaign]** Added support for Mariana Islands map.  
 * **[Mission Generation]** Improvements for better support of the Skynet Plugin and long range SAMs are now acting as EWR
+* **[Mission Generation]** SAM sites are now headed towards the center of the conflict
 * **[Plugins]** Increased time JTAC Autolase messages stay visible on the UI.
 * **[UI]** Added ability to take notes and have those notes appear as a kneeboard page.
 * **[UI]** Hovering over the weather information now dispalys the cloud base (meters and feet).

--- a/gen/sam/airdefensegroupgenerator.py
+++ b/gen/sam/airdefensegroupgenerator.py
@@ -48,6 +48,7 @@ class AirDefenseGroupGenerator(VehicleGroupGenerator[SamGroundObject], ABC):
 
         self.vg.name = self.group_name_for_role(self.vg.id, self.primary_group_role())
         self.auxiliary_groups: List[VehicleGroup] = []
+        self.heading = self.heading_to_conflict()
 
     def add_auxiliary_group(self, role: SkynetRole) -> VehicleGroup:
         gid = self.game.next_group_id()

--- a/gen/sam/group_generator.py
+++ b/gen/sam/group_generator.py
@@ -72,7 +72,7 @@ class GroupGenerator(Generic[GroupT, UnitT, UnitTypeT, TgoT]):
     ) -> UnitT:
         raise NotImplementedError
 
-    def heading_to_conflict(self) -> int:
+    def heading_to_conflict(self) -> Heading:
         # Heading for a Group to the enemy.
         # Should be the point between the nearest and the most distant conflict
         conflicts: dict[MissionTarget, float] = {}
@@ -91,7 +91,9 @@ class GroupGenerator(Generic[GroupT, UnitT, UnitTypeT, TgoT]):
             (closest_conflict.position.y + most_distant_conflict.position.y) / 2,
         )
 
-        return int(self.go.position.heading_between_point(conflict_center))
+        return Heading.from_degrees(
+            self.go.position.heading_between_point(conflict_center)
+        )
 
 
 class VehicleGroupGenerator(

--- a/gen/sam/group_generator.py
+++ b/gen/sam/group_generator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import operator
 import random
 from collections import Iterable
 from typing import TYPE_CHECKING, Type, TypeVar, Generic, Any
@@ -15,6 +16,7 @@ from dcs.unittype import VehicleType, UnitType, ShipType
 
 from game.dcs.groundunittype import GroundUnitType
 from game.factions.faction import Faction
+from game.theater import MissionTarget
 from game.theater.theatergroundobject import TheaterGroundObject, NavalGroundObject
 from game.utils import Heading
 
@@ -69,6 +71,27 @@ class GroupGenerator(Generic[GroupT, UnitT, UnitTypeT, TgoT]):
         heading: Heading,
     ) -> UnitT:
         raise NotImplementedError
+
+    def heading_to_conflict(self) -> int:
+        # Heading for a Group to the enemy.
+        # Should be the point between the nearest and the most distant conflict
+        conflicts: dict[MissionTarget, float] = {}
+
+        for conflict in self.game.theater.conflicts():
+            conflicts[conflict] = conflict.distance_to(self.go)
+
+        if len(conflicts) == 0:
+            return self.heading
+
+        closest_conflict = min(conflicts.items(), key=operator.itemgetter(1))[0]
+        most_distant_conflict = max(conflicts.items(), key=operator.itemgetter(1))[0]
+
+        conflict_center = Point(
+            (closest_conflict.position.x + most_distant_conflict.position.x) / 2,
+            (closest_conflict.position.y + most_distant_conflict.position.y) / 2,
+        )
+
+        return int(self.go.position.heading_between_point(conflict_center))
 
 
 class VehicleGroupGenerator(


### PR DESCRIPTION
this fixes #1423

During the SAM Generator the heading towards the center of the conflict will be calculated so that the group will head towards it. This is needed for fixed radars like the one from the Patriot.

The original idea of the issue linked above was to let campaign designers set the heading and this could be reused. But this change would need quite more stuff to be implemented and still we would have to take in account that sams can be bought and sold by the user and then we would loose the heading. So i decided to take the calculation inside the code base instead of giving the option for campaign designers.

The current logic will not recalculate the heading once the theater changes. But this is a more general behaviour of TGOs which can be enhanced in the future if needed.

This is working for V4.X.X as well as V5.X.X. (It is not adopted to the new heading class coming with #1387)