### PR TITLE
Starfire's warbird loadouts for DCS World 2.7.9.17830 open beta.

### DIFF
--- a/resources/customized_payloads/Bf-109K-4.lua
+++ b/resources/customized_payloads/Bf-109K-4.lua
@@ -2,7 +2,8 @@ local unitPayloads = {
 	["name"] = "Bf-109K-4",
 	["payloads"] = {
 		[1] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "SC_501_SC500",
@@ -10,37 +11,25 @@ local unitPayloads = {
 				},
 			},
 			["tasks"] = {
-				[1] = 34,
-				[2] = 31,
-				[3] = 30,
-				[4] = 32,
+				[1] = 11,
 			},
 		},
 		[2] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "SC_501_SC250",
+					["CLSID"] = "BF109K_4_FUEL_TANK",
 					["num"] = 1,
 				},
 			},
 			["tasks"] = {
-				[1] = 34,
-				[2] = 31,
-				[3] = 30,
-				[4] = 32,
+				[1] = 11,
 			},
 		},
 		[3] = {
-			["name"] = "CAP",
-			["pylons"] = {
-			},
-			["tasks"] = {
-				[1] = 31,
-			},
-		},
-		[4] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "SC_501_SC500",
@@ -48,10 +37,96 @@ local unitPayloads = {
 				},
 			},
 			["tasks"] = {
-				[1] = 34,
-				[2] = 31,
-				[3] = 30,
-				[4] = 32,
+				[1] = 11,
+			},
+		},
+		[4] = {
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "BF109K_4_FUEL_TANK",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[5] = {
+			["name"] = "Liberation BARCAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "BF109K_4_FUEL_TANK",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[6] = {
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "BF109K_4_FUEL_TANK",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["name"] = "Liberation Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 	},

--- a/resources/customized_payloads/FW-190A8.lua
+++ b/resources/customized_payloads/FW-190A8.lua
@@ -2,67 +2,131 @@ local unitPayloads = {
 	["name"] = "FW-190A8",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAS",
+			["name"] = "Liberation BARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{SC_250_T1_L2}",
+					["CLSID"] = "BF109K_4_FUEL_TANK",
 					["num"] = 1,
 				},
 			},
 			["tasks"] = {
-				[1] = 31,
+				[1] = 11,
 			},
 		},
 		[2] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{SD_500_A}",
+					["CLSID"] = "BF109K_4_FUEL_TANK",
 					["num"] = 1,
 				},
 			},
 			["tasks"] = {
-				[1] = 31,
+				[1] = 11,
 			},
 		},
 		[3] = {
-			["name"] = "CAP",
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "BF109K_4_FUEL_TANK",
 					["num"] = 1,
 				},
 			},
 			["tasks"] = {
-				[1] = 31,
+				[1] = 11,
 			},
 		},
 		[4] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{SD_500_A}",
+					["CLSID"] = "BF109K_4_FUEL_TANK",
 					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 3,
 				},
 			},
 			["tasks"] = {
-				[1] = 31,
+				[1] = 11,
+			},
+		},
+		[5] = {
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AB_500_1_SD_10A}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[6] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AB_500_1_SD_10A}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AB_500_1_SD_10A}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 	},

--- a/resources/customized_payloads/FW-190D9.lua
+++ b/resources/customized_payloads/FW-190D9.lua
@@ -2,26 +2,8 @@ local unitPayloads = {
 	["name"] = "FW-190D9",
 	["payloads"] = {
 		[1] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 2,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-				[2] = 10,
-				[3] = 32,
-				[4] = 31,
-			},
-		},
-		[2] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "SC_501_SC500",
@@ -29,37 +11,154 @@ local unitPayloads = {
 				},
 			},
 			["tasks"] = {
-				[1] = 34,
-				[2] = 31,
-				[3] = 30,
-				[4] = 32,
+				[1] = 11,
 			},
 		},
