### PR TITLE
Rework map objects kill recognition with new trigger rule

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ Saves from 5.x are not compatible with 6.0.
 ## Fixes
 
 * **[Campaign]** Fixed some minor issues in campaigns which generated error messages in the log.
+* **[Campaign]** Changed the way how map object / scenery kills where tracked. This fixes issues with kill recognition after map updates from ED which change the object ids and therefore prevent correct kill recognition.
 * **[Mission Generation]** Fixed incorrect radio specification for the AN/ARC-222.
 * **[Mission Generation]** Fixed mission scripting error when using a dedicated server.
 * **[Mission Generation]** Fixed an issue where empty convoys lead to an index error when a point capture made a pending transfer of units not completable anymore.

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -99,6 +99,9 @@ class StateData:
     #: Names of vehicle (and ship) units that were killed during the mission.
     killed_ground_units: List[str]
 
+    #: Names of map objects that were killed during the mission.
+    killed_map_objects: list[str]
+
     #: List of descriptions of destroyed statics. Format of each element is a mapping of
     #: the coordinate type ("x", "y", "z", "type", "orientation") to the value.
     destroyed_statics: List[dict[str, Union[float, str]]]
@@ -117,6 +120,7 @@ class StateData:
             # Also normalize dead map objects (which are ints) to strings. The unit map
             # only stores strings.
             killed_ground_units=list({str(u) for u in data["killed_ground_units"]}),
+            killed_map_objects=data["killed_map_objects"],
             destroyed_statics=data["destroyed_objects_positions"],
             base_capture_events=data["base_capture_events"],
         )
@@ -316,6 +320,16 @@ class Debriefing:
                     losses.player_airlifts.append(airlift_unit)
                 else:
                     losses.enemy_airlifts.append(airlift_unit)
+                continue
+
+        # Find killed map objects and mark them as loss
+        for map_object in self.state_data.killed_map_objects:
+            building = self.unit_map.building_or_fortification(map_object)
+            if building is not None:
+                if building.ground_object.control_point.captured:
+                    losses.player_buildings.append(building)
+                else:
+                    losses.enemy_buildings.append(building)
                 continue
 
         return losses

--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -319,16 +319,6 @@ class SceneryGroundObject(BuildingGroundObject):
             is_fob_structure=False,
         )
         self.zone = zone
-        try:
-            # In the default TriggerZone using "assign as..." in the DCS Mission Editor,
-            # property three has the scenery's object ID as its value.
-            self.map_object_id = self.zone.properties[3]["value"]
-        except (IndexError, KeyError):
-            logging.exception(
-                "Invalid TriggerZone for Scenery definition. The third property must "
-                "be the map object ID."
-            )
-            raise
 
 
 class FactoryGroundObject(BuildingGroundObject):

--- a/game/unitmap.py
+++ b/game/unitmap.py
@@ -221,7 +221,7 @@ class UnitMap:
         self.buildings[name] = Building(ground_object)
 
     def add_scenery(self, ground_object: SceneryGroundObject) -> None:
-        name = str(ground_object.map_object_id)
+        name = str(ground_object.zone.name)
         if name in self.buildings:
             raise RuntimeError(
                 f"Duplicate TGO unit: {name}. TriggerZone name: "

--- a/game/version.py
+++ b/game/version.py
@@ -123,8 +123,4 @@ VERSION = _build_version_string()
 #: Version 9.1
 #: * Campaign files can optionally define a start date with
 #:   `recommended_start_date: YYYY-MM-DD`.
-#
-#: Version 10.0
-#: * DCS 2.7.9.17830 changed scenery target IDs. Any mission using map buildings as
-#:   strike targets must check and potentially recreate all those objectives.
-CAMPAIGN_FORMAT_VERSION = (10, 0)
+CAMPAIGN_FORMAT_VERSION = (9, 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Pillow==8.3.2
 pluggy==0.13.1
 pre-commit==2.10.1
 py==1.10.0
--e git://github.com/pydcs/dcs@2f17e05e11ba84423e82867576cf94963bf964b5#egg=pydcs
+-e git://github.com/pydcs/dcs@92e3046d476781bd617a6c1abd6853cccf97d57c#egg=pydcs
 pyinstaller==4.3
 pyinstaller-hooks-contrib==2021.1
 pyparsing==2.4.7

--- a/resources/campaigns/Caucasus_Multi_Georgia.yaml
+++ b/resources/campaigns/Caucasus_Multi_Georgia.yaml
@@ -8,7 +8,7 @@ recommended_enemy_faction: Georgia 2008
 recommended_start_date: 1995-06-13
 miz: Caucasus_Multi_Georgia.miz
 performance: 2
-version: "10.0"
+version: "9.1"
 squadrons:
   # Kutaisi
   22:

--- a/resources/campaigns/battle_of_abu_dhabi.yaml
+++ b/resources/campaigns/battle_of_abu_dhabi.yaml
@@ -7,7 +7,7 @@ recommended_enemy_faction: United Arab Emirates 2015
 description: <p>You have managed to establish a foothold near Ras Al Khaima. Continue pushing south.</p>
 miz: battle_of_abu_dhabi.miz
 performance: 2
-version: "10.0"
+version: "9.0"
 squadrons:
   # Blue CPs:
   # The default faction is Iran, but the F-14B is given higher precedence so

--- a/resources/campaigns/black_sea.yaml
+++ b/resources/campaigns/black_sea.yaml
@@ -8,7 +8,7 @@ recommended_enemy_faction: Russia 2010
 recommended_start_date: 2004-01-07
 miz: black_sea.miz
 performance: 2
-version: "10.0"
+version: "9.1"
 squadrons:
   # Anapa-Vityazevo
   12:

--- a/resources/campaigns/marianas_guam_barrigada.yaml
+++ b/resources/campaigns/marianas_guam_barrigada.yaml
@@ -5,7 +5,7 @@ authors: Ghosti
 description: <p>The objective of this campaign is the capture of Guam. Blue side, having landed their forces on the beaches of Agat, controls Antonio B. Won Pat airfield and are pushing towards the enemy stronghold of Mount Barrigada.</p>
 miz: marianas_guam_barrigada.miz
 performance: 2
-version: "10.0"
+version: "9.0"
 squadrons:
   Blue CV:
     - primary: BARCAP

--- a/resources/campaigns/marianas_guam_landing_at_agat.yaml
+++ b/resources/campaigns/marianas_guam_landing_at_agat.yaml
@@ -5,7 +5,7 @@ authors: Ghosti
 description: <p>The objective of this campaign is the capture of Guam. Blue side, having landed their forces on the beaches of Agat, are pushing inland. <strong>Note:</strong> This campaign requires a carrier-capable (or LHA-capable) BLUFOR faction to be able to field aircraft.</p>
 miz: marianas_guam_landing_at_agat.miz
 performance: 2
-version: "10.0"
+version: "9.0"
 squadrons:
   Blue CV:
     - primary: BARCAP

--- a/resources/campaigns/northern_russia.yaml
+++ b/resources/campaigns/northern_russia.yaml
@@ -8,7 +8,7 @@ recommended_enemy_faction: Russia 1975
 recommended_start_date: 1995-06-13
 miz: northern_russia.miz
 performance: 2
-version: "10.0"
+version: "9.1"
 squadrons:
   # Kutaisi
   25:

--- a/resources/campaigns/operation_allied_sword.yaml
+++ b/resources/campaigns/operation_allied_sword.yaml
@@ -5,7 +5,7 @@ authors: Fuzzle
 recommended_player_faction: Israel-USN 2005 (Allied Sword)
 recommended_enemy_faction: Syria-Lebanon 2005 (Allied Sword)
 description: <p>In this fictional scenario, a US/Israeli coalition must push north from the Israeli border, through Syria and Lebanon to Aleppo.</p><p><strong>Backstory:</strong> A Syrian-Lebanese joint force (with Russian materiel support) has attacked Israel, attmepting to cross the northern border. With the arrival of a US carrier group, Israel prepares its counterattack. The US Navy will handle the Beirut region's coastal arena, while the IAF will push through Damascus and the inland mountain ranges.</p>,
-version: "10.0"
+version: "9.1"
 miz: operation_allied_sword.miz
 performance: 2
 recommended_start_date: 2004-07-17

--- a/resources/campaigns/operation_blackball.yaml
+++ b/resources/campaigns/operation_blackball.yaml
@@ -3,7 +3,7 @@ name: Syria - Operation Blackball
 theater: Syria
 authors: Fuzzle
 description: <p>A lightweight fictional showcase of Cyprus for the Syria terrain. A US Navy force must deploy from a FOB and carrier group to push from the north-east down through the island. <strong>Note that the ground units purchased on turn zero must sustain you until you've taken the first hostile FOB. The starting point does not have a factory to simulate a Marine Expeditionary Force deploying from the carrier group.</strong></p><p><strong>Backstory:</strong> The world is at war. With the help of her eastern allies Russia has taken the Suez Canal and deployed a large naval force to the Mediterranean trapping a US carrier group near the Turkish-Syrian border. Now they must break out by taking Cyprus back.</p>
-version: "10.0"
+version: "9.1"
 recommended_player_faction: US Navy 2005
 recommended_enemy_faction: Russia 2010
 miz: operation_blackball.miz

--- a/resources/campaigns/scenic_route.yaml
+++ b/resources/campaigns/scenic_route.yaml
@@ -3,7 +3,7 @@ name: Persian Gulf - Scenic Route
 theater: Persian Gulf
 authors: Fuzzle
 description: <p>A lightweight naval campaign involving a US Navy carrier group pushing across the coast of Iran. <strong>Note that the ground units purchased on turn zero must sustain you until you've taken the first hostile FOB. The starting point does not have a factory to simulate a Marine Expeditionary Force deploying from the carrier group.</strong></p><p><strong>Backstory:</strong> Iran has declared war on all US forces in the Gulf resulting in all local allies withdrawing their support for American troops. A lone carrier group must pacify the southern coast of Iran and hold out until backup can arrive lest the US and her interests be ejected from the region permanently.</p>
-version: "10.0"
+version: "9.1"
 recommended_player_faction: US Navy 2005
 recommended_enemy_faction: Iran 2015
 miz: scenic_route.miz

--- a/resources/plugins/base/dcs_liberation.lua
+++ b/resources/plugins/base/dcs_liberation.lua
@@ -4,10 +4,11 @@ local WRITESTATE_SCHEDULE_IN_SECONDS = 60
 logger = mist.Logger:new("DCSLiberation", "info")
 logger:info("Check that json.lua is loaded : json = "..tostring(json))
 
-killed_aircrafts = {}
-killed_ground_units = {}
+killed_aircrafts = {} -- killed aircraft will be added via S_EVENT_CRASH event
+killed_ground_units = {} -- killed units will be added via S_EVENT_DEAD event
 base_capture_events = {}
-destroyed_objects_positions = {}
+destroyed_objects_positions = {} -- will be added via S_EVENT_DEAD event
+killed_map_objects = {} -- killed map objects will be added via TriggerRules
 mission_ended = false
 
 local function ends_with(str, ending)
@@ -35,6 +36,7 @@ function write_state()
         ["base_capture_events"] = base_capture_events,
         ["mission_ended"] = mission_ended,
         ["destroyed_objects_positions"] = destroyed_objects_positions,
+        ["killed_map_objects"] = killed_map_objects,
     }
     if not json then
         local message = string.format("Unable to save DCS Liberation state to %s, JSON library is not loaded !", _debriefing_file_location)


### PR DESCRIPTION
This adds a new triggerrule wit the mapobjectisdead condition which allows us to track the kill of a map object independant of the event `S_EVENT_DEAD` which currently adds the real object id to the list of `killed_ground_units`. This leads to the problem that when ED updates the map and changes the object_id we can not track the kill anymore as we still use the "old" object id

With this PR i completly removed the `map_object_id` from the SceneryGroundObject as it is more meaningful and safe (in regard to unique identifier) to use just the `trigger_zone.name` which should be unique as dcs does not allow duplicate names there. So this feature is save-compat and dcs-map-update compat.
To handle the kill recognition i added triggerrules with the mapobjectisdead conditition which will add the `trigger_zone.name` to the state.json in the `killed_map_objects` array.

As a result we can revert the Campaign Version Update to 10.0 🥳 

This PR can only be merged when the pending PR to pydcs is merged as the current pydcs version does not support the mapobjectisdead condition. Until then this PR will stay at Draft. - Done

closes #1894 

Tested with a simple use case: Change the ObjectID of a trigger zone in the campaign.miz, generate a new campaign, kill the map object with a huge explosion, check state.json:

Generated TriggerRule:
![grafik](https://user-images.githubusercontent.com/6678803/147856721-ebb7580f-8e6a-41bf-bb17-e3d01dca2037.png)

State.json now has: `"killed_map_objects":["Barracks 1 (House)"]`

and the result:
![grafik](https://user-images.githubusercontent.com/6678803/147856732-5291a9ee-3f15-44e9-84bd-1bc775ef0d9c.png)
