### PR TITLE
Carrier type selection

### DIFF
--- a/game/campaignloader/__init__.py
+++ b/game/campaignloader/__init__.py
@@ -1,2 +1,3 @@
 from .campaign import Campaign
 from .campaignairwingconfig import CampaignAirWingConfig, SquadronConfig
+from .campaigncarrierconfig import CampaignCarrierConfig, CarrierConfig

--- a/game/campaignloader/campaign.py
+++ b/game/campaignloader/campaign.py
@@ -137,7 +137,6 @@ class Campaign:
         try:
             carrier_data = self.data["carriers"]
         except KeyError:
-            logging.warning(f"Campaign {self.name} does not define any carriers")
             return CampaignCarrierConfig({})
         return CampaignCarrierConfig.from_campaign_data(carrier_data, theater)
 

--- a/game/campaignloader/campaign.py
+++ b/game/campaignloader/campaign.py
@@ -135,11 +135,11 @@ class Campaign:
 
     def load_carrier_config(self, theater: ConflictTheater) -> CampaignCarrierConfig:
         try:
-            squadron_data = self.data["carriers"]
+            carrier_data = self.data["carriers"]
         except KeyError:
             logging.warning(f"Campaign {self.name} does not define any carriers")
             return CampaignCarrierConfig({})
-        return CampaignCarrierConfig.from_campaign_data(squadron_data, theater)
+        return CampaignCarrierConfig.from_campaign_data(carrier_data, theater)
 
     @property
     def is_out_of_date(self) -> bool:

--- a/game/campaignloader/campaign.py
+++ b/game/campaignloader/campaign.py
@@ -23,6 +23,7 @@ from game.theater import (
     TheChannelTheater,
 )
 from game.version import CAMPAIGN_FORMAT_VERSION
+from .campaigncarrierconfig import CampaignCarrierConfig
 from .campaignairwingconfig import CampaignAirWingConfig
 from .mizcampaignloader import MizCampaignLoader
 from .. import persistency
@@ -131,6 +132,14 @@ class Campaign:
             logging.warning(f"Campaign {self.name} does not define any squadrons")
             return CampaignAirWingConfig({})
         return CampaignAirWingConfig.from_campaign_data(squadron_data, theater)
+
+    def load_carrier_config(self, theater: ConflictTheater) -> CampaignCarrierConfig:
+        try:
+            squadron_data = self.data["carriers"]
+        except KeyError:
+            logging.warning(f"Campaign {self.name} does not define any carriers")
+            return CampaignCarrierConfig({})
+        return CampaignCarrierConfig.from_campaign_data(squadron_data, theater)
 
     @property
     def is_out_of_date(self) -> bool:

--- a/game/campaignloader/campaigncarrierconfig.py
+++ b/game/campaignloader/campaigncarrierconfig.py
@@ -7,7 +7,7 @@ from typing import Any, TYPE_CHECKING, Union
 
 from dcs.unittype import ShipType
 
-from game.ato.flighttype import FlightType
+from game.db import ship_type_from_name
 from game.theater.controlpoint import ControlPoint
 
 if TYPE_CHECKING:
@@ -17,16 +17,12 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class CarrierConfig:
     preferred_name: str
-    preferred_type: ShipType
-
-    @property
-    def auto_assignable(self) -> set[FlightType]:
-        return set(self.secondary) | {self.primary}
+    preferred_type: Type[ShipType]
 
     @classmethod
     def from_data(cls, data: dict[str, Any]) -> CarrierConfig:
         return CarrierConfig(
-            str(data["preferred_name"]), ShipType.named(data["preferred_type"])
+            str(data["preferred_name"]), ship_type_from_name(data["preferred_type"])
         )
 
 
@@ -40,17 +36,15 @@ class CampaignCarrierConfig:
     ) -> CampaignCarrierConfig:
         by_location: dict[ControlPoint, CarrierConfig] = defaultdict(CarrierConfig)
         print(data)
-        for base_id in data.items():
+        for base_id, carrier_configs in data.items():
             if isinstance(base_id, int):
                 base = theater.find_control_point_by_id(base_id)
             else:
                 base = theater.control_point_named(base_id)
 
-            carrier_config = CarrierConfig.from_data(data.items())
+            carrier_config = CarrierConfig.from_data(carrier_configs)
             base.preferred_name = carrier_config.preferred_name
-            print("Set preferred name as " + base.preferred_name)
             base.preferred_type = carrier_config.preferred_type