-		[3] = {
-			["name"] = "CAS",
+		[2] = {
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{WGr21}",
-					["num"] = 3,
+					["CLSID"] = "FW109_FUEL_TANK",
+					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{WGr21}",
+					["CLSID"] = "{FW_190_R4M_RGHT_WING}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{FW_190_R4M_LEFT_WING}",
 					["num"] = 2,
 				},
 			},
 			["tasks"] = {
 				[1] = 11,
-				[2] = 10,
-				[3] = 32,
-				[4] = 31,
+			},
+		},
+		[3] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 		[4] = {
-			["name"] = "CAP",
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
+				[1] = {
+					["CLSID"] = "FW109_FUEL_TANK",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{FW_190_R4M_RGHT_WING}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{FW_190_R4M_LEFT_WING}",
+					["num"] = 2,
+				},
 			},
 			["tasks"] = {
-				[1] = 31,
+				[1] = 11,
+			},
+		},
+		[5] = {
+			["name"] = "Liberation BARCAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "FW109_FUEL_TANK",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{FW_190_R4M_RGHT_WING}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{FW_190_R4M_LEFT_WING}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[6] = {
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "FW109_FUEL_TANK",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{FW_190_R4M_RGHT_WING}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{FW_190_R4M_LEFT_WING}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "ER_4_SC50",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "SC_501_SC500",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 	},

--- a/resources/customized_payloads/I-16.lua
+++ b/resources/customized_payloads/I-16.lua
@@ -2,47 +2,32 @@ local unitPayloads = {
 	["name"] = "I-16",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
+				[1] = {
+					["CLSID"] = "I16_DROP_FUEL_TANK",
+					["num"] = 5,
+				},
+				[2] = {
+					["CLSID"] = "I16_DROP_FUEL_TANK",
+					["num"] = 4,
+				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[2] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation BARCAP",
+			["name"] = "Liberation BARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 8,
-				},
-				[2] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 7,
-				},
-				[3] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 6,
-				},
-				[4] = {
-					["CLSID"] = "I16_FAB_100SV",
+					["CLSID"] = "I16_DROP_FUEL_TANK",
 					["num"] = 5,
 				},
-				[5] = {
-					["CLSID"] = "I16_FAB_100SV",
+				[2] = {
+					["CLSID"] = "I16_DROP_FUEL_TANK",
 					["num"] = 4,
-				},
-				[6] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 3,
-				},
-				[7] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 2,
-				},
-				[8] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -50,39 +35,16 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "I16_FAB_100SV",
+					["CLSID"] = "I16_DROP_FUEL_TANK",
 					["num"] = 5,
 				},
 				[2] = {
-					["CLSID"] = "I16_FAB_100SV",
+					["CLSID"] = "I16_DROP_FUEL_TANK",
 					["num"] = 4,
-				},
-				[3] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 1,
-				},
-				[4] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 2,
-				},
-				[5] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 3,
-				},
-				[6] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 8,
 				},
 			},
 			["tasks"] = {
@@ -90,39 +52,16 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "I16_FAB_100SV",
+					["CLSID"] = "I16_DROP_FUEL_TANK",
 					["num"] = 5,
 				},
 				[2] = {
-					["CLSID"] = "I16_FAB_100SV",
+					["CLSID"] = "I16_DROP_FUEL_TANK",
 					["num"] = 4,
-				},
-				[3] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 8,
-				},
-				[4] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 7,
-				},
-				[5] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 3,
-				},
-				[7] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 2,
-				},
-				[8] = {
-					["CLSID"] = "I16_RS_82",
-					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -130,7 +69,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["name"] = "SEAD",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "I16_RS_82",
@@ -145,24 +84,24 @@ local unitPayloads = {
 					["num"] = 6,
 				},
 				[4] = {
-					["CLSID"] = "I16_FAB_100SV",
-					["num"] = 5,
-				},
-				[5] = {
-					["CLSID"] = "I16_FAB_100SV",
-					["num"] = 4,
-				},
-				[6] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 3,
 				},
-				[7] = {
+				[5] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 2,
 				},
-				[8] = {
+				[6] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 1,
+				},
+				[7] = {
+					["CLSID"] = "I16_FAB_100SV",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "I16_FAB_100SV",
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -170,7 +109,8 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["name"] = "DEAD",
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "I16_RS_82",
@@ -185,24 +125,24 @@ local unitPayloads = {
 					["num"] = 6,
 				},
 				[4] = {
-					["CLSID"] = "I16_FAB_100SV",
-					["num"] = 5,
-				},
-				[5] = {
-					["CLSID"] = "I16_FAB_100SV",
-					["num"] = 4,
-				},
-				[6] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 3,
 				},
