### PR TITLE
Changed "range" to "max_range" on several aircraft .yaml files

### DIFF
--- a/resources/units/aircraft/F-4E.yaml
+++ b/resources/units/aircraft/F-4E.yaml
@@ -13,7 +13,7 @@ manufacturer: McDonnell Douglas
 origin: USA
 price: 10
 role: Fighter-Bomber
-range: 200
+max_range: 200
 variants:
   F-4E Phantom II: {}
   F-4EJ Kai Phantom II: {}

--- a/resources/units/aircraft/F-5E-3.yaml
+++ b/resources/units/aircraft/F-5E-3.yaml
@@ -21,7 +21,7 @@ manufacturer: Northrop
 origin: USA
 price: 12
 role: Light Fighter
-range: 100
+max_range: 100
 gunfighter: true
 variants:
   F-5E Tiger II: {}

--- a/resources/units/aircraft/M-2000C.yaml
+++ b/resources/units/aircraft/M-2000C.yaml
@@ -12,7 +12,7 @@ manufacturer: Dassault
 origin: France
 price: 17
 role: Multirole Fighter
-range: 400
+max_range: 400
 variants:
   Mirage 2000C: {}
 radios:

--- a/resources/units/aircraft/MiG-21Bis.yaml
+++ b/resources/units/aircraft/MiG-21Bis.yaml
@@ -11,7 +11,7 @@ manufacturer: Mikoyan-Gurevich
 origin: USSR/Russia
 price: 12
 role: Fighter
-range: 200
+max_range: 200
 gunfighter: true
 variants:
   J-7B:

--- a/resources/units/aircraft/MiG-29A.yaml
+++ b/resources/units/aircraft/MiG-29A.yaml
@@ -25,6 +25,6 @@ manufacturer: Mikoyan
 origin: USSR/Russia
 price: 15
 role: Multirole Fighter
-range: 150
+max_range: 150
 variants:
   MiG-29A Fulcrum-A: {}

--- a/resources/units/aircraft/MiG-29G.yaml
+++ b/resources/units/aircraft/MiG-29G.yaml
@@ -25,6 +25,6 @@ manufacturer: Mikoyan
 origin: USSR/Russia
 price: 18
 role: Multirole Fighter
-range: 150
+max_range: 150
 variants:
   MiG-29G Fulcrum-A: {}

--- a/resources/units/aircraft/MiG-29S.yaml
+++ b/resources/units/aircraft/MiG-29S.yaml
@@ -25,6 +25,6 @@ manufacturer: Mikoyan
 origin: USSR/Russia
 price: 19
 role: Multirole Fighter
-range: 150
+max_range: 150
 variants:
   MiG-29S Fulcrum-C: {}

--- a/resources/units/aircraft/Mirage 2000-5.yaml
+++ b/resources/units/aircraft/Mirage 2000-5.yaml
@@ -12,6 +12,6 @@ manufacturer: Dassault
 origin: France
 price: 18
 role: Multirole Fighter
-range: 400
+max_range: 400
 variants:
   Mirage 2000-5: {}

--- a/resources/units/aircraft/Su-17M4.yaml
+++ b/resources/units/aircraft/Su-17M4.yaml
@@ -12,7 +12,7 @@ manufacturer: Sukhoi
 origin: USSR/Russia
 price: 10
 role: Fighter-Bomber
-range: 300
+max_range: 300
 variants:
   Su-17M4 Fitter-K: {}
   Su-22M4 Fitter-K:

--- a/resources/units/aircraft/Su-24M.yaml
+++ b/resources/units/aircraft/Su-24M.yaml
@@ -11,7 +11,7 @@ manufacturer: Sukhoi
 origin: USSR/Russia
 price: 14
 role: Attack
-range: 200
+max_range: 200
 variants:
   Su-24M Fencer-D: {}
   Su-24MK Fencer-D:

--- a/resources/units/aircraft/Su-24MR.yaml
+++ b/resources/units/aircraft/Su-24MR.yaml
@@ -1,4 +1,4 @@
 price: 15
-range: 200
+max_range: 200
 variants:
   Su-24MR: null


### PR DESCRIPTION
Changed "range" to "max_range" on several aircraft .yaml files since that is the key which is actually evaluated in the code.