### PR TITLE
Add ECM pod to Viper A2G loadouts.

### DIFF
--- a/resources/customized_payloads/F-16C_50.lua
+++ b/resources/customized_payloads/F-16C_50.lua
@@ -5,7 +5,7 @@ local unitPayloads = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "ALQ_184",
 					["num"] = 5,
 				},
 				[2] = {
@@ -80,7 +80,7 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[8] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "ALQ_184",
 					["num"] = 5,
 				},
 			},
@@ -166,7 +166,7 @@ local unitPayloads = {
 					["num"] = 7,
 				},
 				[9] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "ALQ_184",
 					["num"] = 5,
 				},
 				[10] = {
@@ -198,7 +198,7 @@ local unitPayloads = {
 					["num"] = 6,
 				},
 				[5] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "ALQ_184",
 					["num"] = 5,
 				},
 				[6] = {
@@ -271,7 +271,7 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[10] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "ALQ_184",
 					["num"] = 5,
 				},
 				[11] = {


### PR DESCRIPTION
Didn't add to the A2A loadouts since the ECM interferes with radar
operation and is otherwise weight and drag. It does have a radar
priority mode though, so maybe it should be added there too?

https://github.com/dcs-liberation/dcs_liberation/issues/1868