-				[7] = {
+				[5] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 2,
 				},
-				[8] = {
+				[6] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 1,
+				},
+				[7] = {
+					["CLSID"] = "I16_FAB_100SV",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "I16_FAB_100SV",
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -210,7 +150,8 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["name"] = "BAI",
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "I16_RS_82",
@@ -225,24 +166,24 @@ local unitPayloads = {
 					["num"] = 6,
 				},
 				[4] = {
-					["CLSID"] = "I16_FAB_100SV",
-					["num"] = 5,
-				},
-				[5] = {
-					["CLSID"] = "I16_FAB_100SV",
-					["num"] = 4,
-				},
-				[6] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 3,
 				},
-				[7] = {
+				[5] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 2,
 				},
-				[8] = {
+				[6] = {
 					["CLSID"] = "I16_RS_82",
 					["num"] = 1,
+				},
+				[7] = {
+					["CLSID"] = "I16_FAB_100SV",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "I16_FAB_100SV",
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {

--- a/resources/customized_payloads/Ju-88A4.lua
+++ b/resources/customized_payloads/Ju-88A4.lua
@@ -2,15 +2,16 @@ local unitPayloads = {
 	["name"] = "Ju-88A4",
 	["payloads"] = {
 		[1] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{LTF_5B}",
-					["num"] = 1,
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "{LTF_5B}",
-					["num"] = 3,
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -18,14 +19,14 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "CAS",
+			["name"] = "Liberation Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{LTF_5B}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{LTF_5B}",
 					["num"] = 1,
 				},
 			},
@@ -34,22 +35,31 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "CAP",
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
 			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{SC_500_L2}",
+					["num"] = 1,
+				},
 			},
 			["tasks"] = {
 				[1] = 32,
 			},
 		},
 		[4] = {
-			["name"] = "STRIKE",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{SC_500_L2}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{SC_500_L2}",
 					["num"] = 1,
 				},
 			},
@@ -58,15 +68,15 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "RUNWAY_ATTACK",
-			["name"] = "RUNWAY_ATTACK",
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{AB_500_1_SD_10A}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{AB_500_1_SD_10A}",
 					["num"] = 1,
 				},
 			},
@@ -75,15 +85,15 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "SEAD",
-			["name"] = "SEAD",
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{SC_500_L2}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{SC_500_L2}",
 					["num"] = 1,
 				},
 			},
@@ -92,15 +102,15 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "DEAD",
-			["name"] = "DEAD",
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{SC_500_L2}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "SC_501_SC500",
+					["CLSID"] = "{SC_500_L2}",
 					["num"] = 1,
 				},
 			},

--- a/resources/customized_payloads/MosquitoFBMkVI.lua
+++ b/resources/customized_payloads/MosquitoFBMkVI.lua
@@ -2,82 +2,78 @@ local unitPayloads = {
 	["name"] = "MosquitoFBMkVI",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAP",
-			["pylons"] = {
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[2] = {
-			["displayName"] = "CAS",
-			["name"] = "CAS",
+			["displayName"] = "500 lb GP Mk.V*2, 500 lb GP Short tail*2",
+			["name"] = "500 lb GP Mk.V*2, 500 lb GP Short tail*2",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{British_MC_250LB_Bomb_Mk2}",
+					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
 					["num"] = 2,
 				},
 				[2] = {
-					["CLSID"] = "{British_MC_250LB_Bomb_Mk2}",
+					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{British_MC_250LB_Bomb_Mk2_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
 				[4] = {
-					["CLSID"] = "{British_MC_250LB_Bomb_Mk2_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
+			},
+			["tasks"] = {
+				[1] = 11,
+				[2] = 32,
+				[3] = 31,
+				[4] = 34,
+			},
+		},
+		[2] = {
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
+			["pylons"] = {
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[3] = {
-			["displayName"] = "STRIKE",
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
-					["num"] = 4,
-				},
-				[4] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
-					["num"] = 3,
-				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[4] = {
-			["displayName"] = "DEAD",
-			["name"] = "DEAD",
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
+					["CLSID"] = "",
 					["num"] = 2,
 				},
 				[2] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
+					["CLSID"] = "",
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
 				[4] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
+					["num"] = 5,
 				},
 			},
 			["tasks"] = {
@@ -85,24 +81,32 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "SEAD",
-			["name"] = "SEAD",
+			["displayName"] = "Liberation Anti-ship",
+			["name"] = "Liberation Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
+					["CLSID"] = "",
 					["num"] = 2,
 				},
 				[2] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
+					["CLSID"] = "",
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
 				[4] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
+					["num"] = 5,
 				},
 			},
 			["tasks"] = {
@@ -110,25 +114,165 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "ANTISHIP",
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
+					["CLSID"] = "",
 					["num"] = 2,
 				},
 				[2] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk5}",
