### PR TITLE
fix generation of empty transfer during cp capture

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[Mission Generation]** The lua data for other plugins is now generated correctly
 * **[Mission Generation]** Fixed problem with opfor planning missions against sold ground objects like SAMs
 * **[Mission Generation]** The legacy always-available tanker option no longer prevents mission creation.
+* **[Mission Generation]** Prevent the creation of a transfer order with 0 units for a rare situtation when a point was captured.
 * **[Mission Generation]** Fix occasional KeyError preventing mission generation when all units of the same type in a convoy were killed.
 * **[UI]** Statistics window tick marks are now always integers.
 * **[UI]** Statistics window now shows the correct info for the turn

--- a/game/unitdelivery.py
+++ b/game/unitdelivery.py
@@ -40,7 +40,10 @@ class PendingUnitDeliveries:
 
     def sell(self, units: dict[UnitType[Any], int]) -> None:
         for k, v in units.items():
-            self.units[k] -= v
+            if self.units[k] > v:
+                self.units[k] -= v
+            else:
+                del self.units[k]
 
     def refund_all(self, coalition: Coalition) -> None:
         self.refund(coalition, self.units)

--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -209,8 +209,6 @@ class QRecruitBehaviour:
         if self.pending_deliveries.available_next_turn(unit_type) > 0:
             self.budget += unit_type.price
             self.pending_deliveries.sell({unit_type: 1})
-            if self.pending_deliveries.units[unit_type] == 0:
-                del self.pending_deliveries.units[unit_type]
         self.update_purchase_controls()
         self.update_available_budget()
         return True


### PR DESCRIPTION
during debugging of #1455 i found this rare bug:

when a cp capture happens and the next cp has pending unit deliveries then they will be redeployed to the newly captured cp. The redeploy was drecreasing the num of pending unit deliveries for the old cp but was not removing them completly from the dict when all were removed. This lead to an transfer order with unit_count 0 for every unit.

Also removed the specific handling of empty pending_deliveries out of the Recruiting UI as it should and will be handled by the sell function only.

Compatible to V4 as well as V5