### PR TITLE
Tu 142 support

### DIFF
--- a/gen/flights/ai_flight_planner_db.py
+++ b/gen/flights/ai_flight_planner_db.py
@@ -101,6 +101,7 @@ from dcs.planes import (
     Tu_160,
     Tu_22M3,
     Tu_95MS,
+    Tu_142,
     WingLoong_I,
     I_16,
     Yak_40,
@@ -360,6 +361,7 @@ STRIKE_CAPABLE = [
 
 ANTISHIP_CAPABLE = [
     AJS37,
+    Tu_142,
     Tu_22M3,
     H_6J,
     FA_18C_hornet,

--- a/resources/campaigns/marianas_guam_barrigada.yaml
+++ b/resources/campaigns/marianas_guam_barrigada.yaml
@@ -59,10 +59,15 @@ squadrons:
       secondary: air-to-air
     - primary: Strike
       secondary: any
+    - primary: Anti-ship
+      secondary: any
     - primary: BAI
       secondary: any
     - primary: CAS
       secondary: air-to-ground
+    - primary: AEW&C
+    - primary: Refueling
+    - primary: Transport
   # Antonio B. Won Pat Intl
   4:
     - primary: BARCAP
@@ -70,6 +75,8 @@ squadrons:
     - primary: BARCAP
       secondary: air-to-air
     - primary: Strike
+      secondary: any
+    - primary: Anti-ship
       secondary: any
     - primary: BAI
       secondary: any

--- a/resources/campaigns/marianas_guam_landing_at_agat.yaml
+++ b/resources/campaigns/marianas_guam_landing_at_agat.yaml
@@ -59,10 +59,15 @@ squadrons:
       secondary: air-to-air
     - primary: Strike
       secondary: any
+    - primary: Anti-ship
+      secondary: any
     - primary: BAI
       secondary: any
     - primary: CAS
       secondary: air-to-ground
+    - primary: AEW&C
+    - primary: Refueling
+    - primary: Transport
   # Antonio B. Won Pat Intl
   4:
     - primary: BARCAP
@@ -70,6 +75,8 @@ squadrons:
     - primary: BARCAP
       secondary: air-to-air
     - primary: Strike
+      secondary: any
+    - primary: Anti-ship
       secondary: any
     - primary: BAI
       secondary: any


### PR DESCRIPTION
Added Tu_142 to ANTISHIP_CAPABLE in ai_flight_planner_db.py, enabling its use in Liberation campaigns (it only has anti-ship capable weapons in DCS so this is the only applicable mission type). Also added Anti-ship (and other missing) squadrons to Marianas campaigns to allow Tu-142 squadrons to spawn. Resolves #1683