+					["CLSID"] = "",
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
 				[4] = {
-					["CLSID"] = "{British_GP_500LB_Bomb_Mk4_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
+				[5] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
+			["name"] = "Liberation Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short}",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 4,
+				},
+				[4] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 4,
+				},
+				[4] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 4,
+				},
+				[4] = {
+					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[11] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{British_SAP_500LB_Bomb_Mk5}",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "{British_SAP_500LB_Bomb_Mk5}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 4,
+				},
+				[4] = {
+					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[12] = {
+			["name"] = "Liberation BARCAP",
+			["pylons"] = {
 			},
 			["tasks"] = {
 				[1] = 11,

--- a/resources/customized_payloads/P-47D-30.lua
+++ b/resources/customized_payloads/P-47D-30.lua
@@ -2,27 +2,16 @@ local unitPayloads = {
 	["name"] = "P-47D-30",
 	["payloads"] = {
 		[1] = {
-			["name"] = "STRIKE",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AN_M65}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{AN_M65}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 1,
-				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[2] = {
-			["name"] = "ANTISTRIKE",
+			["displayName"] = "Liberation BARCAP",
+			["name"] = "Liberation BARCAP",
 			["pylons"] = {
 			},
 			["tasks"] = {
@@ -30,27 +19,17 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 1,
-				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[4] = {
-			["name"] = "CAP",
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
 			["pylons"] = {
 			},
 			["tasks"] = {
@@ -58,18 +37,19 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["name"] = "SEAD",
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{AN_M57}",
+					["CLSID"] = "{AN-M64}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "{AN_M57}",
+					["CLSID"] = "{AN-M64}",
 					["num"] = 2,
 				},
 				[3] = {
-					["CLSID"] = "{AN_M57}",
+					["CLSID"] = "{AN-M64}",
 					["num"] = 1,
 				},
 			},
@@ -78,7 +58,8 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{AN-M64}",
@@ -94,6 +75,87 @@ local unitPayloads = {
 				},
 			},
 			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN_M65}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN_M65}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 	},

--- a/resources/customized_payloads/P-47D-30bl1.lua
+++ b/resources/customized_payloads/P-47D-30bl1.lua
@@ -2,7 +2,7 @@ local unitPayloads = {
 	["name"] = "P-47D-30bl1",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
 			},
 			["tasks"] = {
@@ -10,47 +10,35 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation BARCAP",
+			["name"] = "Liberation BARCAP",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AN_M57}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{AN_M57}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AN_M57}",
-					["num"] = 3,
-				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[3] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 1,
-				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[4] = {
-			["name"] = "SEAD",
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[5] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{AN-M64}",
@@ -69,8 +57,9 @@ local unitPayloads = {
 				[1] = 11,
 			},
 		},
-		[5] = {
-			["name"] = "ANTISHIP",
+		[6] = {
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{AN-M64}",
@@ -86,6 +75,91 @@ local unitPayloads = {
 				},
 			},
 			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 	},

--- a/resources/customized_payloads/P-47D-40.lua
+++ b/resources/customized_payloads/P-47D-40.lua
@@ -2,31 +2,34 @@ local unitPayloads = {
 	["name"] = "P-47D-40",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAP",
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
 			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN_M65}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN_M65}",
+					["num"] = 2,
+				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[2] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
-					["num"] = 4,
-				},
-				[2] = {
-					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
-					["num"] = 5,
-				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[3] = {
-			["name"] = "SEAD",
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
@@ -35,6 +38,18 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
 					["num"] = 5,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -42,7 +57,17 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation BARCAP",
+			["name"] = "Liberation BARCAP",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[5] = {
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{AN-M64}",
@@ -53,6 +78,14 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[3] = {
+					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
+					["num"] = 4,
+				},
+				[5] = {
 					["CLSID"] = "{AN-M64}",
 					["num"] = 1,
 				},
@@ -61,7 +94,45 @@ local unitPayloads = {
 				[1] = 11,
 			},
 		},
-		[5] = {
+		[6] = {
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation SEAD",
+			["name"] = "Liberation SEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
 			["name"] = "ANTISHIP",
 			["pylons"] = {
 				[1] = {
@@ -76,8 +147,141 @@ local unitPayloads = {
 					["CLSID"] = "{AN-M64}",
 					["num"] = 1,
 				},
+				[4] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
 			},
 			["tasks"] = {
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation SEAD Escort",
+			["name"] = "Liberation SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
+					["num"] = 4,
+				},
+				[2] = {
+					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
+					["num"] = 5,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
+					["num"] = 4,
+				},
+				[2] = {
+					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
+					["num"] = 5,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[11] = {
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[12] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
+					["num"] = 4,
+				},
+				[2] = {
+					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
+					["num"] = 5,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[13] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{P47_5_HVARS_ON_LEFT_WING_RAILS}",
+					["num"] = 4,
+				},
+				[2] = {
+					["CLSID"] = "{P47_5_HVARS_ON_RIGHT_WING_RAILS}",
+					["num"] = 5,
+				},
+				[3] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 2,
+				},
+				[5] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 	},

--- a/resources/customized_payloads/P-51D-30-NA.lua
+++ b/resources/customized_payloads/P-51D-30-NA.lua
@@ -2,39 +2,16 @@ local unitPayloads = {
 	["name"] = "P-51D-30-NA",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 10,
-				},
-				[2] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 9,
-				},
-				[3] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 8,
-				},
-				[4] = {
 					["CLSID"] = "{AN-M64}",
 					["num"] = 7,
 				},
-				[5] = {
+				[2] = {
 					["CLSID"] = "{AN-M64}",
 					["num"] = 4,
-				},
-				[6] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 3,
-				},
-				[7] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 2,
-				},
-				[8] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -44,7 +21,17 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[3] = {
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{HVAR}",
@@ -59,11 +46,11 @@ local unitPayloads = {
 					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "{AN-M64}",
+					["CLSID"] = "{HVAR}",
 					["num"] = 7,
 				},
 				[5] = {
-					["CLSID"] = "{AN-M64}",
+					["CLSID"] = "{HVAR}",
 					["num"] = 4,
 				},
 				[6] = {
@@ -77,6 +64,14 @@ local unitPayloads = {
 				[8] = {
 					["CLSID"] = "{HVAR}",
 					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
 				},
 			},
 			["tasks"] = {
@@ -85,16 +80,9 @@ local unitPayloads = {
 				[3] = 30,
 			},
 		},
-		[3] = {
-			["name"] = "CAP",
-			["pylons"] = {
-			},
-			["tasks"] = {
-				[1] = 31,
-			},
-		},
 		[4] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{HVAR}",
@@ -109,11 +97,11 @@ local unitPayloads = {
 					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "{AN-M64}",
+					["CLSID"] = "{HVAR}",
 					["num"] = 7,
 				},
 				[5] = {
-					["CLSID"] = "{AN-M64}",
+					["CLSID"] = "{HVAR}",
 					["num"] = 4,
 				},
 				[6] = {
@@ -127,6 +115,245 @@ local unitPayloads = {
 				[8] = {
 					["CLSID"] = "{HVAR}",
 					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 30,
+			},
+		},
+		[5] = {
+			["displayName"] = "Liberation Anti-ship",
+			["name"] = "Liberation Anti-ship",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 30,
+			},
+		},
+		[6] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 30,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 30,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation BARCAP",
+			["name"] = "Liberation BARCAP",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[11] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
 				},
 			},
 			["tasks"] = {

--- a/resources/customized_payloads/P-51D.lua
+++ b/resources/customized_payloads/P-51D.lua
@@ -2,7 +2,8 @@ local unitPayloads = {
 	["name"] = "P-51D",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAS",
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{HVAR}",
@@ -17,22 +18,30 @@ local unitPayloads = {
 					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "{AN-M64}",
+					["CLSID"] = "{HVAR}",
 					["num"] = 7,
 				},
 				[5] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 4,
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
 				},
 				[6] = {
 					["CLSID"] = "{HVAR}",
-					["num"] = 3,
+					["num"] = 5,
 				},
 				[7] = {
 					["CLSID"] = "{HVAR}",
-					["num"] = 2,
+					["num"] = 4,
 				},
 				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[10] = {
 					["CLSID"] = "{HVAR}",
 					["num"] = 1,
 				},
@@ -40,53 +49,48 @@ local unitPayloads = {
 			["tasks"] = {
 				[1] = 31,
 				[2] = 32,
-				[3] = 30,
+				[3] = 34,
+				[4] = 30,
 			},
 		},
 		[2] = {
-			["name"] = "STRIKE",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 10,
-				},
-				[2] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 9,
-				},
-				[3] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 8,
-				},
-				[4] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 7,
-				},
-				[5] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 4,
-				},
-				[6] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 3,
-				},
-				[7] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 2,
-				},
-				[8] = {
-					["CLSID"] = "{HVAR}",
-					["num"] = 1,
-				},
 			},
 			["tasks"] = {
 				[1] = 31,
-				[2] = 32,
-				[3] = 30,
 			},
 		},
 		[3] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation BARCAP",
