### PR TITLE
Support UTC Kneeboard timings

### DIFF
--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -157,6 +157,9 @@ class AircraftType(UnitType[Type[FlyingType]]):
     # If true, kneeboards will be generated in metric units
     metric_kneeboard: bool
 
+    # If true, kneeboards will display zulu times
+    utc_kneeboard: bool
+
     max_group_size: int
     patrol_altitude: Optional[Distance]
     patrol_speed: Optional[Speed]
@@ -399,4 +402,5 @@ class AircraftType(UnitType[Type[FlyingType]]):
                 channel_allocator=radio_config.channel_allocator,
                 channel_namer=radio_config.channel_namer,
                 metric_kneeboard=data.get("metric_kneeboard", False),
+                utc_kneeboard=data.get("utc_kneeboard", False),
             )

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -266,7 +266,7 @@ class FlightPlanBuilder:
         if time is None:
             return ""
         local_time = self.start_time + time
-        return local_time.strftime(f"%H:%M:%S")
+        return f"{local_time.strftime('%H:%M:%S')}{'Z' if local_time.tzinfo is not None else ''}"
 
     def _format_alt(self, alt: Distance) -> str:
         if self.is_metric:
@@ -584,7 +584,7 @@ class SupportPage(KneeboardPage):
         if time is None:
             return ""
         local_time = self.start_time + time
-        return local_time.strftime(f"%H:%M:%S")
+        return f"{local_time.strftime('%H:%M:%S')}{'Z' if local_time.tzinfo is not None else ''}"
 
 
 class SeadTaskPage(KneeboardPage):
@@ -743,13 +743,21 @@ class KneeboardGenerator(MissionInfoGenerator):
 
     def generate_flight_kneeboard(self, flight: FlightData) -> List[KneeboardPage]:
         """Returns a list of kneeboard pages for the given flight."""
+
+        if flight.aircraft_type.utc_kneeboard:
+            zoned_time = self.game.conditions.start_time.replace(
+                tzinfo=self.game.theater.timezone
+            ).astimezone(datetime.timezone.utc)
+        else:
+            zoned_time = self.game.conditions.start_time
+
         pages: List[KneeboardPage] = [
             BriefingPage(
                 flight,
                 self.game.bullseye_for(flight.friendly),
                 self.game.theater,
                 self.game.conditions.weather,
-                self.game.conditions.start_time,
+                zoned_time,
                 self.dark_kneeboard,
             ),
             SupportPage(
@@ -758,7 +766,7 @@ class KneeboardGenerator(MissionInfoGenerator):
                 self.awacs,
                 self.tankers,
                 self.jtacs,
-                self.game.conditions.start_time,
+                zoned_time,
                 self.dark_kneeboard,
             ),
         ]

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import math
 from dataclasses import dataclass
 from pathlib import Path
@@ -47,6 +48,8 @@ class ConflictTheater:
     """
     daytime_map: Dict[str, Tuple[int, int]]
 
+    timezone: datetime.timezone
+
     def __init__(self) -> None:
         self.controlpoints: List[ControlPoint] = []
         self.point_to_ll_transformer = Transformer.from_crs(
@@ -55,6 +58,8 @@ class ConflictTheater:
         self.ll_to_point_transformer = Transformer.from_crs(
             CRS("WGS84"), self.projection_parameters.to_crs()
         )
+        # Set default timezone as UTC
+        self.timezone = datetime.timezone(datetime.timedelta(hours=0))
         """
         self.land_poly = geometry.Polygon(self.landmap[0][0])
         for x in self.landmap[1]:
@@ -277,6 +282,8 @@ class CaucasusTheater(ConflictTheater):
         "night": (0, 5),
     }
 
+    timezone = datetime.timezone(datetime.timedelta(hours=4))
+
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
         from .seasonalconditions.caucasus import CONDITIONS
@@ -304,6 +311,8 @@ class PersianGulfTheater(ConflictTheater):
         "dusk": (16, 18),
         "night": (0, 5),
     }
