### PR TITLE
Handling for blank weapon clsids to fix error with_clsid KeyError: ''

### DIFF
--- a/game/data/weapons.py
+++ b/game/data/weapons.py
@@ -37,7 +37,7 @@ class Weapon:
 
     @cached_property
     def pydcs_data(self) -> PydcsWeapon:
-        if self.clsid == "<CLEAN>":
+        if self.clsid in ("<CLEAN>", ""):
             # Special case for a "weapon" that isn't exposed by pydcs.
             return {
                 "clsid": self.clsid,
@@ -223,15 +223,18 @@ class Pylon:
     allowed: set[Weapon]
 
     def can_equip(self, weapon: Weapon) -> bool:
-        # TODO: Fix pydcs to support the <CLEAN> "weapon".
+        # TODO: Fix pydcs to support the <CLEAN> "weapon" and blank "" clsid.
         # <CLEAN> is a special case because pydcs doesn't know about that "weapon", so
         # it's not compatible with *any* pylon. Just trust the loadout and try to equip
         # it.
         #
+        # Same with blank hardpoints with the weapon of clsid "" (blank), seen at least
+        # on the Mosquito.
+        #
         # A similar hack exists in QPylonEditor to forcibly add "Clean" to the list of
         # valid configurations for that pylon if a loadout has been seen with that
         # configuration.
-        return weapon in self.allowed or weapon.clsid == "<CLEAN>"
+        return weapon in self.allowed or weapon.clsid in ("<CLEAN>", "")
 
     def equip(self, group: FlyingGroup[Any], weapon: Weapon) -> None:
         if not self.can_equip(weapon):

--- a/gen/flights/loadouts.py
+++ b/gen/flights/loadouts.py
@@ -117,7 +117,11 @@ class Loadout:
             pylons = payload["pylons"]
             yield Loadout(
                 name,
-                {p["num"]: Weapon.with_clsid(p["CLSID"]) for p in pylons.values()},
+                {
+                    p["num"]: Weapon.with_clsid(p["CLSID"])
+                    for p in pylons.values()
+                    if p["CLSID"] not in ("<CLEAN>", "")
+                },
                 date=None,
             )
 
@@ -178,7 +182,11 @@ class Loadout:
             if payload is not None:
                 return Loadout(
                     name,
-                    {i: Weapon.with_clsid(d["clsid"]) for i, d in payload},
+                    {
+                        i: Weapon.with_clsid(d["clsid"])
+                        for i, d in payload
+                        if d["clsid"] not in ("<CLEAN>", "")
+                    },
                     date=None,
                 )
 

--- a/gen/flights/loadouts.py
+++ b/gen/flights/loadouts.py
@@ -120,7 +120,7 @@ class Loadout:
                 {
                     p["num"]: Weapon.with_clsid(p["CLSID"])
                     for p in pylons.values()
-                    if p["CLSID"] not in ("<CLEAN>", "")
+                    if p["CLSID"] != ""
                 },
                 date=None,
             )
@@ -185,7 +185,7 @@ class Loadout:
                     {
                         i: Weapon.with_clsid(d["clsid"])
                         for i, d in payload
-                        if d["clsid"] not in ("<CLEAN>", "")
+                        if d["clsid"] != ""
                     },
                     date=None,
                 )

--- a/qt_ui/windows/mission/flight/payload/QPylonEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QPylonEditor.py
@@ -46,7 +46,7 @@ class QPylonEditor(QComboBox):
         weapon = loadout.pylons.get(self.pylon.number)
         if weapon is None:
             return None
-        # TODO: Fix pydcs to support the <CLEAN> "weapon".
+        # TODO: Fix pydcs to support the <CLEAN> "weapon" and blank "" clsid.
         # These are not exported in the pydcs weapon map, which causes the pydcs pylon
         # exporter to fail to include them in the supported list. Since they aren't
         # known to be compatible (and we can't show them as compatible for *every*
