### PR TITLE
Enabled unrestricted_satnav with some non-US factions

### DIFF
--- a/resources/factions/Israel-USN_2005_Allied_Sword.json
+++ b/resources/factions/Israel-USN_2005_Allied_Sword.json
@@ -107,5 +107,6 @@
     "UH-1H Iroquois": [
       "US NAVY"
     ]
-  }
+  },
+  "unrestricted_satnav": true
 }

--- a/resources/factions/australia_2005.json
+++ b/resources/factions/australia_2005.json
@@ -66,5 +66,6 @@
       "Australian 75th Squadron",
       "Australian 77th Squadron"
     ]
-  }
+  },
+  "unrestricted_satnav": true
 }

--- a/resources/factions/canada_2005.json
+++ b/resources/factions/canada_2005.json
@@ -71,5 +71,6 @@
     "C-130J-30 Super Hercules": [
       "Royal Canadian AF CC-130J"
     ]
-  }
+  },
+  "unrestricted_satnav": true
 }

--- a/resources/factions/greece_2005.json
+++ b/resources/factions/greece_2005.json
@@ -59,5 +59,6 @@
     "LaCombattanteIIGroupGenerator"
   ],
   "has_jtac": true,
-  "jtac_unit": "MQ-9 Reaper"
+  "jtac_unit": "MQ-9 Reaper",
+  "unrestricted_satnav": true
 }

--- a/resources/factions/israel_2000.json
+++ b/resources/factions/israel_2000.json
@@ -63,5 +63,6 @@
     "ArleighBurkeGroupGenerator"
   ],
   "has_jtac": true,
-  "jtac_unit": "MQ-9 Reaper"
+  "jtac_unit": "MQ-9 Reaper",
+  "unrestricted_satnav": true
 }

--- a/resources/factions/israel_2012.json
+++ b/resources/factions/israel_2012.json
@@ -93,5 +93,6 @@
     "Mirage 2000C": [
       "UAE Air Force"
     ]
-  }
+  },
+  "unrestricted_satnav": true
 }

--- a/resources/factions/netherlands_1990.json
+++ b/resources/factions/netherlands_1990.json
@@ -55,5 +55,6 @@
     "OliverHazardPerryGroupGenerator"
   ],
   "has_jtac": true,
-  "jtac_unit": "MQ-9 Reaper"
+  "jtac_unit": "MQ-9 Reaper",
+  "unrestricted_satnav": true
 }

--- a/resources/factions/poland_2010.json
+++ b/resources/factions/poland_2010.json
@@ -59,5 +59,6 @@
   "navy_generators": [
     "MolniyaGroupGenerator",
     "OliverHazardPerryGroupGenerator"
-  ]
+  ],
+  "unrestricted_satnav": true
 }

--- a/resources/factions/turkey_2005.json
+++ b/resources/factions/turkey_2005.json
@@ -59,5 +59,6 @@
     "OliverHazardPerryGroupGenerator"
   ],
   "has_jtac": true,
-  "jtac_unit": "MQ-9 Reaper"
+  "jtac_unit": "MQ-9 Reaper",
+  "unrestricted_satnav": true
 }

--- a/resources/factions/uae_2005.json
+++ b/resources/factions/uae_2005.json
@@ -44,5 +44,6 @@
     "OliverHazardPerryGroupGenerator"
   ],
   "has_jtac": true,
-  "jtac_unit": "WingLoong-I"
+  "jtac_unit": "WingLoong-I",
+  "unrestricted_satnav": true
 }

--- a/resources/factions/uae_2015.json
+++ b/resources/factions/uae_2015.json
@@ -49,5 +49,6 @@
     "OliverHazardPerryGroupGenerator"
   ],
   "has_jtac": true,
-  "jtac_unit": "WingLoong-I"
+  "jtac_unit": "WingLoong-I",
+  "unrestricted_satnav": true
 }


### PR DESCRIPTION
Enabled unrestricted_satnav with non-US factions operating either the F-16CM or the F/A-18C to allow the use of GPS in missions.