### PR TITLE
Force carrier planes to start at +1s

### DIFF
--- a/gen/flights/flightplan.py
+++ b/gen/flights/flightplan.py
@@ -245,7 +245,9 @@ class FlightPlan:
         if takeoff_time is None:
             return None
 
-        start_time: timedelta = takeoff_time - self.estimate_startup() - self.estimate_ground_ops()
+        start_time: timedelta = (
+            takeoff_time - self.estimate_startup() - self.estimate_ground_ops()
+        )
 
         # In case FP math has given us some barely below zero time, round to
         # zero.


### PR DESCRIPTION
Forces carrier planes with original start_time of zero seconds to have a start time of 1 second. This will prevent them from spawning on the 'sixpack' and functions as a workaround for a DCS problem (deadlock / traffic jam).