-            print("Set preferred type as " + base.preferred_type)
             by_location[base] = carrier_config
             # for carrier_data in carrier_configs:
             #    CarrierConfig.from_data(squadron_data)

--- a/game/campaignloader/campaigncarrierconfig.py
+++ b/game/campaignloader/campaigncarrierconfig.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union, Type
 
 from dcs.unittype import ShipType
 
@@ -34,7 +34,7 @@ class CampaignCarrierConfig:
     def from_campaign_data(
         cls, data: dict[Union[str, int], Any], theater: ConflictTheater
     ) -> CampaignCarrierConfig:
-        by_location: dict[ControlPoint, CarrierConfig] = defaultdict(CarrierConfig)
+        by_location: dict[ControlPoint, CarrierConfig] = defaultdict()
         print(data)
         for base_id, carrier_configs in data.items():
             if isinstance(base_id, int):

--- a/game/campaignloader/campaigncarrierconfig.py
+++ b/game/campaignloader/campaigncarrierconfig.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING, Union
+
+from dcs.unittype import ShipType
+
+from game.ato.flighttype import FlightType
+from game.theater.controlpoint import ControlPoint
+
+if TYPE_CHECKING:
+    from game.theater import ConflictTheater
+
+
+@dataclass(frozen=True)
+class CarrierConfig:
+    preferred_name: str
+    preferred_type: ShipType
+
+    @property
+    def auto_assignable(self) -> set[FlightType]:
+        return set(self.secondary) | {self.primary}
+
+    @classmethod
+    def from_data(cls, data: dict[str, Any]) -> CarrierConfig:
+        return CarrierConfig(
+            str(data["preferred_name"]), ShipType.named(data["preferred_type"])
+        )
+
+
+@dataclass(frozen=True)
+class CampaignCarrierConfig:
+    by_location: dict[ControlPoint, CarrierConfig]
+
+    @classmethod
+    def from_campaign_data(
+        cls, data: dict[Union[str, int], Any], theater: ConflictTheater
+    ) -> CampaignCarrierConfig:
+        by_location: dict[ControlPoint, CarrierConfig] = defaultdict(CarrierConfig)
+        print(data)
+        for base_id in data.items():
+            if isinstance(base_id, int):
+                base = theater.find_control_point_by_id(base_id)
+            else:
+                base = theater.control_point_named(base_id)
+
+            carrier_config = CarrierConfig.from_data(data.items())
+            base.preferred_name = carrier_config.preferred_name
+            print("Set preferred name as " + base.preferred_name)
+            base.preferred_type = carrier_config.preferred_type
+            print("Set preferred type as " + base.preferred_type)
+            by_location[base] = carrier_config
+            # for carrier_data in carrier_configs:
+            #    CarrierConfig.from_data(squadron_data)
+            #    by_location[base].preferred_name = carrier_configs
+
+        return CampaignCarrierConfig(by_location)

--- a/game/campaignloader/campaigncarrierconfig.py
+++ b/game/campaignloader/campaigncarrierconfig.py
@@ -36,18 +36,15 @@ class CampaignCarrierConfig:
     ) -> CampaignCarrierConfig:
         by_location: dict[ControlPoint, CarrierConfig] = defaultdict()
         print(data)
-        for base_id, carrier_configs in data.items():
+        for base_id, carrier_config_data in data.items():
             if isinstance(base_id, int):
                 base = theater.find_control_point_by_id(base_id)
             else:
                 base = theater.control_point_named(base_id)
 
-            carrier_config = CarrierConfig.from_data(carrier_configs)
+            carrier_config = CarrierConfig.from_data(carrier_config_data)
             base.preferred_name = carrier_config.preferred_name
             base.preferred_type = carrier_config.preferred_type
             by_location[base] = carrier_config
-            # for carrier_data in carrier_configs:
-            #    CarrierConfig.from_data(squadron_data)
-            #    by_location[base].preferred_name = carrier_configs
 
         return CampaignCarrierConfig(by_location)

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Type, List, Any, Iterator, TYPE_CHECKING
 
@@ -84,13 +85,10 @@ class Faction:
     requirements: Dict[str, str] = field(default_factory=dict)
 
     # possible aircraft carrier units
-    aircraft_carrier: List[Type[ShipType]] = field(default_factory=list)
+    carriers: Dict[Type[ShipType], List[str]] = field(default_factory=dict)
 
     # possible helicopter carrier units
     helicopter_carrier: List[Type[ShipType]] = field(default_factory=list)
