### PR TITLE
Update SA-5 Generator for factions without the TinShield

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed an issue where empty convoys lead to an index error when a point capture made a pending transfer of units not completable anymore.
 * **[Mission Generation]** Corrected Viggen FR22 & FR24 preset channels for the DCS 2.7.9 update
 * **[Mission Generation]** Fixed an issue which prevented the mission generation if two controlpoints are really close to each other (e.g. Marianas campaigns)
+* **[Mission Generation]** Fixed the SA-5 Generator to use the P-19 FlatFace SR as a Fallback radar if the faction does not have access to the TinShield SR.
 * **[UI]** Enable / Disable the settings, save and stats actions if no game is loaded to prevent an error as these functions can only be used on a valid game.
 
 # 5.0.0

--- a/gen/sam/sam_group_generator.py
+++ b/gen/sam/sam_group_generator.py
@@ -49,7 +49,7 @@ from gen.sam.sam_sa17 import SA17Generator
 from gen.sam.sam_sa19 import SA19Generator
 from gen.sam.sam_sa2 import SA2Generator
 from gen.sam.sam_sa3 import SA3Generator
-from gen.sam.sam_sa5 import SA5Generator
+from gen.sam.sam_sa5 import SA5Generator, SA5FlatFaceGenerator
 from gen.sam.sam_sa6 import SA6Generator
 from gen.sam.sam_sa8 import SA8Generator
 from gen.sam.sam_sa9 import SA9Generator
@@ -79,6 +79,7 @@ SAM_MAP: Dict[str, Type[AirDefenseGroupGenerator]] = {
     "SA2Generator": SA2Generator,
     "SA3Generator": SA3Generator,
     "SA5Generator": SA5Generator,
+    "SA5FlatFaceGenerator": SA5FlatFaceGenerator,
     "SA6Generator": SA6Generator,
     "SA8Generator": SA8Generator,
     "SA9Generator": SA9Generator,

--- a/gen/sam/sam_sa5.py
+++ b/gen/sam/sam_sa5.py
@@ -1,5 +1,10 @@
+from typing import Type
+
+from dcs.unittype import VehicleType
 from dcs.vehicles import AirDefence, Unarmed
 
+from game import Game
+from game.theater import SamGroundObject
 from gen.sam.airdefensegroupgenerator import (
     AirDefenseRange,
     AirDefenseGroupGenerator,
@@ -8,15 +13,18 @@ from gen.sam.airdefensegroupgenerator import (
 
 class SA5Generator(AirDefenseGroupGenerator):
     """
-    This generate a SA-5 group
+    This generate a SA-5 group using the TinShield SR
     """
 
     name = "SA-5/S-200 Site"
 
-    def generate(self) -> None:
+    def __init__(self, game: Game, ground_object: SamGroundObject):
+        super().__init__(game, ground_object)
+        self.sr: Type[VehicleType] = AirDefence.RLS_19J6
 
+    def generate(self) -> None:
         self.add_unit(
-            AirDefence.RLS_19J6,
+            self.sr,
             "SR",
             self.position.x,
             self.position.y,
@@ -54,3 +62,14 @@ class SA5Generator(AirDefenseGroupGenerator):
     @classmethod
     def range(cls) -> AirDefenseRange:
         return AirDefenseRange.Long
+
+
+# TODO Replace this legacy handling once the Generators can be faction sensitive #1903
+class SA5FlatFaceGenerator(SA5Generator):
+    """
+    This generate a SA-5 group using the P-19 FlatFace SR
+    """
+
+    def __init__(self, game: Game, ground_object: SamGroundObject):
+        super().__init__(game, ground_object)
+        self.sr: Type[VehicleType] = AirDefence.P_19_s_125_sr

--- a/resources/factions/iran_2015.json
+++ b/resources/factions/iran_2015.json
@@ -55,7 +55,7 @@
     "HawkGenerator",
     "RapierGenerator",
     "SA2Generator",
-    "SA5Generator",
+    "SA5FlatFaceGenerator",
     "SA6Generator",
     "SA11Generator",
     "SA15Generator",

--- a/resources/factions/libya_2011.json
+++ b/resources/factions/libya_2011.json
@@ -45,7 +45,7 @@
     "RapierGenerator",
     "SA2Generator",
     "SA3Generator",
-    "SA5Generator",
+    "SA5FlatFaceGenerator",
     "SA6Generator",
     "SA8Generator",
     "SA9Generator",

--- a/resources/factions/poland_2010.json
+++ b/resources/factions/poland_2010.json
@@ -44,7 +44,7 @@
     "Paratrooper AKS"
   ],
   "air_defenses": [
-    "SA5Generator",
+    "SA5FlatFaceGenerator",
     "SA6Generator",
     "SA8Generator",
     "ZSU23Generator",


### PR DESCRIPTION
Some factions (Iran, Lybia, Poland) do not have access to the TinShield but do have access to the SA-5 Launcher and TR. To make the SA-5 function correctly this PR adds an EarlySA5Generator which uses the P-19 FlatFace SR instead.

closes #1906 

This is a workaround until the #1903 is done.
