### PR TITLE
Fix text foreground color for dark kneeboard

### DIFF
--- a/gen/kneeboard.py
+++ b/gen/kneeboard.py
@@ -96,10 +96,12 @@ class KneeboardPageWriter:
         self,
         text: str,
         font: Optional[ImageFont.FreeTypeFont] = None,
-        fill: Tuple[int, int, int] = (0, 0, 0),
+        fill: Optional[Tuple[int, int, int]] = None,
     ) -> None:
         if font is None:
             font = self.content_font
+        if fill is None:
+            fill = self.foreground_fill
 
         self.draw.text(self.position, text, font=font, fill=fill)
         width, height = self.draw.textsize(text, font=font)


### PR DESCRIPTION
This PR resolves the second bug (`Night mode does not change the color of the body text`) of issue #1483