-
-    # Possible carrier names
-    carrier_names: List[str] = field(default_factory=list)
 
     # Possible helicopter carrier names
     helicopter_carrier_names: List[str] = field(default_factory=list)
@@ -195,10 +193,22 @@ class Faction:
         faction.coastal_defenses = json.get("coastal_defenses", [])
         faction.requirements = json.get("requirements", {})
 
-        faction.carrier_names = json.get("carrier_names", [])
+        # First try to load the carriers in the new format which
+        # specifies different names for different carrier types
+        loaded_carriers = load_carriers(json)
+        if not loaded_carriers:
+            # If there's no carriers element in the faction file,
+            # fall back to the previous type with separate aircraft_carrier and carrier_names
+            carrier_names = json.get("carrier_names", [])
+            aircraft_carrier = load_all_ships(json.get("aircraft_carrier", []))
+            for carrier_shiptype in aircraft_carrier:
+                shiptype = carrier_shiptype
+                faction.carriers[shiptype] = carrier_names
+        else:
+            faction.carriers = loaded_carriers
+
         faction.helicopter_carrier_names = json.get("helicopter_carrier_names", [])
         faction.navy_generators = json.get("navy_generators", [])
-        faction.aircraft_carrier = load_all_ships(json.get("aircraft_carrier", []))
         faction.helicopter_carrier = load_all_ships(json.get("helicopter_carrier", []))
         faction.destroyers = load_all_ships(json.get("destroyers", []))
         faction.cruisers = load_all_ships(json.get("cruisers", []))
@@ -355,4 +365,15 @@ def load_all_ships(data: list[str]) -> List[Type[ShipType]]:
         item = load_ship(name)
         if item is not None:
             items.append(item)
+    return items
+
+
+def load_carriers(json: Dict[str, Any]) -> Dict[Type[ShipType], List[str]]:
+    # Load carriers
+    items: Dict[Type[ShipType], List[str]] = defaultdict(List[str])
+    carriers = json.get("carriers", {})
+    for carrier_shiptype, shipname in carriers.items():
+        shiptype = load_ship(carrier_shiptype)
+        items[shiptype] = shipname
+
     return items

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -374,6 +374,7 @@ def load_carriers(json: Dict[str, Any]) -> Dict[Type[ShipType], List[str]]:
     carriers = json.get("carriers", {})
     for carrier_shiptype, shipname in carriers.items():
         shiptype = load_ship(carrier_shiptype)
-        items[shiptype] = shipname
+        if shiptype is not None:
+            items[shiptype] = shipname
 
     return items

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -33,7 +33,7 @@ from dcs.ships import (
 )
 from dcs.terrain.terrain import Airport, ParkingSlot
 from dcs.unit import Unit
-from dcs.unittype import FlyingType
+from dcs.unittype import FlyingType, ShipType
 
 from game import db
 from game.point_with_heading import PointWithHeading
@@ -286,6 +286,10 @@ class ControlPoint(MissionTarget, ABC):
     name = None  # type: str
 
     has_frontline = True
+
+    # Preferred carrier type and name, if any
+    preferred_type = None
+    preferred_name = None
 
     alt = 0
 

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -21,6 +21,7 @@ from typing import (
     Sequence,
     Iterable,
     Tuple,
+    Type,
 )
 
 from dcs.mapping import Point
@@ -288,8 +289,8 @@ class ControlPoint(MissionTarget, ABC):
     has_frontline = True
 
     # Preferred carrier type and name, if any
-    preferred_type = None
-    preferred_name = None
+    preferred_name: Optional[str] = None
+    preferred_type: Optional[Type[ShipType]] = None
 
     alt = 0
 

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -229,6 +229,8 @@ class CarrierGroundObjectGenerator(ControlPointGroundObjectGenerator):
         self.control_point.connected_objectives.append(g)
 
         # If the campaign designer has specified a preferred name, use that
