### PR TITLE
Raise helo AGL to 60 m for ingress, egress, cap, escort

### DIFF
--- a/gen/flights/waypointbuilder.py
+++ b/gen/flights/waypointbuilder.py
@@ -213,7 +213,7 @@ class WaypointBuilder:
             ingress_type,
             position.x,
             position.y,
-            meters(50) if self.is_helo else self.doctrine.ingress_altitude,
+            meters(60) if self.is_helo else self.doctrine.ingress_altitude,
         )
         if self.is_helo:
             waypoint.alt_type = "RADIO"
@@ -228,7 +228,7 @@ class WaypointBuilder:
             FlightWaypointType.EGRESS,
             position.x,
             position.y,
-            meters(50) if self.is_helo else self.doctrine.ingress_altitude,
+            meters(60) if self.is_helo else self.doctrine.ingress_altitude,
         )
         if self.is_helo:
             waypoint.alt_type = "RADIO"
@@ -312,7 +312,7 @@ class WaypointBuilder:
             FlightWaypointType.CAS,
             position.x,
             position.y,
-            meters(50) if self.is_helo else meters(1000),
+            meters(60) if self.is_helo else meters(1000),
         )
         waypoint.alt_type = "RADIO"
         waypoint.description = "Provide CAS"
@@ -448,7 +448,7 @@ class WaypointBuilder:
             FlightWaypointType.TARGET_GROUP_LOC,
             target.position.x,
             target.position.y,
-            meters(50) if self.is_helo else self.doctrine.ingress_altitude,
+            meters(60) if self.is_helo else self.doctrine.ingress_altitude,
         )
         if self.is_helo:
             waypoint.alt_type = "RADIO"


### PR DESCRIPTION
Due to claims of occasionally hitting trees when using 50 meters.
Tested during a pretty intense mission, works well so I don't see why not.

I suspect that helicopters will also maintain a more consistent higher ground speed when not flying so low. Seems to be less bobbing back and forth with 60 meters instead of 50 meters. But this is just a feeling. Anyway like I said 60 meters doesn't seem to hurt - I've observed a lengthy mission with apaches and hinds working effectively tasked at 60 meters, on both CAS and BAI.