### PR TITLE
Improve unit selling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Saves from 4.x are not compatible with 5.0.
 ## Fixes
 
 * **[Campaign]** Naval control points will no longer claim ground objectives during campaign generation and prevent them from spawning.
+* **[UI]** Selling of Units is now visible again in the UI dialog and shows the correct amount of sold units
 
 # 4.1.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Saves from 4.x are not compatible with 5.0.
 * **[Kneeboard]** Minimum required fuel estimates have been added to the kneeboard for aircraft with supporting data (currently only the Hornet).
 * **[Kneeboard]** QNH (pressure MSL) and temperature have been added to the kneeboard.
 * **[New Game Wizard]** Can now customize the player's air wing before campaign start to disable or rename squadrons.
+* **[UI]** Sell Button for aircraft will be disabled if there are no units available to be sold or all are already assigned to a mission
 
 ## Fixes
 

--- a/game/unitdelivery.py
+++ b/game/unitdelivery.py
@@ -40,9 +40,8 @@ class PendingUnitDeliveries:
 
     def sell(self, units: dict[UnitType[Any], int]) -> None:
         for k, v in units.items():
-            if self.units[k] > v:
-                self.units[k] -= v
-            else:
+            self.units[k] -= v
+            if self.units[k] == 0:
                 del self.units[k]
 
     def refund_all(self, coalition: Coalition) -> None:

--- a/qt_ui/windows/basemenu/QRecruitBehaviour.py
+++ b/qt_ui/windows/basemenu/QRecruitBehaviour.py
@@ -80,7 +80,13 @@ class PurchaseGroup(QGroupBox):
 
     def update_state(self) -> None:
         self.buy_button.setEnabled(self.recruiter.enable_purchase(self.unit_type))
+        self.buy_button.setToolTip(
+            self.recruiter.purchase_tooltip(self.buy_button.isEnabled())
+        )
         self.sell_button.setEnabled(self.recruiter.enable_sale(self.unit_type))
+        self.sell_button.setToolTip(
+            self.recruiter.sell_tooltip(self.sell_button.isEnabled())
+        )
         self.amount_bought.setText(f"<b>{self.pending_units}</b>")
 
 
@@ -222,6 +228,18 @@ class QRecruitBehaviour:
 
     def enable_sale(self, unit_type: UnitType) -> bool:
         return True
+
+    def purchase_tooltip(self, is_enabled: bool) -> str:
+        if is_enabled:
+            return "Buy unit. Use Shift or Ctrl key to buy multiple units at once."
+        else:
+            return "Unit can not be bought."
+
+    def sell_tooltip(self, is_enabled: bool) -> str:
+        if is_enabled:
+            return "Sell unit. Use Shift or Ctrl key to buy multiple units at once."
+        else:
+            return "Unit can not be sold."
 
     def info(self, unit_type: UnitType) -> None:
         self.info_window = QUnitInfoWindow(self.game_model.game, unit_type)


### PR DESCRIPTION
fixes #1535 

- Selling of Units is now visible again in the UI dialog and shows the correct amount of sold units (There was an issue i introduced with #1459)
- Sell Button for aircraft will be disabled if there are no units available to be sold or all are already assigned to a mission. Currently i also implemented a tooltip for the sell button to offer some info for the user to not be confused when aircraft can not be sold.

I am not quite sure if the 2nd commit is really necessary or if it should be discarded.