+        # Note that the preferred name needs to exist in the faction, so we
+        # don't end up with Kuznetsov carriers called CV-59 Forrestal
         carrier_type = ship_type_from_name(group.units[0].type)
         if (
             self.control_point.preferred_name

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -48,6 +48,7 @@ from . import (
     Fob,
     OffMapSpawn,
 )
+from ..campaignloader import CampaignCarrierConfig
 from ..campaignloader.campaignairwingconfig import CampaignAirWingConfig
 from ..profiling import logged_duration
 from ..settings import Settings
@@ -86,6 +87,7 @@ class GameGenerator:
         enemy: Faction,
         theater: ConflictTheater,
         air_wing_config: CampaignAirWingConfig,
+        carrier_config: CampaignCarrierConfig,
         settings: Settings,
         generator_settings: GeneratorSettings,
         mod_settings: ModSettings,
@@ -94,6 +96,7 @@ class GameGenerator:
         self.enemy = enemy.apply_mod_settings(mod_settings)
         self.theater = theater
         self.air_wing_config = air_wing_config
+        self.carrier_config = carrier_config
         self.settings = settings
         self.generator_settings = generator_settings
 
@@ -226,11 +229,14 @@ class CarrierGroundObjectGenerator(ControlPointGroundObjectGenerator):
         self.control_point.connected_objectives.append(g)
 
         # If the campaign designer has specified a preferred name, use that
-        if self.control_point.preferred_name:
+        carrier_type = ship_type_from_name(group.units[0].type)
+        if (
+            self.control_point.preferred_name
+            and self.control_point.preferred_name in self.faction.carriers[carrier_type]
+        ):
             self.control_point.name = self.control_point.preferred_name
         else:
             # Otherwise pick randomly from the names specified for that particular carrier type
-            carrier_type = ship_type_from_name(group.units[0].type)
             carrier_names = self.faction.carriers[carrier_type]
             self.control_point.name = random.choice(carrier_names)
         # Prevents duplicate carrier or LHA names in campaigns with more that one of either.

--- a/gen/fleet/carrier_group.py
+++ b/gen/fleet/carrier_group.py
@@ -13,7 +13,6 @@ class CarrierGroupGenerator(ShipGroupGenerator):
     def generate(self) -> None:
 
         if self.faction.carriers:
-            print(self.ground_object.control_point)
             # If the campaign designer has specified a preferred type, use that
             if (
                 self.ground_object.control_point.preferred_type

--- a/gen/fleet/carrier_group.py
+++ b/gen/fleet/carrier_group.py
@@ -1,5 +1,7 @@
 import random
 
+from game.theater import ControlPoint
+from game.theater.theatergroundobject import CarrierGroundObject
 from gen.sam.group_generator import ShipGroupGenerator
 from game.utils import Heading
 
@@ -7,11 +9,20 @@ from dcs.ships import USS_Arleigh_Burke_IIa, TICONDEROG
 
 
 class CarrierGroupGenerator(ShipGroupGenerator):
-    def generate(self) -> None:
+    def generate(self, control_point: ControlPoint) -> None:
+
+        if self.faction.carriers:
+            # If the campaign designer has specified a preferred type, use that
+            if control_point.preferred_type:
+                carrier_type = control_point.preferred_type
+            else:
+                # Otherwise pick randomly from the carrier types in the faction
+                carrier_type = random.choice(list(self.faction.carriers.keys()))
+        else:
+            return
 
         # Carrier Strike Group 8
-        if self.faction.carrier_names[0] == "Carrier Strike Group 8":
-            carrier_type = random.choice(self.faction.aircraft_carrier)
+        if list(self.faction.carriers.values())[0] == "Carrier Strike Group 8":
 
             self.add_unit(
                 carrier_type,
@@ -76,8 +87,7 @@ class CarrierGroupGenerator(ShipGroupGenerator):
         ##################################################################################################
         # Add carrier for normal generation
         else:
-            if len(self.faction.aircraft_carrier) > 0:
-                carrier_type = random.choice(self.faction.aircraft_carrier)
+            if self.faction.carriers:
                 self.add_unit(
                     carrier_type,
                     "Carrier",

--- a/gen/fleet/carrier_group.py
+++ b/gen/fleet/carrier_group.py
@@ -1,6 +1,5 @@
 import random
 
-from game.theater import ControlPoint
 from game.theater.theatergroundobject import CarrierGroundObject
 from gen.sam.group_generator import ShipGroupGenerator
 from game.utils import Heading
@@ -9,15 +8,19 @@ from dcs.ships import USS_Arleigh_Burke_IIa, TICONDEROG
 
 
 class CarrierGroupGenerator(ShipGroupGenerator):
-    def generate(self, control_point: ControlPoint) -> None:
+    ground_object: CarrierGroundObject
+
+    def generate(self) -> None:
 
         if self.faction.carriers:
+            print(self.ground_object.control_point)
             # If the campaign designer has specified a preferred type, use that
             if (
-                control_point.preferred_type
-                and control_point.preferred_type in self.faction.carriers.keys()
+                self.ground_object.control_point.preferred_type
+                and self.ground_object.control_point.preferred_type
+                in self.faction.carriers.keys()
             ):
-                carrier_type = control_point.preferred_type
+                carrier_type = self.ground_object.control_point.preferred_type
             else:
                 # Otherwise pick randomly from the carrier types in the faction
                 carrier_type = random.choice(list(self.faction.carriers.keys()))

--- a/gen/fleet/carrier_group.py
+++ b/gen/fleet/carrier_group.py
@@ -13,7 +13,10 @@ class CarrierGroupGenerator(ShipGroupGenerator):
 
         if self.faction.carriers:
             # If the campaign designer has specified a preferred type, use that
-            if control_point.preferred_type:
+            if (
+                control_point.preferred_type
+                and control_point.preferred_type in self.faction.carriers.keys()
+            ):
                 carrier_type = control_point.preferred_type
             else:
                 # Otherwise pick randomly from the carrier types in the faction

--- a/gen/fleet/ship_group_generator.py
+++ b/gen/fleet/ship_group_generator.py
@@ -87,7 +87,8 @@ def generate_carrier_group(
     :return: The generated group.
     """
     generator = CarrierGroupGenerator(game, ground_object, db.FACTIONS[faction])
-    generator.generate(ground_object.control_point)
+    generator.ground_object = ground_object
+    generator.generate()
     return generator.get_generated_group()
 
 

--- a/gen/fleet/ship_group_generator.py
+++ b/gen/fleet/ship_group_generator.py
@@ -87,7 +87,7 @@ def generate_carrier_group(
     :return: The generated group.
     """
     generator = CarrierGroupGenerator(game, ground_object, db.FACTIONS[faction])
-    generator.generate()
+    generator.generate(ground_object.control_point)
     return generator.get_generated_group()
 
 

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -248,6 +248,7 @@ def create_game(
         FACTIONS[red],
         theater,
         campaign.load_air_wing_config(theater),
+        campaign.load_carrier_config(theater),
         Settings(
             supercarrier=supercarrier,
             automate_runway_repair=auto_procurement,

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -121,6 +121,7 @@ class NewGameWizard(QtWidgets.QWizard):
             red_faction,
             theater,
             campaign.load_air_wing_config(theater),
+            campaign.load_carrier_config(theater),
             settings,
             generator_settings,
             mod_settings,

--- a/tests/test_factions.py
+++ b/tests/test_factions.py
@@ -99,7 +99,7 @@ class TestFactionLoader(unittest.TestCase):
 
             self.assertIn("HawkGenerator", faction.air_defenses)
 
-            self.assertIn(Stennis, faction.aircraft_carrier)
+            self.assertIn(Stennis, faction.carriers.keys())
             self.assertIn(LHA_Tarawa, faction.helicopter_carrier)
             self.assertIn(PERRY, faction.destroyers)
             self.assertIn(USS_Arleigh_Burke_IIa, faction.destroyers)
@@ -108,7 +108,7 @@ class TestFactionLoader(unittest.TestCase):
             self.assertIn("mod", faction.requirements.keys())
             self.assertIn("Some mod is required", faction.requirements.values())
 
-            self.assertEqual(4, len(faction.carrier_names))
+            self.assertEqual(4, len(faction.carriers.values()))
             self.assertEqual(5, len(faction.helicopter_carrier_names))
 
             self.assertIn("OliverHazardPerryGroupGenerator", faction.navy_generators)


### PR DESCRIPTION
Added an alternate way to define carriers in the faction file:
```
  "carriers": {
    "Forrestal": [
      "CV-59 Forrestal",
      "CV-60 Saratoga",
      "CV-61 Ranger",
      "CV-62 Independence"
    ],
    "Stennis": [
      "CVN-71 Theodore Roosevelt",
      "CVN-72 Abraham Lincoln",
      "CVN-73 George Washington",
      "CVN-74 John C. Stennis",
      "CVN-75 Harry S. Truman"
    ]
  },
```

The carrier names are picked based on the carrier type. Several carriers can be included in the same campaign with names coming from different pools. Also prevented duplicate names in campaigns with more than one carrier.

If the carriers are not found in the faction file with this new format, Liberation falls back to the previous method. This retains compatibility with existing faction files.

Also added support for defining preferred carrier types and carrier names in the campaign yaml:
```
carriers:
  Blue CV-1:
    preferred_name: CVN-74 John C. Stennis
    preferred_type: Stennis
  Blue CV-2:
    preferred_name: CV-60 Saratoga
    preferred_type: Forrestal
```

Resolves #1699
