### PR TITLE
Potential fix for Could not find front line point 5000 from...

### DIFF
--- a/game/theater/frontline.py
+++ b/game/theater/frontline.py
@@ -160,9 +160,14 @@ class FrontLine(MissionTarget):
                 )
             else:
                 remaining_dist -= segment.attack_distance
-        raise RuntimeError(
-            f"Could not find front line point {distance} from {self.blue_cp}"
-        )
+        if distance > 100:
+            # Failed to find front line point the intended distance away
+            # Recursively try again with shorter distance until succeeds
+            return self.point_from_a(distance - 100)
+        else:
+            raise RuntimeError(
+                f"Could not find front line point {distance} from {self.blue_cp}"
+            )
 
     @property
     def _position_distance(self) -> float:


### PR DESCRIPTION
A potential fix for #1784 which implements a recursive retry to find a front line point between FOBs which are close together (such as in the Marianas). I had made some changes to the positions of the FOBs in the Landing at Agat campaign and it seems the distance between Dededo and Yigo is too short. My hypothesis is that Liberation tries to find the initial front line point 5000 meters away, which is too far for this distance.

This is intentionally branched from the 5.0.0 release branch. I will submit a proper fix to the develop branch and create a separate PR if this fix is reported to work, this is just to have the reporter test and continue the campaign.