+			["name"] = "Liberation BARCAP",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[4] = {
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[5] = {
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[6] = {
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{HVAR}",
@@ -101,22 +105,30 @@ local unitPayloads = {
 					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "{AN-M64}",
+					["CLSID"] = "{HVAR}",
 					["num"] = 7,
 				},
 				[5] = {
-					["CLSID"] = "{AN-M64}",
-					["num"] = 4,
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
 				},
 				[6] = {
 					["CLSID"] = "{HVAR}",
-					["num"] = 3,
+					["num"] = 5,
 				},
 				[7] = {
 					["CLSID"] = "{HVAR}",
-					["num"] = 2,
+					["num"] = 4,
 				},
 				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[10] = {
 					["CLSID"] = "{HVAR}",
 					["num"] = 1,
 				},
@@ -124,7 +136,236 @@ local unitPayloads = {
 			["tasks"] = {
 				[1] = 31,
 				[2] = 32,
-				[3] = 30,
+				[3] = 34,
+				[4] = 30,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation Anti-ship",
+			["name"] = "Liberation Anti-ship",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 34,
+				[4] = 30,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 34,
+				[4] = 30,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 34,
+				[4] = 30,
+			},
+		},
+		[10] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 10,
+				},
+				[2] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 9,
+				},
+				[3] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{HVAR}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 34,
+				[4] = 30,
+			},
+		},
+		[11] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{AN-M64}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+				[2] = 32,
+				[3] = 34,
+				[4] = 30,
 			},
 		},
 	},

