### PR TITLE
Campaigns updated to 9.1

### DIFF
--- a/resources/campaigns/exercise_vegas_nerve.yaml
+++ b/resources/campaigns/exercise_vegas_nerve.yaml
@@ -7,7 +7,8 @@ recommended_enemy_faction: Redfor (China) 2010
 description: <p>This is an asymmetrical Red Flag Exercise scenario for the NTTR comprising 4 control points. You start off in control of the two Tonopah airports, and will push south to capture Groom Lake and Nellis AFBs. Taking down Nellis AFB's IADS and striking their resource sites ASAP once Groom Lake has been captured is recommended to offset their substantial resource advantage.</p>
 miz: exercise_vegas_nerve.miz
 performance: 1
-version: "9.0"
+recommended_start_date: 2011-04-24
+version: "9.1"
 squadrons:
 # Tonopah Airport
   17:
@@ -24,14 +25,17 @@ squadrons:
         - E-3A
     - primary: Refueling
       aircraft:
+        - KC-135 Stratotanker
+    - primary: Refueling
+      aircraft:
         - KC-135 Stratotanker MPRS
     - primary: Transport
       aircraft:
-        - CH-47D
+        - C-130
     - primary: Strike
       secondary: air-to-ground
       aircraft:
-        - F-15E Strike Eagle      
+        - F-15E Strike Eagle
 # Tonopah Test Range
   18:
     - primary: CAS
@@ -53,43 +57,23 @@ squadrons:
 # Groom Lake
   2:
     - primary: BARCAP
-      secondary: air-to-air
-      aircraft:
-        - J-11A Flanker-L
-    - primary: CAS
-      secondary: air-to-ground
-      aircraft:
-        - Su-25T Frogfoot
-    - primary: DEAD
       secondary: any
       aircraft:
-        - Su-30MKK Flanker-G
+        - J-11A Flanker-L
     - primary: BAI
       secondary: air-to-ground
       aircraft:
         - Su-34 Fullback
 # Nellis AFB
   4:
-    - primary: TARCAP
+    - primary: DEAD
       secondary: any
       aircraft:
-        - J-15 Flanker X-2
-    - primary: BARCAP
-      secondary: any
-      aircraft:
-        - MiG-29S Fulcrum-C
-    - primary: SEAD
-      secondary: any
-      aircraft:
-        - FC-1 Fierce Dragon
+        - Su-30MKK Flanker-G
     - primary: Strike
       secondary: air-to-ground
       aircraft:
-        - Su-24M Fencer-D
-    - primary: Strike
-      secondary: air-to-ground
-      aircraft:
-        - Tu-22M3 Backfire-C
+        - H-6J Badger
     - primary: AEW&C
       aircraft:
         - KJ-2000
@@ -98,4 +82,4 @@ squadrons:
         - IL-78M
     - primary: Transport
       aircraft:
-        - Mi-8MTV2 Hip
+        - IL-76MD

--- a/resources/campaigns/operation_peace_spring.yaml
+++ b/resources/campaigns/operation_peace_spring.yaml
@@ -3,11 +3,12 @@ name: Syria - Operation Peace Spring
 theater: Syria
 authors: Starfire
 recommended_player_faction: Bluefor Modern
-recommended_enemy_faction: Turkey 2005
-description: <p>This is a semi-fictional what-if scenario for Operation Peace Spring, during which Turkish forces that crossed into Syria on an offensive against Kurdish militias were emboldened by early successes to continue pushing further southward. Attempts to broker a ceasefire have failed. Members of Operation Inherent Resolve have gathered at Ramat David Airbase in Israel to launch a counter-offensive.</p><p><strong>Note:</strong> While Turkey 2005 is the default faction for historical reasons, the OPFOR squadron complement in this campaign scenario has also been specifically customised to work just as well with the Iraq 1991 faction in order to provide an opponent with a wide variety of units.</p>
+recommended_enemy_faction: Iraq 1991
+description: <p>This is a semi-fictional what-if scenario for Operation Peace Spring, during which Turkish forces that crossed into Syria on an offensive against Kurdish militias were emboldened by early successes to continue pushing further southward. Attempts to broker a ceasefire have failed. Members of Operation Inherent Resolve have gathered at Ramat David Airbase in Israel to launch a counter-offensive.</p><p><strong>Note:</strong> The default faction is set as Iraq 1991 in order to provide an opponent with a wider variety of units. While Turkey 2005 would be the historical faction, you would be facing nothing in the air except F-4 Phantoms.</p>
 miz: operation_peace_spring.miz
 performance: 1
-version: "9.0"
+recommended_start_date: 2019-12-23
+version: "9.1"
 squadrons:
 # Ramat David
   30:
@@ -64,7 +65,10 @@ squadrons:
         - B-52H Stratofortress
     - primary: AEW&C
       aircraft:
-        - E-2C Hawkeye
+        - E-3A
+    - primary: Refueling
+      aircraft:
+        - KC-135 Stratotanker
     - primary: Refueling
       aircraft:
         - KC-135 Stratotanker MPRS
@@ -77,60 +81,60 @@ squadrons:
       secondary: any
       aircraft:
         - F-4E Phantom II
-        - MiG-21bis Fishbed-N        
+        - MiG-21bis Fishbed-N
+    - primary: CAS
+      secondary: air-to-ground
+      aircraft:
+        - AH-1W SuperCobra
+        - Su-25 Frogfoot
 # Tiyas
   39:
