### PR TITLE
Community-JAS-39-C mod version v1.8.0-Beta support

### DIFF
--- a/pydcs_extensions/jas39/jas39.py
+++ b/pydcs_extensions/jas39/jas39.py
@@ -18,166 +18,236 @@ class JAS39GripenWeapons:
         "name": "Integrated ELINT",
         "weight": 1,
     }
-    JAS39_AIM120B = {
-        "clsid": "JAS39_AIM120B",
+    AIM_120B_AMRAAM_Active_Rdr_AAM = {
+        "clsid": "{JAS39_AIM120B}",
         "name": "AIM-120B AMRAAM Active Rdr AAM",
         "weight": 157,
     }
-    JAS39_AIM120C5 = {
-        "clsid": "JAS39_AIM120C5",
+    AIM_120C_5_AMRAAM_Active_Rdr_AAM = {
+        "clsid": "{JAS39_AIM120C5}",
         "name": "AIM-120C-5 AMRAAM Active Rdr AAM",
         "weight": 162.5,
     }
-    JAS39_AIM120C7 = {
-        "clsid": "JAS39_AIM120C7",
+    AIM_120C_7_AMRAAM_Active_Rdr_AAM = {
+        "clsid": "{JAS39_AIM120C7}",
         "name": "AIM-120C-7 AMRAAM Active Rdr AAM",
         "weight": 162.5,
     }
-    JAS39_AIM_9L = {
-        "clsid": "JAS39_AIM-9L",
+    AIM_9L_Sidewinder_IR_AAM_ = {
+        "clsid": "{JAS39_AIM-9L}",
         "name": "AIM-9L Sidewinder IR AAM",
         "weight": 86,
     }
-    JAS39_AIM_9M = {
-        "clsid": "JAS39_AIM-9M",
+    AIM_9M_Sidewinder_IR_AAM_ = {
+        "clsid": "{JAS39_AIM-9M}",
         "name": "AIM-9M Sidewinder IR AAM",
         "weight": 86,
     }
-    JAS39_AIM_9X = {
-        "clsid": "JAS39_AIM-9X",
+    AIM_9X_Sidewinder_IR_AAM_ = {
+        "clsid": "{JAS39_AIM-9X}",
         "name": "AIM-9X Sidewinder IR AAM",
         "weight": 86.5,
     }
-    JAS39_ASRAAM = {
-        "clsid": "JAS39_ASRAAM",
+    AIM_132_ASRAAM_IR_AAM = {
+        "clsid": "{JAS39_ASRAAM}",
         "name": "AIM-132 ASRAAM IR AAM",
         "weight": 89,
     }
-    JAS39_A_DARTER = {
-        "clsid": "JAS39_A-DARTER",
+    A_Darter_IR_AAM = {
+        "clsid": "{JAS39_A-DARTER}",
         "name": "A-Darter IR AAM",
         "weight": 90,
     }
-    JAS39_BRIMSTONE = {
-        "clsid": "JAS39_BRIMSTONE",
-        "name": "Brimstone Laser Guided Missile",
+    _3_x_Brimstone_Laser_Guided_Missile = {
+        "clsid": "{JAS39_BRIMSTONE}",
+        "name": "3 x Brimstone Laser Guided Missile",
         "weight": 195.5,
     }
-    JAS39_Derby = {
-        "clsid": "JAS39_Derby",
+    I_Derby_ER_BVRAAM_Active_Rdr_AAM = {
+        "clsid": "{JAS39_Derby}",
         "name": "I-Derby ER BVRAAM Active Rdr AAM",
         "weight": 119,
     }
-    JAS39_DWS39 = {
-        "clsid": "JAS39_DWS39",
-        "name": "DWS39 Unguided Cluster Munition",
-        "weight": 605,
+    DWS_39_MJ2_Anti_radiation_Cluster_Bomb = {
+        "clsid": "{JAS39_DWS39_ARM}",
+        "name": "DWS 39 MJ2 Anti-radiation Cluster Bomb",
+        "weight": 672,
     }
-    JAS39_GBU10 = {
-        "clsid": "JAS39_GBU10",
+    DWS_39_MJ2_TV_Guided_Cluster_Bomb = {
+        "clsid": "{JAS39_DWS39_TV}",
+        "name": "DWS 39 MJ2 TV Guided Cluster Bomb",
+        "weight": 672,
+    }
+    GBU_10_2000_lb_Laser_guided_Bomb = {
+        "clsid": "{JAS39_GBU10}",
         "name": "GBU-10 2000 lb Laser-guided Bomb",
         "weight": 934,
     }
-    JAS39_GBU12 = {
-        "clsid": "JAS39_GBU12",
+    GBU_12_500_lb_Laser_guided_Bomb = {
+        "clsid": "{JAS39_GBU12}",
         "name": "GBU-12 500 lb Laser-guided Bomb",
         "weight": 275,
     }
-    JAS39_GBU16 = {
-        "clsid": "JAS39_GBU16",
+    GBU_16_1000_lb_Laser_guided_Bomb = {
+        "clsid": "{JAS39_GBU16}",
         "name": "GBU-16 1000 lb Laser-guided Bomb",
         "weight": 454,
     }
-    JAS39_GBU31 = {
-        "clsid": "JAS39_GBU31",
-        "name": "GBU-31 2000lb TV Guided Glide-Bomb",
+    GBU_31_2000_lb_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_GBU31}",
+        "name": "GBU-31 2000 lb TV Guided Glide-Bomb",
         "weight": 934,
     }
-    JAS39_GBU32 = {
-        "clsid": "JAS39_GBU32",
-        "name": "GBU-32 1000lb TV Guided Glide-Bomb",
-        "weight": 454,
+    GBU_31_2000_lb_Penetrator_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_GBU31_BLU109}",
+        "name": "GBU-31 2000 lb Penetrator TV Guided Glide-Bomb",
+        "weight": 970,
     }
-    JAS39_GBU38 = {
-        "clsid": "JAS39_GBU38",
-        "name": "GBU-38 500lb TV Guided Glide-Bomb",
+    GBU_32_1000_lb_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_GBU32}",
+        "name": "GBU-32 1000 lb TV Guided Glide-Bomb",
+        "weight": 467,
+    }
+    GBU_38_500_lb_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_GBU38}",
+        "name": "GBU-38 500 lb TV Guided Glide-Bomb",
         "weight": 241,
     }
-    JAS39_GBU49 = {
-        "clsid": "JAS39_GBU49",
-        "name": "GBU-49 500lb TV Guided Bomb",
+    GBU_49_500_lb_TV_Guided_Bomb = {
+        "clsid": "{JAS39_GBU49}",
+        "name": "GBU-49 500 lb TV Guided Bomb",
         "weight": 241,
     }
-    JAS39_IRIS_T = {"clsid": "JAS39_IRIS-T", "name": "IRIS-T IR AAM", "weight": 88.4}
-    JAS39_Litening = {
-        "clsid": "JAS39_Litening",
+    IRIS_T_IR_AAM = {"clsid": "{JAS39_IRIS-T}", "name": "IRIS-T IR AAM", "weight": 88.4}
+    Litening_III_Targeting_Pod = {
+        "clsid": "{JAS39_Litening}",
         "name": "Litening III Targeting Pod",
         "weight": 208,
     }
-    JAS39_M70BAP = {
-        "clsid": "JAS39_M70BAP",
+    M70B_AP_Unguided_rocket = {
+        "clsid": "{JAS39_M70BAP}",
         "name": "M70B AP Unguided rocket",
         "weight": 372.2,
     }
-    JAS39_M70BHE = {
-        "clsid": "JAS39_M70BHE",
+    M70B_HE_Unguided_rocket = {
+        "clsid": "{JAS39_M70BHE}",
         "name": "M70B HE Unguided rocket",
         "weight": 372.2,
     }
-    JAS39_M71LD = {
-        "clsid": "JAS39_M71LD",
-        "name": "4x M/71 120kg GP Bomb Low-drag",
+    _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = {
+        "clsid": "{JAS39_M71LD}",
+        "name": "4 x M/71 120 kg GP Bomb Low-drag ",
         "weight": 605,
     }
-    JAS39_MAR_1 = {
-        "clsid": "JAS39_MAR-1",
+    MAR_1_High_Speed_Anti_Radiation_Missile = {
+        "clsid": "{JAS39_MAR-1}",
         "name": "MAR-1 High Speed Anti-Radiation Missile",
         "weight": 350,
     }
-    JAS39_Meteor = {
-        "clsid": "JAS39_Meteor",
+    Meteor_BVRAAM_Active_Rdr_AAM = {
+        "clsid": "{JAS39_Meteor}",
         "name": "Meteor BVRAAM Active Rdr AAM",
         "weight": 191,
     }
-    JAS39_PYTHON_5 = {
-        "clsid": "JAS39_PYTHON-5",
+    Python_5_IR_AAM = {
+        "clsid": "{JAS39_PYTHON-5}",
         "name": "Python-5 IR AAM",
         "weight": 106,
     }
-    JAS39_RBS15 = {
-        "clsid": "JAS39_RBS15",
+    RBS_15_Mk4_Gungnir_Anti_ship_Missile = {
+        "clsid": "{JAS39_RBS15}",
         "name": "RBS-15 Mk4 Gungnir Anti-ship Missile",
         "weight": 650,
     }
-    JAS39_RBS15AI = {
-        "clsid": "JAS39_RBS15AI",
+    RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_ = {
+        "clsid": "{JAS39_RBS15AI}",
         "name": "RBS-15 Mk4 Gungnir Anti-ship Missile (AI)",
         "weight": 650,
     }
-    JAS39_SDB = {
-        "clsid": "JAS39_SDB",
-        "name": "GBU-39 SDB 285lb TV Guided Glide-Bomb",
+    _4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_SDB}",
+        "name": "4 x GBU-39 SDB 285 lb TV Guided Glide-Bomb",
         "weight": 661,
     }
-    JAS39_STORMSHADOW = {
-        "clsid": "JAS39_STORMSHADOW",
+    Storm_Shadow_Long_Range_Anti_Radiation_Cruise_missile = {
+        "clsid": "{JAS39_STORMSHADOW_ARM}",
         "name": "Storm Shadow Long Range Anti-Radiation Cruise-missile",
         "weight": 1300,
     }
-    JAS39_TANK1100 = {
-        "clsid": "JAS39_TANK1100",
+    Drop_tank_1100_litre = {
+        "clsid": "{JAS39_TANK1100}",
         "name": "Drop tank 1100 litre",
-        "weight": 1019,
-    }
-    JAS39_TANK1700 = {
-        "clsid": "JAS39_TANK1700",
-        "name": "Drop tank 1700 litre",
-        "weight": 1533,
+        "weight": 946.06,
     }
     Litening_III_Targeting_Pod_FLIR = {
         "clsid": "{JAS39_FLIR}",
         "name": "Litening III Targeting Pod FLIR",
         "weight": 2,
+    }
+    Mk_82_500_lb_GP_Bomb = {
+        "clsid": "{JAS39_MK82}",
+        "name": "Mk-82 500 lb GP Bomb",
+        "weight": 241,
+    }
+    Mk_83_1000_lb_GP_Bomb = {
+        "clsid": "{JAS39_MK83}",
+        "name": "Mk-83 1000 lb GP Bomb",
+        "weight": 447,
+    }
+    Mk_84_2000_lb_GP_Bomb = {
+        "clsid": "{JAS39_MK84}",
+        "name": "Mk-84 2000 lb GP Bomb",
+        "weight": 894,
+    }
+    _2_x_GBU_12_500_lb_Laser_guided_Bomb = {
+        "clsid": "{JAS39_BRU33_GBU12}",
+        "name": "2 x GBU-12 500 lb Laser-guided Bomb",
+        "weight": 625,
+    }
+    _2_x_GBU_16_1000_lb_Laser_guided_Bomb = {
+        "clsid": "{JAS39_BRU33_GBU16}",
+        "name": "2 x GBU-16 1000 lb Laser-guided Bomb",
+        "weight": 983,
+    }
+    _2_x_GBU_32_1000_lb_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_BRU33_GBU32}",
+        "name": "2 x GBU-32 1000 lb TV Guided Glide-Bomb",
+        "weight": 1009,
+    }
+    _2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb = {
+        "clsid": "{JAS39_BRU33_GBU38}",
+        "name": "2 x GBU-38 500 lb TV Guided Glide-Bomb",
+        "weight": 557,
+    }
+    _2_x_GBU_49_500_lb_TV_Guided_Bomb = {
+        "clsid": "{JAS39_BRU33_GBU49}",
+        "name": "2 x GBU-49 500 lb TV Guided Bomb",
+        "weight": 557,
+    }
+    _2_x_Mk_82_500_lb_GP_Bomb = {
+        "clsid": "{JAS39_BRU33_MK82}",
+        "name": "2 x Mk-82 500 lb GP Bomb",
+        "weight": 557,
+    }
+    _2_x_Mk_83_1000_lb_GP_Bomb = {
+        "clsid": "{JAS39_BRU33_MK83}",
+        "name": "2 x Mk-83 1000 lb GP Bomb",
+        "weight": 969,
+    }
+    _3_x_SPEAR_3_Anti_Radiation_Missile = {
+        "clsid": "{JAS39_SPEAR3}",
+        "name": "3 x SPEAR-3 Anti-Radiation Missile",
+        "weight": 360,
+    }
+    _3_x_SPEAR_EW_Decoy = {
+        "clsid": "{JAS39_SPEAREW}",
+        "name": "3 x SPEAR-EW Decoy",
+        "weight": 360,
+    }
+    KEPD_350_Long_Range_Anti_Radiation_Cruise_missile = {
+        "clsid": "{JAS39_KEPD350_ARM}",
+        "name": "KEPD 350 Long Range Anti-Radiation Cruise-missile",
+        "weight": 1400,
     }
 
 
@@ -197,17 +267,18 @@ class JAS39Gripen(PlaneType):
     charge_total = 120
     chaff_charge_size = 1
     flare_charge_size = 1
+    eplrs = True
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     class Pylon1:
-        JAS39_IRIS_T = (1, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (1, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (1, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (1, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (1, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (1, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (1, JAS39GripenWeapons.JAS39_ASRAAM)
+        IRIS_T_IR_AAM = (1, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (1, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (1, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (1, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (1, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (1, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (1, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (1, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
         Smokewinder___red = (1, Weapons.Smokewinder___red)
         Smokewinder___green = (1, Weapons.Smokewinder___green)
@@ -217,79 +288,177 @@ class JAS39Gripen(PlaneType):
         Smokewinder___orange = (1, Weapons.Smokewinder___orange)
 
     class Pylon2:
-        JAS39_IRIS_T = (2, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (2, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (2, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (2, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (2, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (2, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (2, JAS39GripenWeapons.JAS39_ASRAAM)
-        JAS39_Meteor = (2, JAS39GripenWeapons.JAS39_Meteor)
-        JAS39_AIM120B = (2, JAS39GripenWeapons.JAS39_AIM120B)
-        JAS39_AIM120C5 = (2, JAS39GripenWeapons.JAS39_AIM120C5)
-        JAS39_AIM120C7 = (2, JAS39GripenWeapons.JAS39_AIM120C7)
-        JAS39_Derby = (2, JAS39GripenWeapons.JAS39_Derby)
+        IRIS_T_IR_AAM = (2, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (2, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (2, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (2, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (2, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (2, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (2, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
+        Meteor_BVRAAM_Active_Rdr_AAM = (
+            2,
+            JAS39GripenWeapons.Meteor_BVRAAM_Active_Rdr_AAM,
+        )
+        AIM_120B_AMRAAM_Active_Rdr_AAM = (
+            2,
+            JAS39GripenWeapons.AIM_120B_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_5_AMRAAM_Active_Rdr_AAM = (
+            2,
+            JAS39GripenWeapons.AIM_120C_5_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_7_AMRAAM_Active_Rdr_AAM = (
+            2,
+            JAS39GripenWeapons.AIM_120C_7_AMRAAM_Active_Rdr_AAM,
+        )
+        I_Derby_ER_BVRAAM_Active_Rdr_AAM = (
+            2,
+            JAS39GripenWeapons.I_Derby_ER_BVRAAM_Active_Rdr_AAM,
+        )
+        Mk_82_500_lb_GP_Bomb = (2, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (2, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (2, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            2,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        M70B_HE_Unguided_rocket = (2, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (2, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
 
     class Pylon3:
-        JAS39_AIM_9L = (3, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_IRIS_T = (3, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_A_DARTER = (3, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (3, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (3, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (3, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (3, JAS39GripenWeapons.JAS39_ASRAAM)
-        JAS39_Meteor = (3, JAS39GripenWeapons.JAS39_Meteor)
-        JAS39_AIM120B = (3, JAS39GripenWeapons.JAS39_AIM120B)
-        JAS39_AIM120C5 = (3, JAS39GripenWeapons.JAS39_AIM120C5)
-        JAS39_AIM120C7 = (3, JAS39GripenWeapons.JAS39_AIM120C7)
-        JAS39_Derby = (3, JAS39GripenWeapons.JAS39_Derby)
-        JAS39_TANK1100 = (3, JAS39GripenWeapons.JAS39_TANK1100)
-        JAS39_TANK1700 = (3, JAS39GripenWeapons.JAS39_TANK1700)
+        AIM_9L_Sidewinder_IR_AAM_ = (3, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        IRIS_T_IR_AAM = (3, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        A_Darter_IR_AAM = (3, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (3, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (3, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (3, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (3, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
+        Meteor_BVRAAM_Active_Rdr_AAM = (
+            3,
+            JAS39GripenWeapons.Meteor_BVRAAM_Active_Rdr_AAM,
+        )
+        AIM_120B_AMRAAM_Active_Rdr_AAM = (
+            3,
+            JAS39GripenWeapons.AIM_120B_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_5_AMRAAM_Active_Rdr_AAM = (
+            3,
+            JAS39GripenWeapons.AIM_120C_5_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_7_AMRAAM_Active_Rdr_AAM = (
+            3,
+            JAS39GripenWeapons.AIM_120C_7_AMRAAM_Active_Rdr_AAM,
+        )
+        I_Derby_ER_BVRAAM_Active_Rdr_AAM = (
+            3,
+            JAS39GripenWeapons.I_Derby_ER_BVRAAM_Active_Rdr_AAM,
+        )
+        Mk_82_500_lb_GP_Bomb = (3, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (3, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        Mk_84_2000_lb_GP_Bomb = (3, JAS39GripenWeapons.Mk_84_2000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (3, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _2_x_Mk_83_1000_lb_GP_Bomb = (3, JAS39GripenWeapons._2_x_Mk_83_1000_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            3,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        M70B_HE_Unguided_rocket = (3, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (3, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
+        Drop_tank_1100_litre = (3, JAS39GripenWeapons.Drop_tank_1100_litre)
 
     class Pylon4:
-        JAS39_TANK1100 = (4, JAS39GripenWeapons.JAS39_TANK1100)
+        Drop_tank_1100_litre = (4, JAS39GripenWeapons.Drop_tank_1100_litre)
 
     class Pylon5:
-        JAS39_Litening = (5, JAS39GripenWeapons.JAS39_Litening)
+        Litening_III_Targeting_Pod = (5, JAS39GripenWeapons.Litening_III_Targeting_Pod)
 
     class Pylon6:
-        JAS39_AIM_9L = (6, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_IRIS_T = (6, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_A_DARTER = (6, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (6, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (6, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (6, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (6, JAS39GripenWeapons.JAS39_ASRAAM)
-        JAS39_Meteor = (6, JAS39GripenWeapons.JAS39_Meteor)
-        JAS39_AIM120B = (6, JAS39GripenWeapons.JAS39_AIM120B)
-        JAS39_AIM120C5 = (6, JAS39GripenWeapons.JAS39_AIM120C5)
-        JAS39_AIM120C7 = (6, JAS39GripenWeapons.JAS39_AIM120C7)
-        JAS39_Derby = (6, JAS39GripenWeapons.JAS39_Derby)
-        JAS39_TANK1100 = (6, JAS39GripenWeapons.JAS39_TANK1100)
-        JAS39_TANK1700 = (6, JAS39GripenWeapons.JAS39_TANK1700)
+        AIM_9L_Sidewinder_IR_AAM_ = (6, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        IRIS_T_IR_AAM = (6, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        A_Darter_IR_AAM = (6, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (6, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (6, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (6, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (6, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
+        Meteor_BVRAAM_Active_Rdr_AAM = (
+            6,
+            JAS39GripenWeapons.Meteor_BVRAAM_Active_Rdr_AAM,
+        )
+        AIM_120B_AMRAAM_Active_Rdr_AAM = (
+            6,
+            JAS39GripenWeapons.AIM_120B_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_5_AMRAAM_Active_Rdr_AAM = (
+            6,
+            JAS39GripenWeapons.AIM_120C_5_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_7_AMRAAM_Active_Rdr_AAM = (
+            6,
+            JAS39GripenWeapons.AIM_120C_7_AMRAAM_Active_Rdr_AAM,
+        )
+        I_Derby_ER_BVRAAM_Active_Rdr_AAM = (
+            6,
+            JAS39GripenWeapons.I_Derby_ER_BVRAAM_Active_Rdr_AAM,
+        )
+        Mk_82_500_lb_GP_Bomb = (6, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (6, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        Mk_84_2000_lb_GP_Bomb = (6, JAS39GripenWeapons.Mk_84_2000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (6, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _2_x_Mk_83_1000_lb_GP_Bomb = (6, JAS39GripenWeapons._2_x_Mk_83_1000_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            6,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        M70B_HE_Unguided_rocket = (6, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (6, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
+        Drop_tank_1100_litre = (6, JAS39GripenWeapons.Drop_tank_1100_litre)
 
     class Pylon7:
-        JAS39_IRIS_T = (7, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (7, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (7, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (7, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (7, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (7, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (7, JAS39GripenWeapons.JAS39_ASRAAM)
-        JAS39_Meteor = (7, JAS39GripenWeapons.JAS39_Meteor)
-        JAS39_AIM120B = (7, JAS39GripenWeapons.JAS39_AIM120B)
-        JAS39_AIM120C5 = (7, JAS39GripenWeapons.JAS39_AIM120C5)
-        JAS39_AIM120C7 = (7, JAS39GripenWeapons.JAS39_AIM120C7)
-        JAS39_Derby = (7, JAS39GripenWeapons.JAS39_Derby)
+        IRIS_T_IR_AAM = (7, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (7, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (7, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (7, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (7, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (7, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (7, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
+        Meteor_BVRAAM_Active_Rdr_AAM = (
+            7,
+            JAS39GripenWeapons.Meteor_BVRAAM_Active_Rdr_AAM,
+        )
+        AIM_120B_AMRAAM_Active_Rdr_AAM = (
+            7,
+            JAS39GripenWeapons.AIM_120B_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_5_AMRAAM_Active_Rdr_AAM = (
+            7,
+            JAS39GripenWeapons.AIM_120C_5_AMRAAM_Active_Rdr_AAM,
+        )
+        AIM_120C_7_AMRAAM_Active_Rdr_AAM = (
+            7,
+            JAS39GripenWeapons.AIM_120C_7_AMRAAM_Active_Rdr_AAM,
+        )
+        I_Derby_ER_BVRAAM_Active_Rdr_AAM = (
+            7,
+            JAS39GripenWeapons.I_Derby_ER_BVRAAM_Active_Rdr_AAM,
+        )
+        Mk_82_500_lb_GP_Bomb = (7, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (7, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (7, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            7,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        M70B_HE_Unguided_rocket = (7, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (7, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
 
     class Pylon8:
-        JAS39_IRIS_T = (8, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (8, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (8, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (8, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (8, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (8, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (8, JAS39GripenWeapons.JAS39_ASRAAM)
+        IRIS_T_IR_AAM = (8, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (8, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (8, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (8, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (8, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (8, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (8, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (8, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
         Smokewinder___red = (8, Weapons.Smokewinder___red)
         Smokewinder___green = (8, Weapons.Smokewinder___green)
@@ -335,17 +504,18 @@ class JAS39Gripen_AG(PlaneType):
     charge_total = 120
     chaff_charge_size = 1
     flare_charge_size = 1
+    eplrs = True
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     class Pylon1:
-        JAS39_IRIS_T = (1, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (1, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (1, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (1, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (1, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (1, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (1, JAS39GripenWeapons.JAS39_ASRAAM)
+        IRIS_T_IR_AAM = (1, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (1, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (1, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (1, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (1, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (1, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (1, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (1, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
         Smokewinder___red = (1, Weapons.Smokewinder___red)
         Smokewinder___green = (1, Weapons.Smokewinder___green)
@@ -355,165 +525,440 @@ class JAS39Gripen_AG(PlaneType):
         Smokewinder___orange = (1, Weapons.Smokewinder___orange)
 
     class Pylon2:
-        JAS39_IRIS_T = (2, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (2, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (2, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (2, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (2, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (2, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (2, JAS39GripenWeapons.JAS39_ASRAAM)
-        JAS39_RBS15 = (2, JAS39GripenWeapons.JAS39_RBS15)
-        JAS39_RBS15AI = (2, JAS39GripenWeapons.JAS39_RBS15AI)
-        JAS39_MAR_1 = (2, JAS39GripenWeapons.JAS39_MAR_1)
-        JAS39_GBU49 = (2, JAS39GripenWeapons.JAS39_GBU49)
-        JAS39_GBU32 = (2, JAS39GripenWeapons.JAS39_GBU32)
-        JAS39_GBU38 = (2, JAS39GripenWeapons.JAS39_GBU38)
-        JAS39_SDB = (2, JAS39GripenWeapons.JAS39_SDB)
-        JAS39_GBU12 = (2, JAS39GripenWeapons.JAS39_GBU12)
-        JAS39_GBU16 = (2, JAS39GripenWeapons.JAS39_GBU16)
-        JAS39_DWS39 = (2, JAS39GripenWeapons.JAS39_DWS39)
-        Mk_82___500lb_GP_Bomb_LD = (2, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        Mk_83___1000lb_GP_Bomb_LD = (2, Weapons.Mk_83___1000lb_GP_Bomb_LD)
-        JAS39_M71LD = (2, JAS39GripenWeapons.JAS39_M71LD)
-        JAS39_M70BHE = (2, JAS39GripenWeapons.JAS39_M70BHE)
-        JAS39_M70BAP = (2, JAS39GripenWeapons.JAS39_M70BAP)
-        JAS39_BRIMSTONE = (2, JAS39GripenWeapons.JAS39_BRIMSTONE)
+        IRIS_T_IR_AAM = (2, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (2, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (2, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (2, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (2, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (2, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (2, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile = (
+            2,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile,
+        )
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_ = (
+            2,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_,
+        )
+        MAR_1_High_Speed_Anti_Radiation_Missile = (
+            2,
+            JAS39GripenWeapons.MAR_1_High_Speed_Anti_Radiation_Missile,
+        )
+        GBU_49_500_lb_TV_Guided_Bomb = (
+            2,
+            JAS39GripenWeapons.GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_32_1000_lb_TV_Guided_Glide_Bomb = (
+            2,
+            JAS39GripenWeapons.GBU_32_1000_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            2,
+            JAS39GripenWeapons.GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb = (
+            2,
+            JAS39GripenWeapons._4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_12_500_lb_Laser_guided_Bomb = (
+            2,
+            JAS39GripenWeapons.GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_12_500_lb_Laser_guided_Bomb = (
+            2,
+            JAS39GripenWeapons._2_x_GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            2,
+            JAS39GripenWeapons._2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _2_x_GBU_49_500_lb_TV_Guided_Bomb = (
+            2,
+            JAS39GripenWeapons._2_x_GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_16_1000_lb_Laser_guided_Bomb = (
+            2,
+            JAS39GripenWeapons.GBU_16_1000_lb_Laser_guided_Bomb,
+        )
+        DWS_39_MJ2_TV_Guided_Cluster_Bomb = (
+            2,
+            JAS39GripenWeapons.DWS_39_MJ2_TV_Guided_Cluster_Bomb,
+        )
+        DWS_39_MJ2_Anti_radiation_Cluster_Bomb = (
+            2,
+            JAS39GripenWeapons.DWS_39_MJ2_Anti_radiation_Cluster_Bomb,
+        )
+        Mk_82_500_lb_GP_Bomb = (2, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (2, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (2, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            2,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        M70B_HE_Unguided_rocket = (2, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (2, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
+        _3_x_Brimstone_Laser_Guided_Missile = (
+            2,
+            JAS39GripenWeapons._3_x_Brimstone_Laser_Guided_Missile,
+        )
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
             2,
             Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
         )
         LAU_117_AGM_65H = (2, Weapons.LAU_117_AGM_65H)
+        _3_x_SPEAR_3_Anti_Radiation_Missile = (
+            2,
+            JAS39GripenWeapons._3_x_SPEAR_3_Anti_Radiation_Missile,
+        )
+        _3_x_SPEAR_EW_Decoy = (2, JAS39GripenWeapons._3_x_SPEAR_EW_Decoy)
 
     class Pylon3:
-        JAS39_AIM_9L = (3, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_IRIS_T = (3, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_A_DARTER = (3, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (3, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (3, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (3, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (3, JAS39GripenWeapons.JAS39_ASRAAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (3, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        IRIS_T_IR_AAM = (3, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        A_Darter_IR_AAM = (3, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (3, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (3, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (3, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (3, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
             3,
             Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
         )
         LAU_117_AGM_65H = (3, Weapons.LAU_117_AGM_65H)
-        JAS39_BRIMSTONE = (3, JAS39GripenWeapons.JAS39_BRIMSTONE)
-        JAS39_RBS15 = (3, JAS39GripenWeapons.JAS39_RBS15)
-        JAS39_RBS15AI = (3, JAS39GripenWeapons.JAS39_RBS15AI)
-        JAS39_MAR_1 = (3, JAS39GripenWeapons.JAS39_MAR_1)
-        JAS39_GBU49 = (3, JAS39GripenWeapons.JAS39_GBU49)
-        JAS39_GBU31 = (3, JAS39GripenWeapons.JAS39_GBU31)
-        JAS39_GBU32 = (3, JAS39GripenWeapons.JAS39_GBU32)
-        JAS39_GBU38 = (3, JAS39GripenWeapons.JAS39_GBU38)
-        JAS39_SDB = (3, JAS39GripenWeapons.JAS39_SDB)
-        JAS39_GBU12 = (3, JAS39GripenWeapons.JAS39_GBU12)
-        JAS39_GBU10 = (3, JAS39GripenWeapons.JAS39_GBU10)
-        JAS39_GBU16 = (3, JAS39GripenWeapons.JAS39_GBU16)
-        JAS39_DWS39 = (3, JAS39GripenWeapons.JAS39_DWS39)
-        Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        Mk_83___1000lb_GP_Bomb_LD = (3, Weapons.Mk_83___1000lb_GP_Bomb_LD)
-        Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        JAS39_M71LD = (3, JAS39GripenWeapons.JAS39_M71LD)
-        JAS39_TANK1100 = (3, JAS39GripenWeapons.JAS39_TANK1100)
-        JAS39_TANK1700 = (3, JAS39GripenWeapons.JAS39_TANK1700)
-        JAS39_M70BHE = (3, JAS39GripenWeapons.JAS39_M70BHE)
-        JAS39_M70BAP = (3, JAS39GripenWeapons.JAS39_M70BAP)
-        JAS39_STORMSHADOW = (3, JAS39GripenWeapons.JAS39_STORMSHADOW)
+        _3_x_Brimstone_Laser_Guided_Missile = (
+            3,
+            JAS39GripenWeapons._3_x_Brimstone_Laser_Guided_Missile,
+        )
+        _3_x_SPEAR_3_Anti_Radiation_Missile = (
+            3,
+            JAS39GripenWeapons._3_x_SPEAR_3_Anti_Radiation_Missile,
+        )
+        _3_x_SPEAR_EW_Decoy = (3, JAS39GripenWeapons._3_x_SPEAR_EW_Decoy)
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile = (
+            3,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile,
+        )
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_ = (
+            3,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_,
+        )
+        MAR_1_High_Speed_Anti_Radiation_Missile = (
+            3,
+            JAS39GripenWeapons.MAR_1_High_Speed_Anti_Radiation_Missile,
+        )
+        GBU_49_500_lb_TV_Guided_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_31_2000_lb_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_31_2000_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_31_2000_lb_Penetrator_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_31_2000_lb_Penetrator_TV_Guided_Glide_Bomb,
+        )
+        GBU_32_1000_lb_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_32_1000_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons._4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_12_500_lb_Laser_guided_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_12_500_lb_Laser_guided_Bomb = (
+            3,
+            JAS39GripenWeapons._2_x_GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons._2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _2_x_GBU_49_500_lb_TV_Guided_Bomb = (
+            3,
+            JAS39GripenWeapons._2_x_GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_10_2000_lb_Laser_guided_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_10_2000_lb_Laser_guided_Bomb,
+        )
+        GBU_16_1000_lb_Laser_guided_Bomb = (
+            3,
+            JAS39GripenWeapons.GBU_16_1000_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_16_1000_lb_Laser_guided_Bomb = (
+            3,
+            JAS39GripenWeapons._2_x_GBU_16_1000_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_32_1000_lb_TV_Guided_Glide_Bomb = (
+            3,
+            JAS39GripenWeapons._2_x_GBU_32_1000_lb_TV_Guided_Glide_Bomb,
+        )
+        DWS_39_MJ2_TV_Guided_Cluster_Bomb = (
+            3,
+            JAS39GripenWeapons.DWS_39_MJ2_TV_Guided_Cluster_Bomb,
+        )
+        DWS_39_MJ2_Anti_radiation_Cluster_Bomb = (
+            3,
+            JAS39GripenWeapons.DWS_39_MJ2_Anti_radiation_Cluster_Bomb,
+        )
+        Mk_82_500_lb_GP_Bomb = (3, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (3, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        Mk_84_2000_lb_GP_Bomb = (3, JAS39GripenWeapons.Mk_84_2000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (3, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _2_x_Mk_83_1000_lb_GP_Bomb = (3, JAS39GripenWeapons._2_x_Mk_83_1000_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            3,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        Drop_tank_1100_litre = (3, JAS39GripenWeapons.Drop_tank_1100_litre)
+        M70B_HE_Unguided_rocket = (3, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (3, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
+        Storm_Shadow_Long_Range_Anti_Radiation_Cruise_missile = (
+            3,
+            JAS39GripenWeapons.Storm_Shadow_Long_Range_Anti_Radiation_Cruise_missile,
+        )
+        KEPD_350_Long_Range_Anti_Radiation_Cruise_missile = (
+            3,
+            JAS39GripenWeapons.KEPD_350_Long_Range_Anti_Radiation_Cruise_missile,
+        )
 
     class Pylon4:
-        JAS39_BRIMSTONE = (4, JAS39GripenWeapons.JAS39_BRIMSTONE)
-        JAS39_STORMSHADOW = (4, JAS39GripenWeapons.JAS39_STORMSHADOW)
-        JAS39_GBU49 = (4, JAS39GripenWeapons.JAS39_GBU49)
-        JAS39_GBU31 = (4, JAS39GripenWeapons.JAS39_GBU31)
-        JAS39_GBU32 = (4, JAS39GripenWeapons.JAS39_GBU32)
-        JAS39_GBU38 = (4, JAS39GripenWeapons.JAS39_GBU38)
-        JAS39_SDB = (4, JAS39GripenWeapons.JAS39_SDB)
-        JAS39_GBU10 = (4, JAS39GripenWeapons.JAS39_GBU10)
-        JAS39_GBU12 = (4, JAS39GripenWeapons.JAS39_GBU12)
-        JAS39_GBU16 = (4, JAS39GripenWeapons.JAS39_GBU16)
-        Mk_82___500lb_GP_Bomb_LD = (4, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
-        Mk_84___2000lb_GP_Bomb_LD = (4, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        JAS39_M71LD = (4, JAS39GripenWeapons.JAS39_M71LD)
-        JAS39_TANK1100 = (4, JAS39GripenWeapons.JAS39_TANK1100)
+        Drop_tank_1100_litre = (4, JAS39GripenWeapons.Drop_tank_1100_litre)
+
+    # ERRR {INV-SMOKE-RED}
+    # ERRR {INV-SMOKE-GREEN}
+    # ERRR {INV-SMOKE-BLUE}
+    # ERRR {INV-SMOKE-WHITE}
+    # ERRR {INV-SMOKE-YELLOW}
+    # ERRR {INV-SMOKE-ORANGE}
 
     class Pylon5:
-        JAS39_Litening = (5, JAS39GripenWeapons.JAS39_Litening)
+        Litening_III_Targeting_Pod = (5, JAS39GripenWeapons.Litening_III_Targeting_Pod)
 
     class Pylon6:
-        JAS39_AIM_9L = (6, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_IRIS_T = (6, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_A_DARTER = (6, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (6, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (6, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (6, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (6, JAS39GripenWeapons.JAS39_ASRAAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (6, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        IRIS_T_IR_AAM = (6, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        A_Darter_IR_AAM = (6, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (6, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (6, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (6, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (6, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
             6,
             Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
         )
         LAU_117_AGM_65H = (6, Weapons.LAU_117_AGM_65H)
-        JAS39_BRIMSTONE = (6, JAS39GripenWeapons.JAS39_BRIMSTONE)
-        JAS39_RBS15 = (6, JAS39GripenWeapons.JAS39_RBS15)
-        JAS39_RBS15AI = (6, JAS39GripenWeapons.JAS39_RBS15AI)
-        JAS39_MAR_1 = (6, JAS39GripenWeapons.JAS39_MAR_1)
-        JAS39_GBU49 = (6, JAS39GripenWeapons.JAS39_GBU49)
-        JAS39_GBU31 = (6, JAS39GripenWeapons.JAS39_GBU31)
-        JAS39_GBU32 = (6, JAS39GripenWeapons.JAS39_GBU32)
-        JAS39_GBU38 = (6, JAS39GripenWeapons.JAS39_GBU38)
-        JAS39_SDB = (6, JAS39GripenWeapons.JAS39_SDB)
-        JAS39_GBU12 = (6, JAS39GripenWeapons.JAS39_GBU12)
-        JAS39_GBU10 = (6, JAS39GripenWeapons.JAS39_GBU10)
-        JAS39_GBU16 = (6, JAS39GripenWeapons.JAS39_GBU16)
-        JAS39_DWS39 = (6, JAS39GripenWeapons.JAS39_DWS39)
-        Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        Mk_83___1000lb_GP_Bomb_LD = (6, Weapons.Mk_83___1000lb_GP_Bomb_LD)
-        Mk_84___2000lb_GP_Bomb_LD = (6, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        JAS39_M71LD = (6, JAS39GripenWeapons.JAS39_M71LD)
-        JAS39_TANK1100 = (6, JAS39GripenWeapons.JAS39_TANK1100)
-        JAS39_TANK1700 = (6, JAS39GripenWeapons.JAS39_TANK1700)
-        JAS39_M70BHE = (6, JAS39GripenWeapons.JAS39_M70BHE)
-        JAS39_M70BAP = (6, JAS39GripenWeapons.JAS39_M70BAP)
-        JAS39_STORMSHADOW = (6, JAS39GripenWeapons.JAS39_STORMSHADOW)
+        _3_x_Brimstone_Laser_Guided_Missile = (
+            6,
+            JAS39GripenWeapons._3_x_Brimstone_Laser_Guided_Missile,
+        )
+        _3_x_SPEAR_3_Anti_Radiation_Missile = (
+            6,
+            JAS39GripenWeapons._3_x_SPEAR_3_Anti_Radiation_Missile,
+        )
+        _3_x_SPEAR_EW_Decoy = (6, JAS39GripenWeapons._3_x_SPEAR_EW_Decoy)
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile = (
+            6,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile,
+        )
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_ = (
+            6,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_,
+        )
+        MAR_1_High_Speed_Anti_Radiation_Missile = (
+            6,
+            JAS39GripenWeapons.MAR_1_High_Speed_Anti_Radiation_Missile,
+        )
+        GBU_49_500_lb_TV_Guided_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_31_2000_lb_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_31_2000_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_31_2000_lb_Penetrator_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_31_2000_lb_Penetrator_TV_Guided_Glide_Bomb,
+        )
+        GBU_32_1000_lb_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_32_1000_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons._4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_12_500_lb_Laser_guided_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_12_500_lb_Laser_guided_Bomb = (
+            6,
+            JAS39GripenWeapons._2_x_GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons._2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _2_x_GBU_49_500_lb_TV_Guided_Bomb = (
+            6,
+            JAS39GripenWeapons._2_x_GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_10_2000_lb_Laser_guided_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_10_2000_lb_Laser_guided_Bomb,
+        )
+        GBU_16_1000_lb_Laser_guided_Bomb = (
+            6,
+            JAS39GripenWeapons.GBU_16_1000_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_16_1000_lb_Laser_guided_Bomb = (
+            6,
+            JAS39GripenWeapons._2_x_GBU_16_1000_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_32_1000_lb_TV_Guided_Glide_Bomb = (
+            6,
+            JAS39GripenWeapons._2_x_GBU_32_1000_lb_TV_Guided_Glide_Bomb,
+        )
+        DWS_39_MJ2_TV_Guided_Cluster_Bomb = (
+            6,
+            JAS39GripenWeapons.DWS_39_MJ2_TV_Guided_Cluster_Bomb,
+        )
+        DWS_39_MJ2_Anti_radiation_Cluster_Bomb = (
+            6,
+            JAS39GripenWeapons.DWS_39_MJ2_Anti_radiation_Cluster_Bomb,
+        )
+        Mk_82_500_lb_GP_Bomb = (6, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (6, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        Mk_84_2000_lb_GP_Bomb = (6, JAS39GripenWeapons.Mk_84_2000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (6, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _2_x_Mk_83_1000_lb_GP_Bomb = (6, JAS39GripenWeapons._2_x_Mk_83_1000_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            6,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        Drop_tank_1100_litre = (6, JAS39GripenWeapons.Drop_tank_1100_litre)
+        M70B_HE_Unguided_rocket = (6, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (6, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
+        Storm_Shadow_Long_Range_Anti_Radiation_Cruise_missile = (
+            6,
+            JAS39GripenWeapons.Storm_Shadow_Long_Range_Anti_Radiation_Cruise_missile,
+        )
+        KEPD_350_Long_Range_Anti_Radiation_Cruise_missile = (
+            6,
+            JAS39GripenWeapons.KEPD_350_Long_Range_Anti_Radiation_Cruise_missile,
+        )
 
     class Pylon7:
-        JAS39_IRIS_T = (7, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (7, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (7, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (7, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (7, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (7, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (7, JAS39GripenWeapons.JAS39_ASRAAM)
-        JAS39_RBS15 = (7, JAS39GripenWeapons.JAS39_RBS15)
-        JAS39_RBS15AI = (7, JAS39GripenWeapons.JAS39_RBS15AI)
-        JAS39_MAR_1 = (7, JAS39GripenWeapons.JAS39_MAR_1)
-        JAS39_GBU49 = (7, JAS39GripenWeapons.JAS39_GBU49)
-        JAS39_GBU32 = (7, JAS39GripenWeapons.JAS39_GBU32)
-        JAS39_GBU38 = (7, JAS39GripenWeapons.JAS39_GBU38)
-        JAS39_SDB = (7, JAS39GripenWeapons.JAS39_SDB)
-        JAS39_GBU12 = (7, JAS39GripenWeapons.JAS39_GBU12)
-        JAS39_GBU16 = (7, JAS39GripenWeapons.JAS39_GBU16)
-        JAS39_DWS39 = (7, JAS39GripenWeapons.JAS39_DWS39)
-        Mk_82___500lb_GP_Bomb_LD = (7, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        Mk_83___1000lb_GP_Bomb_LD = (7, Weapons.Mk_83___1000lb_GP_Bomb_LD)
-        JAS39_M71LD = (7, JAS39GripenWeapons.JAS39_M71LD)
-        JAS39_M70BHE = (7, JAS39GripenWeapons.JAS39_M70BHE)
-        JAS39_M70BAP = (7, JAS39GripenWeapons.JAS39_M70BAP)
-        JAS39_BRIMSTONE = (7, JAS39GripenWeapons.JAS39_BRIMSTONE)
+        IRIS_T_IR_AAM = (7, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (7, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (7, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (7, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (7, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (7, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (7, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile = (
+            7,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile,
+        )
+        RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_ = (
+            7,
+            JAS39GripenWeapons.RBS_15_Mk4_Gungnir_Anti_ship_Missile__AI_,
+        )
+        MAR_1_High_Speed_Anti_Radiation_Missile = (
+            7,
+            JAS39GripenWeapons.MAR_1_High_Speed_Anti_Radiation_Missile,
+        )
+        GBU_49_500_lb_TV_Guided_Bomb = (
+            7,
+            JAS39GripenWeapons.GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_32_1000_lb_TV_Guided_Glide_Bomb = (
+            7,
+            JAS39GripenWeapons.GBU_32_1000_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            7,
+            JAS39GripenWeapons.GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb = (
+            7,
+            JAS39GripenWeapons._4_x_GBU_39_SDB_285_lb_TV_Guided_Glide_Bomb,
+        )
+        GBU_12_500_lb_Laser_guided_Bomb = (
+            7,
+            JAS39GripenWeapons.GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_12_500_lb_Laser_guided_Bomb = (
+            7,
+            JAS39GripenWeapons._2_x_GBU_12_500_lb_Laser_guided_Bomb,
+        )
+        _2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb = (
+            7,
+            JAS39GripenWeapons._2_x_GBU_38_500_lb_TV_Guided_Glide_Bomb,
+        )
+        _2_x_GBU_49_500_lb_TV_Guided_Bomb = (
+            7,
+            JAS39GripenWeapons._2_x_GBU_49_500_lb_TV_Guided_Bomb,
+        )
+        GBU_16_1000_lb_Laser_guided_Bomb = (
+            7,
+            JAS39GripenWeapons.GBU_16_1000_lb_Laser_guided_Bomb,
+        )
+        DWS_39_MJ2_TV_Guided_Cluster_Bomb = (
+            7,
+            JAS39GripenWeapons.DWS_39_MJ2_TV_Guided_Cluster_Bomb,
+        )
+        DWS_39_MJ2_Anti_radiation_Cluster_Bomb = (
+            7,
+            JAS39GripenWeapons.DWS_39_MJ2_Anti_radiation_Cluster_Bomb,
+        )
+        Mk_82_500_lb_GP_Bomb = (7, JAS39GripenWeapons.Mk_82_500_lb_GP_Bomb)
+        Mk_83_1000_lb_GP_Bomb = (7, JAS39GripenWeapons.Mk_83_1000_lb_GP_Bomb)
+        _2_x_Mk_82_500_lb_GP_Bomb = (7, JAS39GripenWeapons._2_x_Mk_82_500_lb_GP_Bomb)
+        _4_x_M_71_120_kg_GP_Bomb_Low_drag_ = (
+            7,
+            JAS39GripenWeapons._4_x_M_71_120_kg_GP_Bomb_Low_drag_,
+        )
+        M70B_HE_Unguided_rocket = (7, JAS39GripenWeapons.M70B_HE_Unguided_rocket)
+        M70B_AP_Unguided_rocket = (7, JAS39GripenWeapons.M70B_AP_Unguided_rocket)
+        _3_x_Brimstone_Laser_Guided_Missile = (
+            7,
+            JAS39GripenWeapons._3_x_Brimstone_Laser_Guided_Missile,
+        )
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
             7,
             Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
         )
         LAU_117_AGM_65H = (7, Weapons.LAU_117_AGM_65H)
+        _3_x_SPEAR_3_Anti_Radiation_Missile = (
+            7,
+            JAS39GripenWeapons._3_x_SPEAR_3_Anti_Radiation_Missile,
+        )
+        _3_x_SPEAR_EW_Decoy = (7, JAS39GripenWeapons._3_x_SPEAR_EW_Decoy)
 
     class Pylon8:
-        JAS39_IRIS_T = (8, JAS39GripenWeapons.JAS39_IRIS_T)
-        JAS39_AIM_9L = (8, JAS39GripenWeapons.JAS39_AIM_9L)
-        JAS39_A_DARTER = (8, JAS39GripenWeapons.JAS39_A_DARTER)
-        JAS39_AIM_9M = (8, JAS39GripenWeapons.JAS39_AIM_9M)
-        JAS39_AIM_9X = (8, JAS39GripenWeapons.JAS39_AIM_9X)
-        JAS39_PYTHON_5 = (8, JAS39GripenWeapons.JAS39_PYTHON_5)
-        JAS39_ASRAAM = (8, JAS39GripenWeapons.JAS39_ASRAAM)
+        IRIS_T_IR_AAM = (8, JAS39GripenWeapons.IRIS_T_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM_ = (8, JAS39GripenWeapons.AIM_9L_Sidewinder_IR_AAM_)
+        A_Darter_IR_AAM = (8, JAS39GripenWeapons.A_Darter_IR_AAM)
+        AIM_9M_Sidewinder_IR_AAM_ = (8, JAS39GripenWeapons.AIM_9M_Sidewinder_IR_AAM_)
+        AIM_9X_Sidewinder_IR_AAM_ = (8, JAS39GripenWeapons.AIM_9X_Sidewinder_IR_AAM_)
+        Python_5_IR_AAM = (8, JAS39GripenWeapons.Python_5_IR_AAM)
+        AIM_132_ASRAAM_IR_AAM = (8, JAS39GripenWeapons.AIM_132_ASRAAM_IR_AAM)
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (8, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
         Smokewinder___red = (8, Weapons.Smokewinder___red)
         Smokewinder___green = (8, Weapons.Smokewinder___green)

--- a/resources/customized_payloads/JAS39Gripen.lua
+++ b/resources/customized_payloads/JAS39Gripen.lua
@@ -6,7 +6,7 @@ local unitPayloads = {
 			["name"] = "CAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[2] = {
@@ -18,23 +18,23 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[5] = {
-					["CLSID"] = "JAS39_Meteor",
+					["CLSID"] = "{JAS39_Meteor}",
 					["num"] = 7,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_Meteor",
+					["CLSID"] = "{JAS39_Meteor}",
 					["num"] = 6,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_Meteor",
+					["CLSID"] = "{JAS39_Meteor}",
 					["num"] = 2,
 				},
 				[8] = {
-					["CLSID"] = "JAS39_Meteor",
+					["CLSID"] = "{JAS39_Meteor}",
 					["num"] = 3,
 				},
 				[9] = {

--- a/resources/customized_payloads/JAS39Gripen.lua
+++ b/resources/customized_payloads/JAS39Gripen.lua
@@ -38,7 +38,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[9] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 			},

--- a/resources/customized_payloads/JAS39Gripen_AG.lua
+++ b/resources/customized_payloads/JAS39Gripen_AG.lua
@@ -6,15 +6,15 @@ local unitPayloads = {
 			["name"] = "ANTISHIP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[3] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 				[4] = {
@@ -26,19 +26,19 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_RBS15AI",
+					["CLSID"] = "{JAS39_RBS15AI}",
 					["num"] = 6,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_RBS15AI",
+					["CLSID"] = "{JAS39_RBS15AI}",
 					["num"] = 7,
 				},
                 [8] = {
-					["CLSID"] = "JAS39_RBS15AI",
+					["CLSID"] = "{JAS39_RBS15AI}",
 					["num"] = 2,
 				},
                 [9] = {
-					["CLSID"] = "JAS39_RBS15AI",
+					["CLSID"] = "{JAS39_RBS15AI}",
 					["num"] = 3,
 				},
 			},
@@ -51,15 +51,15 @@ local unitPayloads = {
 			["name"] = "SEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[3] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 				[4] = {
@@ -71,19 +71,19 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_MAR-1",
+					["CLSID"] = "{JAS39_MAR-1}",
 					["num"] = 2,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_MAR-1",
+					["CLSID"] = "{JAS39_MAR-1}",
 					["num"] = 3,
 				},
                 [8] = {
-					["CLSID"] = "JAS39_MAR-1",
+					["CLSID"] = "{JAS39_MAR-1}",
 					["num"] = 6,
 				},
                 [9] = {
-					["CLSID"] = "JAS39_MAR-1",
+					["CLSID"] = "{JAS39_MAR-1}",
 					["num"] = 7,
 				},
 			},
@@ -96,15 +96,15 @@ local unitPayloads = {
 			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[3] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 				[4] = {
@@ -116,19 +116,19 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_STORMSHADOW",
+					["CLSID"] = "{JAS39_STORMSHADOW_ARM}",
 					["num"] = 3,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_STORMSHADOW",
+					["CLSID"] = "{JAS39_STORMSHADOW_ARM}",
 					["num"] = 6,
 				},
                 [8] = {
-					["CLSID"] = "JAS39_MAR-1",
+					["CLSID"] = "{JAS39_MAR-1}",
 					["num"] = 2,
 				},
                 [9] = {
-					["CLSID"] = "JAS39_MAR-1",
+					["CLSID"] = "{JAS39_MAR-1}",
 					["num"] = 7,
 				},
 			},
@@ -141,15 +141,15 @@ local unitPayloads = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[3] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 				[4] = {
@@ -161,23 +161,23 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_BRIMSTONE",
+					["CLSID"] = "{JAS39_BRIMSTONE}",
 					["num"] = 2,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_BRIMSTONE",
+					["CLSID"] = "{JAS39_BRIMSTONE}",
 					["num"] = 3,
 				},
                 [8] = {
-					["CLSID"] = "JAS39_BRIMSTONE",
+					["CLSID"] = "{JAS39_BRIMSTONE}",
 					["num"] = 6,
 				},
                 [9] = {
-					["CLSID"] = "JAS39_BRIMSTONE",
+					["CLSID"] = "{JAS39_BRIMSTONE}",
 					["num"] = 7,
 				},
                 [10] = {
-					["CLSID"] = "JAS39_Litening",
+					["CLSID"] = "{JAS39_Litening}",
 					["num"] = 5,
 				},
 				[11] = {
@@ -194,15 +194,15 @@ local unitPayloads = {
 			["name"] = "STRIKE",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[3] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 				[4] = {
@@ -214,23 +214,23 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_GBU31",
+					["CLSID"] = "{JAS39_GBU31}",
 					["num"] = 2,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_GBU31",
+					["CLSID"] = "{JAS39_GBU31}",
 					["num"] = 7,
 				},
                 [8] = {
-					["CLSID"] = "JAS39_GBU49",
+					["CLSID"] = "{JAS39_GBU49}",
 					["num"] = 3,
 				},
                 [9] = {
-					["CLSID"] = "JAS39_GBU49",
+					["CLSID"] = "{JAS39_GBU49}",
 					["num"] = 6,
 				},
                 [10] = {
-					["CLSID"] = "JAS39_Litening",
+					["CLSID"] = "{JAS39_Litening}",
 					["num"] = 5,
 				},
 				[11] = {
@@ -247,15 +247,15 @@ local unitPayloads = {
 			["name"] = "OCA",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "JAS39_IRIS-T",
+					["CLSID"] = "{JAS39_IRIS-T}",
 					["num"] = 8,
 				},
 				[3] = {
-					["CLSID"] = "JAS39_TANK1100",
+					["CLSID"] = "{JAS39_TANK1100}",
 					["num"] = 4,
 				},
 				[4] = {
@@ -267,23 +267,23 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "JAS39_DWS39",
+					["CLSID"] = "{JAS39_DWS39_TV}",
 					["num"] = 2,
 				},
 				[7] = {
-					["CLSID"] = "JAS39_DWS39",
+					["CLSID"] = "{JAS39_DWS39_TV}",
 					["num"] = 7,
 				},
                 [8] = {
-					["CLSID"] = "JAS39_M70BHE",
+					["CLSID"] = "{JAS39_M70BHE}",
 					["num"] = 3,
 				},
                 [9] = {
-					["CLSID"] = "JAS39_M70BHE",
+					["CLSID"] = "{JAS39_M70BHE}",
 					["num"] = 6,
 				},
                 [10] = {
-					["CLSID"] = "JAS39_Litening",
+					["CLSID"] = "{JAS39_Litening}",
 					["num"] = 5,
 				},
 				[11] = {


### PR DESCRIPTION
Community-JAS-39-C pydcs extension support updated to mod version v1.8.0-Beta

This is still a draft and requires updated loadouts.