### PR TITLE
Potential fix for Could not find front line point 5000 from... (upstream: develop)

### DIFF
--- a/game/theater/frontline.py
+++ b/game/theater/frontline.py
@@ -13,9 +13,6 @@ if TYPE_CHECKING:
     from game.ato import FlightType
 
 
-FRONTLINE_MIN_CP_DISTANCE = 5000
-
-
 @dataclass
 class FrontLineSegment:
     """
@@ -173,23 +170,8 @@ class FrontLine(MissionTarget):
         """
         total_strength = self.blue_cp.base.strength + self.red_cp.base.strength
         if self.blue_cp.base.strength == 0:
-            return self._adjust_for_min_dist(0)
+            return 0
         if self.red_cp.base.strength == 0:
-            return self._adjust_for_min_dist(self.attack_distance)
+            return self.attack_distance
         strength_pct = self.blue_cp.base.strength / total_strength
-        return self._adjust_for_min_dist(strength_pct * self.attack_distance)
-
-    def _adjust_for_min_dist(self, distance: float) -> float:
-        """
-        Ensures the frontline conflict is never located within the minimum distance
-        constant of either end control point.
-        """
-        if (distance > self.attack_distance / 2) and (
-            distance + FRONTLINE_MIN_CP_DISTANCE > self.attack_distance
-        ):
-            distance = self.attack_distance - FRONTLINE_MIN_CP_DISTANCE
-        elif (distance < self.attack_distance / 2) and (
-            distance < FRONTLINE_MIN_CP_DISTANCE
-        ):
-            distance = FRONTLINE_MIN_CP_DISTANCE
-        return distance
+        return strength_pct * self.attack_distance

--- a/game/theater/frontline.py
+++ b/game/theater/frontline.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from math import sqrt
 from typing import Iterator, List, Tuple, Any, TYPE_CHECKING
 
 from dcs.mapping import Point
@@ -66,23 +65,10 @@ class FrontLine(MissionTarget):
         self.segments: List[FrontLineSegment] = [
             FrontLineSegment(a, b) for a, b in pairwise(route)
         ]
-        try:
-            super().__init__(
-                f"Front line {blue_point}/{red_point}",
-                self.point_from_a(self._position_distance),
-            )
-        except RuntimeError:
-            # Failed to find front line point the intended distance away.
-            # Control points are probably closer to each other than FRONTLINE_MIN_CP_DISTANCE
-            # Fallback: try again with the middle point between the control points.
-            distance_between = sqrt(
-                ((blue_point.position.x - red_point.position.x) ** 2)
-                + ((blue_point.position.y - red_point.position.y) ** 2)
-            )
-            super().__init__(
-                f"Front line {blue_point}/{red_point}",
-                self.point_from_a(distance_between / 2),
-            )
+        super().__init__(
+            f"Front line {blue_point}/{red_point}",
+            self.point_from_a(self._position_distance),
+        )
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, FrontLine):

--- a/game/theater/frontline.py
+++ b/game/theater/frontline.py
@@ -161,9 +161,15 @@ class FrontLine(MissionTarget):
                 )
             else:
                 remaining_dist -= segment.attack_distance
-        raise RuntimeError(
-            f"Could not find front line point {distance} from {self.blue_cp}"
-        )
+        if distance > 100:
+            # Failed to find front line point the intended distance away.
+            # Control points are probably closer to each other than FRONTLINE_MIN_CP_DISTANCE
+            # Recursively try again with shorter distance until succeeds.
+            return self.point_from_a(distance - 100)
+        else:
+            raise RuntimeError(
+                f"Could not find front line point {distance} from {self.blue_cp}"
+            )
 
     @property
     def _position_distance(self) -> float:


### PR DESCRIPTION
A probable fix for #1784 (has been reported to work by the reporter) which implements a recursive retry to find a front line point between FOBs which are close together (such as in the Marianas), too close in fact since the distance appears to be less than FRONTLINE_MIN_CP_DISTANCE. I had made some changes to the positions of the FOBs in the Landing at Agat campaign and it seems the distance between Dededo and Yigo is too short now.

This is separate from  #1793 since that intentionally targeted the develop-5.0 branch.