### PR TITLE
Added missing squadron nickname for 18th Air Refueling Squadron

### DIFF
--- a/resources/squadrons/KC-135/18th ARS.yaml
+++ b/resources/squadrons/KC-135/18th ARS.yaml
@@ -1,6 +1,6 @@
 ---
 name: 18th Air Refueling Squadron
-nickname:
+nickname: Kanza
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker


### PR DESCRIPTION
Added the nickname for the 18th Air Refueling Squadron, as it was missing.