+
+    timezone = datetime.timezone(datetime.timedelta(hours=4))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -333,6 +342,8 @@ class NevadaTheater(ConflictTheater):
         "night": (0, 5),
     }
 
+    timezone = datetime.timezone(datetime.timedelta(hours=-8))
+
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
         from .seasonalconditions.nevada import CONDITIONS
@@ -360,6 +371,8 @@ class NormandyTheater(ConflictTheater):
         "dusk": (17, 18),
         "night": (0, 5),
     }
+
+    timezone = datetime.timezone(datetime.timedelta(hours=0))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -389,6 +402,8 @@ class TheChannelTheater(ConflictTheater):
         "night": (0, 5),
     }
 
+    timezone = datetime.timezone(datetime.timedelta(hours=2))
+
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
         from .seasonalconditions.thechannel import CONDITIONS
@@ -417,6 +432,8 @@ class SyriaTheater(ConflictTheater):
         "night": (0, 5),
     }
 
+    timezone = datetime.timezone(datetime.timedelta(hours=3))
+
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
         from .seasonalconditions.syria import CONDITIONS
@@ -441,6 +458,8 @@ class MarianaIslandsTheater(ConflictTheater):
         "dusk": (16, 18),
         "night": (0, 5),
     }
+
+    timezone = datetime.timezone(datetime.timedelta(hours=10))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -48,8 +48,6 @@ class ConflictTheater:
     """
     daytime_map: Dict[str, Tuple[int, int]]
 
-    timezone: datetime.timezone
-
     def __init__(self) -> None:
         self.controlpoints: List[ControlPoint] = []
         self.point_to_ll_transformer = Transformer.from_crs(
@@ -58,8 +56,6 @@ class ConflictTheater:
         self.ll_to_point_transformer = Transformer.from_crs(
             CRS("WGS84"), self.projection_parameters.to_crs()
         )
-        # Set default timezone as UTC
-        self.timezone = datetime.timezone(datetime.timedelta(hours=0))
         """
         self.land_poly = geometry.Polygon(self.landmap[0][0])
         for x in self.landmap[1]:
@@ -250,6 +246,10 @@ class ConflictTheater:
         raise KeyError(f"Cannot find ControlPoint named {name}")
 
     @property
+    def timezone(self) -> datetime.timezone:
+        raise NotImplementedError
+
+    @property
     def seasonal_conditions(self) -> SeasonalConditions:
         raise NotImplementedError
 
@@ -282,7 +282,9 @@ class CaucasusTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=4))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=4))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -312,7 +314,9 @@ class PersianGulfTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=4))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=4))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -342,7 +346,9 @@ class NevadaTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=-8))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=-8))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -372,7 +378,9 @@ class NormandyTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=0))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=0))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -402,7 +410,9 @@ class TheChannelTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=2))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=2))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -432,7 +442,9 @@ class SyriaTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=3))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=3))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:
@@ -459,7 +471,9 @@ class MarianaIslandsTheater(ConflictTheater):
         "night": (0, 5),
     }
 
-    timezone = datetime.timezone(datetime.timedelta(hours=10))
+    @property
+    def timezone(self) -> datetime.timezone:
+        return datetime.timezone(datetime.timedelta(hours=10))
 
     @property
     def seasonal_conditions(self) -> SeasonalConditions:

--- a/resources/units/aircraft/FA-18C_hornet.yaml
+++ b/resources/units/aircraft/FA-18C_hornet.yaml
@@ -46,3 +46,4 @@ radios:
     # we must use radio 1 for the intra-flight radio.
     intra_flight_radio_index: 1
     inter_flight_radio_index: 2
+utc_kneeboard: true


### PR DESCRIPTION
if utc_kneeboard = true in aircraft type YAML, renders times in UTC.

Time offsets seem to be fixed per theatre, tested only on Syria so far.

Only F-18 currently set for utc_kneeboards.

fixes https://github.com/dcs-liberation/dcs_liberation/issues/792
