### PR TITLE
Add AFAC task to JTAC unit

### DIFF
--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -455,6 +455,7 @@ class Operation:
                 "zone": jtac.region,
                 "dcsUnit": jtac.unit_name,
                 "laserCode": jtac.code,
+                "radio": jtac.freq.mhz,
             }
         flight_count = 0
         for flight in airgen.flights:
@@ -571,7 +572,8 @@ class Operation:
             zone = data["zone"]
             laserCode = data["laserCode"]
             dcsUnit = data["dcsUnit"]
-            lua += f"    {{dcsGroupName='{dcsGroupName}', callsign='{callsign}', zone={repr(zone)}, laserCode='{laserCode}', dcsUnit='{dcsUnit}' }}, \n"
+            radio = data["radio"]
+            lua += f"    {{dcsGroupName='{dcsGroupName}', callsign='{callsign}', zone={repr(zone)}, laserCode='{laserCode}', dcsUnit='{dcsUnit}', radio='{radio}' }}, \n"
         lua += "}"
 
         # Process the Target Points

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -399,6 +399,7 @@ class Operation:
                 player_cp.stances[enemy_cp.id],
                 enemy_cp.stances[player_cp.id],
                 cls.unit_map,
+                cls.radio_registry,
             )
             ground_conflict_gen.generate()
             cls.jtacs.extend(ground_conflict_gen.jtacs)

--- a/gen/armor.py
+++ b/gen/armor.py
@@ -42,6 +42,7 @@ from .callsigns import callsign_for_support_unit
 from .conflictgen import Conflict
 from .ground_forces.combat_stance import CombatStance
 from .naming import namegen
+from .radios import RadioRegistry
 
 if TYPE_CHECKING:
     from game import Game
@@ -88,6 +89,7 @@ class GroundConflictGenerator:
         player_stance: CombatStance,
         enemy_stance: CombatStance,
         unit_map: UnitMap,
+        radio_registry: RadioRegistry,
     ) -> None:
         self.mission = mission
         self.conflict = conflict
@@ -97,6 +99,7 @@ class GroundConflictGenerator:
         self.enemy_stance = enemy_stance
         self.game = game
         self.unit_map = unit_map
+        self.radio_registry = radio_registry
         self.jtacs: List[JtacInfo] = []
 
     def generate(self) -> None:

--- a/gen/armor.py
+++ b/gen/armor.py
@@ -13,9 +13,11 @@ from dcs.country import Country
 from dcs.mapping import Point
 from dcs.point import PointAction
 from dcs.task import (
+    AFAC,
     EPLRS,
     AttackGroup,
     ControlledTask,
+    FAC,
     FireAtPoint,
     GoToWaypoint,
     Hold,
@@ -42,7 +44,7 @@ from .callsigns import callsign_for_support_unit
 from .conflictgen import Conflict
 from .ground_forces.combat_stance import CombatStance
 from .naming import namegen
-from .radios import RadioRegistry
+from .radios import MHz, RadioFrequency, RadioRegistry
 
 if TYPE_CHECKING:
     from game import Game
@@ -75,7 +77,7 @@ class JtacInfo:
     region: str
     code: str
     blue: bool
-    # TODO: Radio info? Type?
+    freq: RadioFrequency
 
 
 class GroundConflictGenerator:
@@ -150,6 +152,7 @@ class GroundConflictGenerator:
         if self.game.blue.faction.has_jtac:
             n = "JTAC" + str(self.conflict.blue_cp.id) + str(self.conflict.red_cp.id)
             code = 1688 - len(self.jtacs)
+            freq = self.radio_registry.alloc_uhf()
 
             utype = self.game.blue.faction.jtac_unit
             if utype is None:
@@ -162,6 +165,10 @@ class GroundConflictGenerator:
                 position=position[0],
                 airport=None,
                 altitude=5000,
+                maintask=AFAC,
+            )
+            jtac.points[0].tasks.append(
+                FAC(callsign=len(self.jtacs) + 1, frequency=int(freq.mhz))
             )
             jtac.points[0].tasks.append(SetInvisibleCommand(True))
             jtac.points[0].tasks.append(SetImmortalCommand(True))
@@ -181,6 +188,7 @@ class GroundConflictGenerator:
                     frontline,
                     str(code),
                     blue=True,
+                    freq=freq,
                 )
             )
 

--- a/gen/kneeboard.py
+++ b/gen/kneeboard.py
@@ -487,8 +487,15 @@ class SupportPage(KneeboardPage):
         writer.heading("JTAC")
         jtacs = []
         for jtac in self.jtacs:
-            jtacs.append([jtac.callsign, jtac.region, jtac.code])
-        writer.table(jtacs, headers=["Callsign", "Region", "Laser Code"])
+            jtacs.append(
+                [
+                    jtac.callsign,
+                    jtac.region,
+                    jtac.code,
+                    self.format_frequency(jtac.freq),
+                ]
+            )
+        writer.table(jtacs, headers=["Callsign", "Region", "Laser Code", "FREQ"])
 
         writer.write(path)
 

--- a/resources/briefing/templates/briefingtemplate_CN.j2
+++ b/resources/briefing/templates/briefingtemplate_CN.j2
@@ -108,6 +108,6 @@ AWACS:
 {%- if jtacs|length > 0 %}
 JTACS [F-10 菜单] :
 ====================
-{% for jtac in jtacs %}前线 {{ jtac.region }} -- 激光编码 : {{ jtac.code }}
+{% for jtac in jtacs %}前线 {{ jtac.region }} -- 激光编码 : {{ jtac.code }}, 频率 : {{ jtac.freq.mhz }}
 {% endfor %}
 {% endif %}

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -108,6 +108,6 @@ AWACS:
 {%- if jtacs|length > 0 %}
 JTACS [F-10 Menu] :
 ====================
-{% for jtac in jtacs %}Frontline {{ jtac.region }} -- Code : {{ jtac.code }}
+{% for jtac in jtacs %}Frontline {{ jtac.region }} -- Code : {{ jtac.code }}, Freq : {{ jtac.freq.mhz }}
 {% endfor %}
 {% endif %}

--- a/resources/briefing/templates/briefingtemplate_FR.j2
+++ b/resources/briefing/templates/briefingtemplate_FR.j2
@@ -108,6 +108,6 @@ AWACS:
 {%- if jtacs|length > 0 %}
 JTACS [Menu F-10] :
 ====================
-{% for jtac in jtacs %}Ligne de front {{ jtac.region }} -- Code : {{ jtac.code }}
+{% for jtac in jtacs %}Ligne de front {{ jtac.region }} -- Code : {{ jtac.code }}, Fréq : {{ jtac.freq.mhz }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This PR adds an AFAC (or FAC) task to the generated JTAC unit, so players can perform guided CAS with 9-line brief and without jtacautolase.