@@ -56,7 +56,7 @@ class QPylonEditor(QComboBox):
         #
         # A similar hack exists in Pylon to support forcibly equipping this even when
         # it's not known to be compatible.
-        if weapon.clsid == "<CLEAN>":
+        if weapon.clsid in ("<CLEAN>", ""):
             if not self.has_added_clean_item:
                 self.addItem("Clean", weapon)
                 self.has_added_clean_item = True

--- a/resources/customized_payloads/MosquitoFBMkVI.lua
+++ b/resources/customized_payloads/MosquitoFBMkVI.lua
@@ -52,26 +52,18 @@ local unitPayloads = {
 			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "",
-					["num"] = 1,
-				},
-				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[4] = {
+				[2] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[5] = {
+				[3] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[6] = {
+				[4] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -85,26 +77,18 @@ local unitPayloads = {
 			["name"] = "Liberation Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "",
-					["num"] = 1,
-				},
-				[3] = {
 					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[4] = {
+				[2] = {
 					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[5] = {
+				[3] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[6] = {
+				[4] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -127,26 +111,18 @@ local unitPayloads = {
 			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "",
-					["num"] = 1,
-				},
-				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[4] = {
+				[2] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[5] = {
+				[3] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[6] = {
+				[4] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -184,26 +160,18 @@ local unitPayloads = {
 			["name"] = "Liberation BAI",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "",
-					["num"] = 1,
-				},
-				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[4] = {
+				[2] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[5] = {
+				[3] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[6] = {
+				[4] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -217,26 +185,18 @@ local unitPayloads = {
 			["name"] = "Liberation DEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "",
-					["num"] = 1,
-				},
-				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[4] = {
+				[2] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[5] = {
+				[3] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[6] = {
+				[4] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},

--- a/resources/customized_payloads/MosquitoFBMkVI.lua
+++ b/resources/customized_payloads/MosquitoFBMkVI.lua
@@ -52,18 +52,26 @@ local unitPayloads = {
 			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[2] = {
+				[4] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[3] = {
+				[5] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[4] = {
+				[6] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -77,18 +85,26 @@ local unitPayloads = {
 			["name"] = "Liberation Anti-ship",
 			["pylons"] = {
 				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
 					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[2] = {
+				[4] = {
 					["CLSID"] = "{British_SAP_250LB_Bomb_Mk5_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[3] = {
+				[5] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[4] = {
+				[6] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -111,18 +127,26 @@ local unitPayloads = {
 			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[2] = {
+				[4] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[3] = {
+				[5] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[4] = {
+				[6] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -160,18 +184,26 @@ local unitPayloads = {
 			["name"] = "Liberation BAI",
 			["pylons"] = {
 				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[2] = {
+				[4] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[3] = {
+				[5] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[4] = {
+				[6] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},
@@ -185,18 +217,26 @@ local unitPayloads = {
 			["name"] = "Liberation DEAD",
 			["pylons"] = {
 				[1] = {
+					["CLSID"] = "",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "",
+					["num"] = 1,
+				},
+				[3] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 4,
 				},
-				[2] = {
+				[4] = {
 					["CLSID"] = "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}",
 					["num"] = 3,
 				},
-				[3] = {
+				[5] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}",
 					["num"] = 6,
 				},
-				[4] = {
+				[6] = {
 					["CLSID"] = "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}",
 					["num"] = 5,
 				},


### PR DESCRIPTION
Removed hardpoints with empty CLSIDs from MosquitoFBMkVI loadouts because they caused an error with Liberation 5.1.0 (File "game\data\weapons.py", line 73, in with_clsid KeyError: '')

https://discordapp.com/channels/595702951800995872/782361390954053643/929408415632097380

New loadout was reported to get rid of the error on Discord **#help-my-question-isnt-in-the-faq** https://discordapp.com/channels/595702951800995872/782361390954053643/929412781969649706