-    - primary: TARCAP
-      secondary: any
-      aircraft:
-        - F-16CM Fighting Falcon (Block 50)
-        - MiG-23ML Flogger-G
     - primary: SEAD
       secondary: air-to-ground
       aircraft:
         - F-16CM Fighting Falcon (Block 50)
         - Su-24M Fencer-D
-    - primary: CAS
-      secondary: air-to-ground
-      aircraft:
-        - AH-1W SuperCobra
-        - Su-25T Frogfoot
-        - Su-25 Frogfoot
     - primary: Transport
+      secondary: any
       aircraft:
         - UH-60A
         - Mi-8MTV2 Hip
 # Abu Al Duhur
 #  1:
 # Gaziantep
-#  11:
+  11:
+    - primary: CAS
+      secondary: air-to-ground
+      aircraft:
+        - OH-58D Kiowa Warrior
+        - Mi-24P Hind-F
 # Incirlik
   16:
-    - primary: BARCAP
+    - primary: TARCAP
       secondary: any
       aircraft:
-            - F-16CM Fighting Falcon (Block 50)
-            - MiG-29A Fulcrum-A
+        - F-16CM Fighting Falcon (Block 50)
+        - MiG-29A Fulcrum-A
     - primary: Strike
       secondary: air-to-ground
       aircraft:
         - F-4E Phantom II
         - Tu-22M3 Backfire-C
-    - primary: CAS
+    - primary: BAI
       secondary: air-to-ground
       aircraft:
-        - AH-1W SuperCobra
-        - Su-22M4 Fitter-K
+        - F-4E Phantom II
+        - H-6J Badger
     - primary: AEW&C
       aircraft:
         - E-3A
         - A-50
     - primary: Refueling
       aircraft:
-        - KC-135 Stratotanker MPRS
         - KC-135 Stratotanker
         - IL-78M
     - primary: Transport
       aircraft:
         - C-130
         - IL-76MD
+        

--- a/resources/campaigns/operation_vectrons_claw.yaml
+++ b/resources/campaigns/operation_vectrons_claw.yaml
@@ -7,11 +7,12 @@ recommended_enemy_faction: Russia 1990
 description: <p>United Nations Observer Mission in Georgia (UNOMIG) observers stationed in Georgia to monitor the ceasefire between Georgia and Abkhazia have been cut off from friendly forces by Russian troops backing the separatist state. The UNOMIG HQ at Sukhumi has been taken, and a small contingent of observers and troops at the Zugdidi Sector HQ will have to make a run for the coast, supported by offshore US naval aircraft. The contingent is aware that their best shot at survival is to swiftly retake Sukhumi before Russian forces have a chance to dig in, so that friendly ground forces can land and reinforce them.</p><p><strong>Note:</strong> Ground unit purchase will not be available past Turn 0 until Sukhumi is retaken, so it is imperative you reach Sukhumi with at least one surviving ground unit to capture it. Two Hueys are available at Zugdidi for some close air support. The player can either play the first leg of the scenario as an evacuation with a couple of light vehicles (e.g. Humvees) set on breakthrough (modifying waypoints in the mission editor so they are not charging head-on into enemy ground forces is suggested), or purchase heavier ground units if they wish to experience a more traditional frontline ground war. Once Sukhumi has been captured, squadrons based in Incirlik Turkey can be ferried in via the "From Incirlik" off-map spawn point.</p>
 miz: operation_vectrons_claw.miz
 performance: 1
-version: "9.0"
+recommended_start_date: 2008-08-08
+version: "9.1"
 squadrons:
   Blue CV:
     - primary: BARCAP
-      secondary: air-to-air
+      secondary: any
       aircraft:
         - F-14B Tomcat
         - F-14A Tomcat (Block 135-GR Late)
@@ -24,7 +25,7 @@ squadrons:
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-    - primary: BAI
+    - primary: DEAD
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
@@ -64,7 +65,7 @@ squadrons:
         - E-3A
     - primary: Refueling
       aircraft:
-        - KC-135 Stratotanker MPRS
+        - KC-135 Stratotanker
     - primary: Transport
       aircraft:
         - C-130
@@ -87,28 +88,16 @@ squadrons:
       secondary: any
       aircraft:
        - MiG-29S Fulcrum-C
-    - primary: BAI
-      secondary: air-to-ground
-      aircraft:
-        - Su-25T Frogfoot
     - primary: CAS
       secondary: air-to-ground
       aircraft:
-        - Ka-50 Hokum
+        - Su-24M Fencer-D
 #Anapa-Vityazevo
   12:
-    - primary: BARCAP
-      secondary: any
-      aircraft:
-        - Su-27 Flanker-B
-    - primary: SEAD
+    - primary: CAS
       secondary: air-to-ground
       aircraft:
-        - Su-24M Fencer-D
-    - primary: Strike
-      secondary: air-to-ground
-      aircraft:
-        - Tu-22M3 Backfire-C
+        - Su-25T Frogfoot
     - primary: AEW&C
       aircraft:
         - A-50
@@ -123,8 +112,9 @@ squadrons:
       secondary: any
       aircraft:
         - SU-33 Flanker-D
+ # I am aware there is no Russian LHA. This is just for campaign inversion.
   Red LHA:
     - primary: BAI
       secondary: air-to-ground
       aircraft:
-        - Mi-8MTV2 Hip
+        - AV-8B Harrier II Night Attack


### PR DESCRIPTION
Peace Spring, Vectron's Claw, and Vegas Nerve have been updated to 9.1. Squadrons have also been completely overhauled to work much better, so there should no longer be a whole bunch of OPFOR squadrons that are never used.