### PR TITLE
Changed the Mi-24 squadrons of 2 campaigns

### DIFF
--- a/resources/campaigns/black_sea.yaml
+++ b/resources/campaigns/black_sea.yaml
@@ -54,7 +54,7 @@ squadrons:
       secondary: air-to-ground
       aircraft:
         - Mi-24P Hind-F
-        - Mi-24P Hind-E
+        - Mi-24V Hind-E
   # Senaki-Kholki
   23:
     - primary: CAS

--- a/resources/campaigns/mozdok_to_maykop.yaml
+++ b/resources/campaigns/mozdok_to_maykop.yaml
@@ -40,7 +40,7 @@ squadrons:
       secondary: air-to-ground
       aircraft:
         - Mi-24P Hind-F
-        - Mi-24P Hind-E
+        - Mi-24V Hind-E
     - primary: CAS
       secondary: air-to-ground
       aircraft:


### PR DESCRIPTION
Changed the Mi-24 squadrons of 2 campaigns from:
        - Mi-24P Hind-F
        - Mi-24P Hind-E
to:
        - Mi-24P Hind-F
        - Mi-24V Hind-E
fixing a problem which caused Mi-24V no not show up in the campaign.