### PR TITLE
Better TARCAP racetracks

### DIFF
--- a/game/utils.py
+++ b/game/utils.py
@@ -62,6 +62,8 @@ class Distance:
     def __mul__(self, other: Union[float, int]) -> Distance:
         return meters(self.meters * other)
 
+    __rmul__ = __mul__
+
     def __truediv__(self, other: Union[float, int]) -> Distance:
         return meters(self.meters / other)
 
@@ -146,6 +148,8 @@ class Speed:
 
     def __mul__(self, other: Union[float, int]) -> Speed:
         return kph(self.kph * other)
+
+    __rmul__ = __mul__
 
     def __truediv__(self, other: Union[float, int]) -> Speed:
         return kph(self.kph / other)


### PR DESCRIPTION
1. TARCAP racetracks are now shorter. TARCAPs are generally in/near hostile airspace so it's not really a good idea to fly 40 NM (~9 minutes) away from the airspace you are trying to protect for strikers. With this change the TARCAPs in modern doctrine will fly 15-22.5 (~3-5 minutes) NM racetracks. The formula for tarcap max track length is now `min_length + 0.3 * (max_length - min_length)`.
2. Frontline TARCAPs are now treated as normal TARCAPS toward the center of the frontline. It didn't really make sense to fly along the frontline. Doing so typically causes a flight to lose radar coverage in the threat direction, which is a big no-no in CAP flying.
3. Added __rmul__ functions to Speed and Distance so that multiplications can be done in reversed order, for example 0.3 * my_speed_object.

Don't squash.

<img width="477" alt="Screenshot 2021-08-16 at 09 59 06" src="https://user-images.githubusercontent.com/548345/129539932-5ed2d36d-c33a-470a-ade4-49aba4b97e22.png">

<img width="684" alt="Screenshot 2021-08-16 at 10 00 45" src="https://user-images.githubusercontent.com/548345/129539966-6200acc9-cbf5-491d-8c0d-f9d2278cdbf8.png">