--- a/resources/customized_payloads/SA342Minigun.lua
+++ b/resources/customized_payloads/SA342Minigun.lua
@@ -1,0 +1,34 @@
+local unitPayloads = {
+	["name"] = "SA342Minigun",
+	["payloads"] = {
+		[1] = {
+			["name"] = "Liberation CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{IR_Deflector}",
+					["num"] = 6,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[2] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{IR_Deflector}",
+					["num"] = 6,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+	},
+	["tasks"] = {
+	},
+	["unitType"] = "SA342Minigun",
+}
+return unitPayloads


### PR DESCRIPTION
@Starfire13 's warbird loadouts for DCS World 2.7.9.17830 open beta.

Major changes:
 - FW190A8 ground attack loadout WGr21 rockets (primarily an air-to-air weapon) replaced with SC500J or AB500 bombs.
 - FW190D9 WGr21 rockets replaced with R4M rocket packs and SC500 bombs for CAS.
 - Added droptanks for I-16.
 - Ju-88A4 CAS loadout changed for AB500 cluster bombs.
 - Mosquito now has rockets which were introduced in DCS World 2.7.9.17830 open beta.
 - Added more/heavier bombs to P-47.
 - P-51 now has a separate OCA/Runway loadout with bombs. Other ground attack loadouts switched to rockets.

Also includes an SA342Minigun loadout which we didn't previously have.

Replaces #1870
