### PR TITLE
Don't force helicopters to join, hold and split, kind of

### DIFF
--- a/gen/flights/flightplan.py
+++ b/gen/flights/flightplan.py
@@ -1734,9 +1734,12 @@ class FlightPlanBuilder:
                 self.target_area_waypoint(flight, location, builder)
             )
 
-        hold = builder.hold(self._hold_point(flight))
-        join = builder.join(self.package.waypoints.join)
-        split = builder.split(self.package.waypoints.split)
+        is_helo = flight.unit_type.dcs_unit_type.helicopter
+        ingress=builder.ingress(ingress_type, self.package.waypoints.ingress, location)
+        
+        hold = builder.hold(self._hold_point(flight) if not is_helo else ingress)
+        join = builder.join(self.package.waypoints.join if not is_helo else ingress)
+        split = builder.split(self.package.waypoints.split if not is_helo else ingress)
 
         return StrikeFlightPlan(
             package=self.package,
@@ -1748,9 +1751,7 @@ class FlightPlanBuilder:
                 hold.position, join.position, self.doctrine.ingress_altitude
             ),
             join=join,
-            ingress=builder.ingress(
-                ingress_type, self.package.waypoints.ingress, location
-            ),
+            ingress=ingress,
             targets=target_waypoints,
             split=split,
             nav_from=builder.nav_path(

--- a/gen/flights/flightplan.py
+++ b/gen/flights/flightplan.py
@@ -1735,11 +1735,19 @@ class FlightPlanBuilder:
             )
 
         is_helo = flight.unit_type.dcs_unit_type.helicopter
-        ingress=builder.ingress(ingress_type, self.package.waypoints.ingress, location)
-        
-        hold = builder.hold(self._hold_point(flight) if not is_helo else ingress)
-        join = builder.join(self.package.waypoints.join if not is_helo else ingress)
-        split = builder.split(self.package.waypoints.split if not is_helo else ingress)
+        ingress = builder.ingress(
+            ingress_type, self.package.waypoints.ingress, location
+        )
+
+        hold = builder.hold(
+            self._hold_point(flight) if not is_helo else ingress.position
+        )
+        join = builder.join(
+            self.package.waypoints.join if not is_helo else ingress.position
+        )
+        split = builder.split(
+            self.package.waypoints.split if not is_helo else ingress.position
+        )
 
         return StrikeFlightPlan(
             package=self.package,

--- a/gen/flights/waypointbuilder.py
+++ b/gen/flights/waypointbuilder.py
@@ -168,6 +168,8 @@ class WaypointBuilder:
             position.y,
             meters(500) if self.is_helo else self.doctrine.rendezvous_altitude,
         )
+        if self.is_helo:
+            waypoint.alt_type = "RADIO"
         waypoint.pretty_name = "Hold"
         waypoint.description = "Wait until push time"
         waypoint.name = "HOLD"


### PR DESCRIPTION
This change causes join, hold and split waypoints to all be on the ingress waypoint for helicopters on a BAI (strike) mission.

I don't yet understand how/if this affects the ToT calculations - that is, if something else needs to change for this to work.
However, I think the waypointbuilder change to rejoin AGL for helicopters is a solid improvement.

I guess a more solid path forward would be to just have a SimpleStrikeFlightPlan made specifically for helicopters, and detect `is_helo` in generate_bai. That SimpleStrikeFlightPlan would not contain any joins,, holds or splits.. the helicopters would just go directly to the ingress.