### PR TITLE
Add ECM behavior to not Air to Air flights

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Added an option to fast-forward mission generation until the point of first contact (WIP).
 * **[Mission Generation]** Add Option to enforce the Easy Communication setting for the mission
 * **[Flight Planning]** Added the ability to plan tankers for recovery on package flights.  AI does not plan.
+* **[Flight Planning]** Air to Ground flights now have ECM enabled on lock at the join point, and SEAD/DEAD also have ECM enabled on detection and lock at ingress.
 * **[Modding]** Add F-104 mod support
 * **[UI]** Added options to the loadout editor for setting properties such as HMD choice.
 

--- a/game/missiongenerator/aircraft/waypoints/deadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/deadingress.py
@@ -1,7 +1,7 @@
 import logging
 
 from dcs.point import MovingPoint
-from dcs.task import AttackGroup, WeaponType
+from dcs.task import AttackGroup, OptECMUsing, WeaponType
 
 from game.theater import TheaterGroundObject
 from .pydcswaypointbuilder import PydcsWaypointBuilder
@@ -32,3 +32,7 @@ class DeadIngressBuilder(PydcsWaypointBuilder):
             task.params["altitudeEnabled"] = False
             task.params["groupAttack"] = True
             waypoint.tasks.append(task)
+
+        # Preemptively use ECM to better avoid getting swatted.
+        ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfDetectedLockByRadar)
+        waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/joinpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/joinpoint.py
@@ -29,7 +29,10 @@ class JoinPointBuilder(PydcsWaypointBuilder):
             waypoint.tasks.append(ecm_option)
 
         elif not self.flight.flight_type.is_air_to_air:
-            # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.  You can bully them with STT to not be able to fire radar guided missiles at you, so best choice is to not let them perform jamming for now.
+            # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.
+            # You can bully them with STT to not be able to fire radar guided missiles at you,
+            # so best choice is to not let them perform jamming for now.
+
             # Let the AI use ECM to defend themselves.
             ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
             waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/joinpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/joinpoint.py
@@ -1,7 +1,7 @@
 from typing import List, Type
 
 from dcs.point import MovingPoint
-from dcs.task import ControlledTask, EngageTargets, TargetType, Targets
+from dcs.task import ControlledTask, EngageTargets, OptECMUsing, TargetType, Targets
 
 from game.ato import FlightType
 from game.utils import nautical_miles
@@ -18,10 +18,23 @@ class JoinPointBuilder(PydcsWaypointBuilder):
                     Targets.All.Air.Planes.MultiroleFighters,
                 ],
             )
+
+            # Let the AI use ECM to defend themselves.
+            ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
+            waypoint.tasks.append(ecm_option)
+
         elif self.flight.flight_type == FlightType.SEAD_ESCORT:
             self.configure_escort_tasks(
                 waypoint, [Targets.All.GroundUnits.AirDefence.AAA.SAMRelated]
             )
+
+            # Let the AI use ECM to preemptively defend themselves.
+            ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfDetectedLockByRadar)
+            waypoint.tasks.append(ecm_option)
+        else:
+            # Let the AI use ECM to defend themselves.
+            ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
+            waypoint.tasks.append(ecm_option)
 
     @staticmethod
     def configure_escort_tasks(

--- a/game/missiongenerator/aircraft/waypoints/joinpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/joinpoint.py
@@ -19,10 +19,6 @@ class JoinPointBuilder(PydcsWaypointBuilder):
                 ],
             )
 
-            # Let the AI use ECM to defend themselves.
-            ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
-            waypoint.tasks.append(ecm_option)
-
         elif self.flight.flight_type == FlightType.SEAD_ESCORT:
             self.configure_escort_tasks(
                 waypoint, [Targets.All.GroundUnits.AirDefence.AAA.SAMRelated]
@@ -31,7 +27,9 @@ class JoinPointBuilder(PydcsWaypointBuilder):
             # Let the AI use ECM to preemptively defend themselves.
             ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfDetectedLockByRadar)
             waypoint.tasks.append(ecm_option)
