### PR TITLE
fix for Type_071 helicopter carrier

### DIFF
--- a/resources/factions/china_2010.json
+++ b/resources/factions/china_2010.json
@@ -75,7 +75,7 @@
     "002 Shandong"
   ],
   "helicopter_carrier": [
-    "Type_071_Amphibious_Transport_Dock"
+    "Type_071"
   ],
   "helicopter_carrier_names": [
     "Kunlun Shan",

--- a/resources/factions/redfor_china_2010.json
+++ b/resources/factions/redfor_china_2010.json
@@ -98,7 +98,7 @@
     "002 Shandong"
   ],
   "helicopter_carrier": [
-    "Type_071_Amphibious_Transport_Dock"
+    "Type_071"
   ],
   "helicopter_carrier_names": [
     "Kunlun Shan",

--- a/resources/factions/redfor_russia_2010.json
+++ b/resources/factions/redfor_russia_2010.json
@@ -97,7 +97,7 @@
     "KUZNECOW"
   ],
   "helicopter_carrier": [
-    "Type_071_Amphibious_Transport_Dock"
+    "Type_071"
   ],
   "helicopter_carrier_names": [
     "Ivan Rogov",


### PR DESCRIPTION
fixed bad name for Type_071 helicopter carrier in factions.
When loading factions you can see an error message caused by the Type_071 
![image](https://user-images.githubusercontent.com/32859499/132326158-9a885daa-4ebf-43a2-8a31-6935a8037203.png)

This is causing the carrier to be "destroyed" and not spawn in the mission
![image](https://user-images.githubusercontent.com/32859499/132327631-b57ae57c-0a41-4563-830d-60f129d9d964.png)
