### PR TITLE
Estimate preferred patrol altitude based on max speed

### DIFF
--- a/gen/flights/flightplan.py
+++ b/gen/flights/flightplan.py
@@ -1116,11 +1116,12 @@ class FlightPlanBuilder:
             raise InvalidObjectiveLocation(flight.flight_type, location)
 
         start_pos, end_pos = self.racetrack_for_objective(location, barcap=True)
-        patrol_alt = meters(
-            random.randint(
-                int(self.doctrine.min_patrol_altitude.meters),
-                int(self.doctrine.max_patrol_altitude.meters),
-            )
+
+        preferred_alt = flight.unit_type.preferred_patrol_altitude
+        randomized_alt = preferred_alt + feet(random.randint(-2, 1) * 1000)
+        patrol_alt = max(
+            self.doctrine.min_patrol_altitude,
+            min(self.doctrine.max_patrol_altitude, randomized_alt),
         )
 
         builder = WaypointBuilder(flight, self.coalition)
@@ -1355,11 +1356,11 @@ class FlightPlanBuilder:
         """
         location = self.package.target
 
-        patrol_alt = meters(
-            random.randint(
-                int(self.doctrine.min_patrol_altitude.meters),
-                int(self.doctrine.max_patrol_altitude.meters),
-            )
+        preferred_alt = flight.unit_type.preferred_patrol_altitude
+        randomized_alt = preferred_alt + feet(random.randint(-2, 1) * 1000)
+        patrol_alt = max(
+            self.doctrine.min_patrol_altitude,
+            min(self.doctrine.max_patrol_altitude, randomized_alt),
         )
 
         # Create points


### PR DESCRIPTION
When no specific data available for aircraft type, use max speed of aircraft to roughly estimate preferred patrol altitude.

Then clamp within reasonable intervals.

This preferred altitude is then used in barcap and tarcap planning. There it is also clamped within the doctrine min/max altitudes for patrol.

The altitudes are also neatly rounded to thousands of feet.

Feel free to suggest alternative implementations/architecture. My mindset with this PR is to improve the situation without requiring a lot of data to be manually added. We could also consider adding this logic directly to the PatrolConfig class.

Some example logging:

> 2021-08-01 20:42:05,294 :: DEBUG :: Preferred patrol altitude for F-4E: 28710.0
2021-08-01 20:42:05,333 :: DEBUG :: Preferred patrol altitude for MiG-29A: 29750.0
2021-08-01 20:42:05,348 :: DEBUG :: Preferred patrol altitude for MiG-21Bis: 30519.6
2021-08-01 20:42:22,709 :: DEBUG :: Preferred patrol altitude for F-14B: 30660.000000000004
2021-08-01 20:42:30,292 :: DEBUG :: Preferred patrol altitude for M-2000C: 28788.0
2021-08-01 20:42:35,329 :: DEBUG :: Preferred patrol altitude for JF-17: 30660.000000000004
2021-08-01 20:42:41,112 :: DEBUG :: Preferred patrol altitude for F-5E-3: 20551.200000000004
2021-08-01 20:42:47,198 :: DEBUG :: Preferred patrol altitude for FA-18C_hornet: 23251.56
2021-08-01 20:43:04,260 :: DEBUG :: Preferred patrol altitude for F-16C_50: 25460.52