### PR TITLE
Add dedicated log window and remove console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ env/
 /liberation_preferences.json
 /state.json
 
-logs/
+/logs/
 
 qt_ui/logs/liberation.log
 

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -36,7 +36,7 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    console=True,
+    console=False,
 )
 coll = COLLECT(
     exe,

--- a/qt_ui/logging_config.py
+++ b/qt_ui/logging_config.py
@@ -3,6 +3,8 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 
+from qt_ui.logging_handler import HookableInMemoryHandler
+
 
 def init_logging(version: str) -> None:
     """Initializes the logging configuration."""
@@ -10,13 +12,22 @@ def init_logging(version: str) -> None:
         os.mkdir("logs")
 
     fmt = "%(asctime)s :: %(levelname)s :: %(message)s"
+    formatter = logging.Formatter(fmt)
+
     logging.basicConfig(level=logging.DEBUG, format=fmt)
     logger = logging.getLogger()
 
-    handler = RotatingFileHandler("./logs/liberation.log", "a", 5000000, 1)
-    handler.setLevel(logging.DEBUG)
-    handler.setFormatter(logging.Formatter(fmt))
+    rotating_file_handler = RotatingFileHandler(
+        "./logs/liberation.log", "a", 5000000, 1
+    )
+    rotating_file_handler.setLevel(logging.DEBUG)
+    rotating_file_handler.setFormatter(formatter)
 
-    logger.addHandler(handler)
+    hookable_in_memory_handler = HookableInMemoryHandler()
+    hookable_in_memory_handler.setLevel(logging.DEBUG)
+    hookable_in_memory_handler.setFormatter(formatter)
+
+    logger.addHandler(rotating_file_handler)
+    logger.addHandler(hookable_in_memory_handler)
 
     logger.info(f"DCS Liberation {version}")

--- a/qt_ui/logging_handler.py
+++ b/qt_ui/logging_handler.py
@@ -1,0 +1,38 @@
+import logging
+import typing
+
+LogHook = typing.Callable[[str], None]
+
+
+class HookableInMemoryHandler(logging.Handler):
+    """Hookable in-memory logging handler for logs window"""
+
+    _log: str
+    _hook: typing.Optional[typing.Callable[[str], None]]
+
+    def __init__(self, *args, **kwargs):
+        super(HookableInMemoryHandler, self).__init__(*args, **kwargs)
+        self._log = ""
+        self._hook = None
+
+    @property
+    def log(self) -> str:
+        return self._log
+
+    def emit(self, record):
+        msg = self.format(record)
+        self._log += msg + "\n"
+        if self._hook is not None:
+            self._hook(msg)
+
+    def write(self, m):
+        pass
+
+    def clearLog(self) -> None:
+        self._log = ""
+
+    def setHook(self, hook: typing.Callable[[str], None]) -> None:
+        self._hook = hook
+
+    def clearHook(self) -> None:
+        self._hook = None

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -37,6 +37,7 @@ from qt_ui.windows.preferences.QLiberationPreferencesWindow import (
 from qt_ui.windows.settings.QSettingsWindow import QSettingsWindow
 from qt_ui.windows.stats.QStatsWindow import QStatsWindow
 from qt_ui.windows.notes.QNotesWindow import QNotesWindow
+from qt_ui.windows.logs.QLogsWindow import QLogsWindow
 
 
 class QLiberationWindow(QMainWindow):
@@ -151,6 +152,9 @@ class QLiberationWindow(QMainWindow):
             )
         )
 
+        self.openLogsAction = QAction("Show &logs", self)
+        self.openLogsAction.triggered.connect(self.showLogsDialog)
+
         self.openSettingsAction = QAction("Settings", self)
         self.openSettingsAction.setIcon(CONST.ICONS["Settings"])
         self.openSettingsAction.triggered.connect(self.showSettingsDialog)
@@ -210,6 +214,7 @@ class QLiberationWindow(QMainWindow):
         help_menu.addAction(
             "Report an &issue", lambda: webbrowser.open_new_tab(URLS["Issues"])
         )
+        help_menu.addAction(self.openLogsAction)
 
         help_menu.addSeparator()
         help_menu.addAction(self.showAboutDialogAction)
@@ -359,6 +364,10 @@ class QLiberationWindow(QMainWindow):
 
     def showNotesDialog(self):
         self.dialog = QNotesWindow(self.game)
+        self.dialog.show()
+
+    def showLogsDialog(self):
+        self.dialog = QLogsWindow()
         self.dialog.show()
 
     def onDebriefing(self, debrief: Debriefing):

--- a/qt_ui/windows/logs/QLogsWindow.py
+++ b/qt_ui/windows/logs/QLogsWindow.py
@@ -1,0 +1,67 @@
+import logging
+import typing
+
+from PySide2.QtWidgets import (
+    QDialog,
+    QPlainTextEdit,
+    QVBoxLayout,
+    QPushButton,
+)
+from PySide2.QtGui import QTextCursor
+
+from qt_ui.logging_handler import HookableInMemoryHandler
+
+
+class QLogsWindow(QDialog):
+    vbox: QVBoxLayout
+    textbox: QPlainTextEdit
+    clear_button: QPushButton
+    _logging_handler: typing.Optional[HookableInMemoryHandler]
+
+    def __init__(self):
+        super().__init__()
+
+        self.setWindowTitle("Logs")
+        self.setMinimumSize(400, 100)
+        self.resize(1000, 450)
+
+        self.vbox = QVBoxLayout()
+        self.setLayout(self.vbox)
+
+        self.textbox = QPlainTextEdit(self)
+        self.textbox.setReadOnly(True)
+        self.textbox.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        self.textbox.move(10, 10)
+        self.textbox.resize(1000, 450)
+        self.textbox.setStyleSheet(
+            "font-family: 'Courier New', monospace; background: #1D2731;"
+        )
+        self.vbox.addWidget(self.textbox)
+
+        self.clear_button = QPushButton(self)
+        self.clear_button.setText("CLEAR")
+        self.clear_button.setProperty("style", "btn-primary")
+        self.clear_button.clicked.connect(self.clearLogs)
+        self.vbox.addWidget(self.clear_button)
+
+        self._logging_handler = None
+        logger = logging.getLogger()
+        for handler in logger.handlers:
+            if isinstance(handler, HookableInMemoryHandler):
+                self._logging_handler = handler
+                break
+        if self._logging_handler is not None:
+            self.textbox.setPlainText(self._logging_handler.log)
+            self.textbox.moveCursor(QTextCursor.End)
+            self._logging_handler.setHook(self.appendLog)
+        else:
+            self.textbox.setPlainText("WARNING: logging not initialized!")
+
+    def clearLogs(self) -> None:
+        if self._logging_handler is not None:
+            self._logging_handler.clearLog()
+        self.textbox.setPlainText("")
+
+    def appendLog(self, msg: str):
+        self.textbox.appendPlainText(msg)
+        self.textbox.moveCursor(QTextCursor.End)


### PR DESCRIPTION
I think it would be better if `liberation_main.exe` does not create a console window.

This PR adds a dedicated log dialog window that shows all logs and removes the console log window.