### PR TITLE
Tweak max-speed-based patrol altitudes

### DIFF
--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -185,13 +185,13 @@ class AircraftType(UnitType[Type[FlyingType]]):
         if self.patrol_altitude:
             return self.patrol_altitude
         else:
-            # Estimate based on max speed
-            # Aircaft with max speed 200 kph will prefer patrol at 5000 ft
-            # Aircraft with max speed 2700 kph will prefer pratrol at 33 000 ft
-            altitude_for_lowest_speed = feet(5 * 100)
+            # Estimate based on max speed.
+            # Aircaft with max speed 600 kph will prefer patrol at 10 000 ft
+            # Aircraft with max speed 2800 kph will prefer pratrol at 33 000 ft
+            altitude_for_lowest_speed = feet(10 * 1000)
             altitude_for_highest_speed = feet(33 * 1000)
-            lowest_speed = kph(200)
-            highest_speed = kph(2700)
+            lowest_speed = kph(600)
+            highest_speed = kph(2800)
             factor = (self.max_speed - lowest_speed).kph / (
                 highest_speed - lowest_speed
             ).kph


### PR DESCRIPTION
Makes them slightly more reasonable.

2021-08-01 23:53:52,637 :: DEBUG :: Preferred patrol altitude for MiG-29A: 29340.90909090909
2021-08-01 23:53:52,639 :: DEBUG :: Preferred patrol altitude for F-4E: 28504.545454545456
2021-08-01 23:53:52,642 :: DEBUG :: Preferred patrol altitude for MiG-21Bis: 29959.818181818177
2021-08-01 23:55:21,104 :: DEBUG :: Preferred patrol altitude for FA-18C_hornet: 24114.890909090907
2021-08-01 23:59:54,530 :: DEBUG :: Preferred patrol altitude for F-16C_50: 25891.32727272727
2021-08-02 00:00:56,515 :: DEBUG :: Preferred patrol altitude for F-15C: 31431.81818181818
2021-08-02 00:01:06,402 :: DEBUG :: Preferred patrol altitude for Su-27: 29863.63636363636
2021-08-02 00:02:04,287 :: DEBUG :: Preferred patrol altitude for L-39ZA: 11706.181818181818
2021-08-02 00:03:59,308 :: DEBUG :: Preferred patrol altitude for P-47D-30bl1: 12383.636363636364
2021-08-02 00:04:04,231 :: DEBUG :: Preferred patrol altitude for P-51D: 11706.181818181818
2021-08-02 00:04:07,668 :: DEBUG :: Preferred patrol altitude for SpitfireLFMkIX: 12383.636363636364