-        else:
+
+        elif not self.flight.flight_type.is_air_to_air:
+            # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.  You can bully them with STT to not be able to fire radar guided missiles at you, so best choice is to not let them perform jamming for now.
             # Let the AI use ECM to defend themselves.
             ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
             waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -1,7 +1,7 @@
 import logging
 
 from dcs.point import MovingPoint
-from dcs.task import AttackGroup, WeaponType
+from dcs.task import AttackGroup, OptECMUsing, WeaponType
 
 from game.theater import TheaterGroundObject
 from .pydcswaypointbuilder import PydcsWaypointBuilder
@@ -32,3 +32,7 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
             task.params["altitudeEnabled"] = False
             task.params["groupAttack"] = True
             waypoint.tasks.append(task)
+
+        # Preemptively use ECM to better avoid getting swatted.
+        ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfDetectedLockByRadar)
+        waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/splitpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/splitpoint.py
@@ -1,13 +1,14 @@
 from dcs.point import MovingPoint
 from dcs.task import OptECMUsing
 
-from game.utils import nautical_miles
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
 class SplitPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
 
-        # Let the AI use ECM to defend themselves.
-        ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
-        waypoint.tasks.append(ecm_option)
+        if not self.flight.flight_type.is_air_to_air:
+            # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.  You can bully them with STT to not be able to fire radar guided missiles at you, so best choice is to not let them perform jamming for now.
+            # Let the AI use ECM to defend themselves.
+            ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
+            waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/splitpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/splitpoint.py
@@ -1,0 +1,13 @@
+from dcs.point import MovingPoint
+from dcs.task import OptECMUsing
+
+from game.utils import nautical_miles
+from .pydcswaypointbuilder import PydcsWaypointBuilder
+
+
+class SplitPointBuilder(PydcsWaypointBuilder):
+    def add_tasks(self, waypoint: MovingPoint) -> None:
+
+        # Let the AI use ECM to defend themselves.
+        ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
+        waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/splitpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/splitpoint.py
@@ -8,7 +8,10 @@ class SplitPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
 
         if not self.flight.flight_type.is_air_to_air:
-            # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.  You can bully them with STT to not be able to fire radar guided missiles at you, so best choice is to not let them perform jamming for now.
+            # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.
+            # You can bully them with STT to not be able to fire radar guided missiles at you,
+            # so best choice is to not let them perform jamming for now.
+
             # Let the AI use ECM to defend themselves.
             ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfOnlyLockByRadar)
             waypoint.tasks.append(ecm_option)

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -27,6 +27,7 @@ from .deadingress import DeadIngressBuilder
 from .default import DefaultWaypointBuilder
 from .holdpoint import HoldPointBuilder
 from .joinpoint import JoinPointBuilder
+from .splitpoint import SplitPointBuilder
 from .landingpoint import LandingPointBuilder
 from .ocaaircraftingress import OcaAircraftIngressBuilder
 from .ocarunwayingress import OcaRunwayIngressBuilder
@@ -127,6 +128,7 @@ class WaypointGenerator:
             FlightWaypointType.INGRESS_STRIKE: StrikeIngressBuilder,
             FlightWaypointType.INGRESS_SWEEP: SweepIngressBuilder,
             FlightWaypointType.JOIN: JoinPointBuilder,
+            FlightWaypointType.SPLIT: SplitPointBuilder,
             FlightWaypointType.LANDING_POINT: LandingPointBuilder,
             FlightWaypointType.LOITER: HoldPointBuilder,
             FlightWaypointType.PATROL: RaceTrackEndBuilder,


### PR DESCRIPTION
Flights that are not air-to-air will receive a ECM usage `Only on Lock` option at `Join` and `Split`.
SEAD and DEAD will also set ECM usage to `On Detection and Lock` at `Ingress`.

#1878 sort of done.  Just not the air to air part.