### PR TITLE
Added an option for the JTAC plugin to force the JTAC laser code to 1113

### DIFF
--- a/gen/armor.py
+++ b/gen/armor.py
@@ -143,8 +143,16 @@ class GroundConflictGenerator:
         # Add JTAC
         if self.game.blue.faction.has_jtac:
             n = "JTAC" + str(self.conflict.blue_cp.id) + str(self.conflict.red_cp.id)
-            code: int = self.laser_code_registry.get_next_laser_code()
+            code: int
             freq = self.radio_registry.alloc_uhf()
+
+            # If the option fc3LaserCode is enabled, force all JTAC
+            # laser codes to 1113 to allow lasing for Su-25 Frogfoots and A-10A Warthogs.
+            # Otherwise use 1688 for the first JTAC, 1687 for the second etc.
+            if self.game.settings.plugins["plugins.jtacautolase.fc3LaserCode"]:
+                code = 1113
+            else:
+                code = self.laser_code_registry.get_next_laser_code()
 
             utype = self.game.blue.faction.jtac_unit
             if utype is None:

--- a/resources/plugins/jtacautolase/jtacautolase-config.lua
+++ b/resources/plugins/jtacautolase/jtacautolase-config.lua
@@ -13,6 +13,7 @@ if dcsLiberation then
 
     -- specific options
     local smoke = false
+    local russianLaserCode = false
 
     -- retrieve specific options values
     if dcsLiberation.plugins then
@@ -22,6 +23,9 @@ if dcsLiberation then
             env.info("DCSLiberation|JTACAutolase plugin - dcsLiberation.plugins.jtacautolase")
             smoke = dcsLiberation.plugins.jtacautolase.smoke
             env.info(string.format("DCSLiberation|JTACAutolase plugin - smoke = %s",tostring(smoke)))
+
+            russianLaserCode = dcsLiberation.plugins.jtacautolase.russianLaserCode
+            env.info(string.format("DCSLiberation|JTACAutolase plugin - russianLaserCode = %s",tostring(russianLaserCode)))
         end
     end
     
@@ -29,6 +33,11 @@ if dcsLiberation then
     for _, jtac in pairs(dcsLiberation.JTACs) do
         env.info(string.format("DCSLiberation|JTACAutolase plugin - setting up %s",jtac.dcsUnit))
         if JTACAutoLase then 
+            if russianLaserCode then
+                -- If russianLaserCode is enabled in the plugin configuration, force the JTAC
+                -- laser code to 1113 to allow lasing for Su-25T Frogfoots
+                jtac.laserCode = 1113
+            end
             env.info("DCSLiberation|JTACAutolase plugin - calling JTACAutoLase")
             JTACAutoLase(jtac.dcsUnit, jtac.laserCode, smoke, 'vehicle') 
         end

--- a/resources/plugins/jtacautolase/jtacautolase-config.lua
+++ b/resources/plugins/jtacautolase/jtacautolase-config.lua
@@ -13,7 +13,7 @@ if dcsLiberation then
 
     -- specific options
     local smoke = false
-    local russianLaserCode = false
+    local fc3LaserCode = false
 
     -- retrieve specific options values
     if dcsLiberation.plugins then
@@ -24,8 +24,8 @@ if dcsLiberation then
             smoke = dcsLiberation.plugins.jtacautolase.smoke
             env.info(string.format("DCSLiberation|JTACAutolase plugin - smoke = %s",tostring(smoke)))
 
-            russianLaserCode = dcsLiberation.plugins.jtacautolase.russianLaserCode
-            env.info(string.format("DCSLiberation|JTACAutolase plugin - russianLaserCode = %s",tostring(russianLaserCode)))
+            fc3LaserCode = dcsLiberation.plugins.jtacautolase.fc3LaserCode
+            env.info(string.format("DCSLiberation|JTACAutolase plugin - fc3LaserCode = %s",tostring(fc3LaserCode)))
         end
     end
     
@@ -33,9 +33,9 @@ if dcsLiberation then
     for _, jtac in pairs(dcsLiberation.JTACs) do
         env.info(string.format("DCSLiberation|JTACAutolase plugin - setting up %s",jtac.dcsUnit))
         if JTACAutoLase then 
-            if russianLaserCode then
-                -- If russianLaserCode is enabled in the plugin configuration, force the JTAC
-                -- laser code to 1113 to allow lasing for Su-25T Frogfoots
+            if fc3LaserCode then
+                -- If fc3LaserCode is enabled in the plugin configuration, force the JTAC
+                -- laser code to 1113 to allow lasing for Su-25 Frogfoots and A-10A Warthogs.
                 jtac.laserCode = 1113
             end
             env.info("DCSLiberation|JTACAutolase plugin - calling JTACAutoLase")

--- a/resources/plugins/jtacautolase/plugin.json
+++ b/resources/plugins/jtacautolase/plugin.json
@@ -6,6 +6,11 @@
             "nameInUI": "Use smoke",
             "mnemonic": "smoke",
             "defaultValue": true
+        },
+        {
+            "nameInUI": "Use Russian laser code (1113)",
+            "mnemonic": "russianLaserCode",
+            "defaultValue": false
         }
     ],
     "scriptsWorkOrders": [

--- a/resources/plugins/jtacautolase/plugin.json
+++ b/resources/plugins/jtacautolase/plugin.json
@@ -8,8 +8,8 @@
             "defaultValue": true
         },
         {
-            "nameInUI": "Use Russian laser code (1113)",
-            "mnemonic": "russianLaserCode",
+            "nameInUI": "Use FC3 laser code (1113)",
+            "mnemonic": "fc3LaserCode",
             "defaultValue": false
         }
     ],


### PR DESCRIPTION
Added an option for the JTAC plugin to force the JTAC laser code to 1113 to allow lasing for Su-25T Frogfoots. Resolves #1585