### PR TITLE
Don't always use 2-ship barcap, since it becomes predictable

### DIFF
--- a/game/commander/tasks/primitive/barcap.py
+++ b/game/commander/tasks/primitive/barcap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import random
 
 from game.commander.tasks.packageplanningtask import PackagePlanningTask
 from game.commander.theaterstate import TheaterState
@@ -21,7 +22,15 @@ class PlanBarcap(PackagePlanningTask[ControlPoint]):
         state.barcaps_needed[self.target] -= 1
 
     def propose_flights(self) -> None:
-        self.propose_flight(FlightType.BARCAP, 2)
+        chances = {
+            2: 75,
+            3: 5,
+            4: 20,
+        }
+        num_aircraft = random.choices(
+            list(chances.keys()), weights=list(chances.values())
+        )[0]
+        self.propose_flight(FlightType.BARCAP, num_aircraft)
 
     @property
     def purchase_multiplier(self) -> int:


### PR DESCRIPTION
The whole point of this is not to allocate 4-ships when needed, but rather to make the game less predictable. Obviously it would be better to allocate 4-ships when there's an actual reason, but maybe this adds some spice with a small effort?

Are these commander tasks designed to be re-runnable? If so then maybe this code needs to do the randomization on instantiation of the task rather than the propose_flight function?