### PR TITLE
Helipad spawn fallback at Airfield control point

### DIFF
--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -220,7 +220,7 @@ class FlightGroupSpawner:
             if isinstance(cp, Airfield):
                 return self._generate_at_airport(name, cp.airport)
             else:
-                return None
+                return self._generate_over_departure(name, cp)
 
         group = self._generate_at_group(name, helipad)
 


### PR DESCRIPTION
Implemented a fallback to _generate_at_airport() in case a "Not enough helipads available" situation is encountered at an Airfield control point. Also generates air starts over OffMapSpawn control points now.

Resolves #1890
