### PR TITLE
Configurable number of parking slots at airfields

### DIFF
--- a/game/missiongenerator/aircraftgenerator.py
+++ b/game/missiongenerator/aircraftgenerator.py
@@ -272,7 +272,7 @@ class AircraftGenerator:
         start_type: str,
         airfield: Airfield,
     ) -> DcsStartType:
-        if airfield.override_aircraft_parking is not None:
+        if airfield.override_aircraft_parking_enabled:
             # If the campaign designer has defined a custom number of aircraft parking slots,
             # make every aircraft start on runway
             return DcsStartType.Runway
@@ -697,7 +697,7 @@ class AircraftGenerator:
         self, squadron: Squadron, country: Country, faction: Faction
     ) -> None:
         assert isinstance(squadron.location, Airfield)
-        if squadron.location.override_aircraft_parking is None:
+        if squadron.location.override_aircraft_parking_enabled:
             # Stop here if the campaign designer has defined a custom number of aircraft parking slots
             # since it's possible there are more unused aircraft at the airfield than actual parking slots
             return

--- a/game/missiongenerator/aircraftgenerator.py
+++ b/game/missiongenerator/aircraftgenerator.py
@@ -268,6 +268,18 @@ class AircraftGenerator:
         return DcsStartType.Warm
 
     @staticmethod
+    def _start_type_at_airfield(
+        start_type: str,
+        airfield: Airfield,
+    ) -> DcsStartType:
+        if airfield.override_aircraft_parking is not None:
+            # If the campaign designer has defined a custom number of aircraft parking slots,
+            # make every aircraft start on runway
+            return DcsStartType.Runway
+        else:
+            return AircraftGenerator._start_type(start_type)
+
+    @staticmethod
     def _start_type_at_group(
         start_type: str,
         unit_type: Type[FlyingType],
@@ -469,25 +481,27 @@ class AircraftGenerator:
                 )
             )
 
-    def _generate_at_airport(
+    def _generate_at_airfield(
         self,
         name: str,
         side: Country,
         unit_type: Type[FlyingType],
         count: int,
         start_type: str,
-        airport: Airport,
+        airfield: Airfield,
     ) -> FlyingGroup[Any]:
         assert count > 0
 
-        logging.info("airgen: {} for {} at {}".format(unit_type, side.id, airport))
+        logging.info(
+            "airgen: {} for {} at {}".format(unit_type, side.id, airfield.airport)
+        )
         return self.m.flight_group_from_airport(
             country=side,
             name=name,
             aircraft_type=unit_type,
-            airport=airport,
+            airport=airfield.airport,
             maintask=None,
-            start_type=self._start_type(start_type),
+            start_type=self._start_type_at_airfield(start_type, airfield),
             group_size=count,
             parking_slots=None,
         )
@@ -683,6 +697,10 @@ class AircraftGenerator:
         self, squadron: Squadron, country: Country, faction: Faction
     ) -> None:
         assert isinstance(squadron.location, Airfield)
+        if squadron.location.override_aircraft_parking is None:
+            # Stop here if the campaign designer has defined a custom number of aircraft parking slots
+            # since it's possible there are more unused aircraft at the airfield than actual parking slots
+            return
         for _ in range(squadron.untasked_aircraft):
             # Creating a flight even those this isn't a fragged mission lets us
             # reuse the existing debriefing code.
@@ -697,13 +715,13 @@ class AircraftGenerator:
                 divert=None,
             )
 
-            group = self._generate_at_airport(
+            group = self._generate_at_airfield(
                 name=namegen.next_aircraft_name(country, flight.departure.id, flight),
                 side=country,
                 unit_type=squadron.aircraft.dcs_unit_type,
                 count=1,
                 start_type="Cold",
-                airport=squadron.location.airport,
+                airfield=squadron.location,
             )
 
             self._setup_livery(flight, group)
@@ -798,13 +816,13 @@ class AircraftGenerator:
                     raise RuntimeError(
                         f"Attempted to spawn at airfield for non-airfield {cp}"
                     )
-                return self._generate_at_airport(
+                return self._generate_at_airfield(
                     name=name,
                     side=country,
                     unit_type=flight.unit_type.dcs_unit_type,
                     count=flight.count,
                     start_type=start_type.value,
-                    airport=cp.airport,
+                    airfield=cp,
                 )
         except NoParkingSlotError:
             # Generated when there is no place on Runway or on Parking Slots

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -289,6 +289,8 @@ class ControlPoint(MissionTarget, ABC):
 
     alt = 0
 
+    override_aircraft_parking: int
+
     # TODO: Only airbases have IDs.
     # TODO: has_frontline is only reasonable for airbases.
     # TODO: cptype is obsolete.
@@ -321,6 +323,9 @@ class ControlPoint(MissionTarget, ABC):
         self.shipping_lanes: Dict[ControlPoint, Tuple[Point, ...]] = {}
         self.base: Base = Base()
         self.cptype = cptype
+
+        self.override_aircraft_parking = None
+
         # TODO: Should be Airbase specific.
         self.stances: Dict[int, CombatStance] = {}
         from ..groundunitorders import GroundUnitOrders
@@ -690,7 +695,10 @@ class ControlPoint(MissionTarget, ABC):
         ...
 
     def unclaimed_parking(self) -> int:
-        return self.total_aircraft_parking - self.allocated_aircraft().total
+        if self.override_aircraft_parking is not None:
+            return self.override_aircraft_parking - self.allocated_aircraft().total
+        else:
+            return self.total_aircraft_parking - self.allocated_aircraft().total
 
     @abstractmethod
     def active_runway(
@@ -918,7 +926,10 @@ class Airfield(ControlPoint):
         Note : additional helipads shouldn't contribute to this score as it could allow airfield
         to buy more planes than what they are able to host
         """
-        return len(self.airport.parking_slots)
+        if self.override_aircraft_parking is not None:
+            return self.override_aircraft_parking
+        else:
+            return len(self.airport.parking_slots)
 
     @property
     def heading(self) -> Heading:


### PR DESCRIPTION
Added campaign designers a possibility to configure the number of parking slots at airfields by (optionally) defining "override_aircraft_parking" in the campaign yaml (for each airfield separately). This will override the actual number of parking slots in DCS, so doing so will make all aircraft at the airfield start on runway.

This is intended to increase the operational feasibility of certain airfields in campaigns. For example, Jiroft in the Persian Gulf (Iran interior) only has three parking slots.