### PR TITLE
Remove console window

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -36,7 +36,7 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    console=True,
+    console=False,
 )
 coll = COLLECT(
     exe,


### PR DESCRIPTION
dcs_liberation already writes logs to `logs/liberation.log` files. So I think it would be better if `liberation_main.exe` does not create console window.