### PR TITLE
Fix unculled zones not updating when needed

### DIFF
--- a/game/settings/boundedintoption.py
+++ b/game/settings/boundedintoption.py
@@ -19,6 +19,7 @@ def bounded_int_option(
     max: int,
     detail: Optional[str] = None,
     tooltip: Optional[str] = None,
+    causes_expensive_game_update: bool = False,
     **kwargs: Any,
 ) -> int:
     return field(
@@ -29,7 +30,7 @@ def bounded_int_option(
                 text,
                 detail,
                 tooltip,
-                causes_expensive_game_update=False,
+                causes_expensive_game_update,
                 min=min,
                 max=max,
             )

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -448,6 +448,7 @@ class Settings:
         default=100,
         min=10,
         max=10000,
+        causes_expensive_game_update=True,
     )
     perf_do_not_cull_carrier: bool = boolean_option(
         "Do not cull carrier's surroundings",

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -255,7 +255,7 @@ class AtoModel(QAbstractListModel):
         self.endInsertRows()
         # noinspection PyUnresolvedReferences
         self.client_slots_changed.emit()
-        self.packages_changed.emit()
+        self.on_packages_changed()
 
     def delete_package_at_index(self, index: QModelIndex) -> None:
         """Removes the package at the given index from the ATO."""
@@ -274,7 +274,12 @@ class AtoModel(QAbstractListModel):
         self.endRemoveRows()
         # noinspection PyUnresolvedReferences
         self.client_slots_changed.emit()
-        self.packages_changed.emit()
+        self.on_packages_changed()
+
+    def on_packages_changed(self) -> None:
+        if self.game is not None:
+            self.game.compute_unculled_zones()
+            self.packages_changed.emit()
 
     def package_at_index(self, index: QModelIndex) -> Package:
         """Returns the package at the given index."""

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -222,6 +222,7 @@ class AtoModel(QAbstractListModel):
     PackageRole = Qt.UserRole
 
     client_slots_changed = Signal()
+    packages_changed = Signal()
 
     def __init__(self, game_model: GameModel, ato: AirTaskingOrder) -> None:
         super().__init__()
@@ -254,6 +255,7 @@ class AtoModel(QAbstractListModel):
         self.endInsertRows()
         # noinspection PyUnresolvedReferences
         self.client_slots_changed.emit()
+        self.packages_changed.emit()
 
     def delete_package_at_index(self, index: QModelIndex) -> None:
         """Removes the package at the given index from the ATO."""
@@ -272,6 +274,7 @@ class AtoModel(QAbstractListModel):
         self.endRemoveRows()
         # noinspection PyUnresolvedReferences
         self.client_slots_changed.emit()
+        self.packages_changed.emit()
 
     def package_at_index(self, index: QModelIndex) -> Package:
         """Returns the package at the given index."""

--- a/qt_ui/widgets/map/model/mapmodel.py
+++ b/qt_ui/widgets/map/model/mapmodel.py
@@ -381,9 +381,6 @@ class MapModel(QObject):
         return self._map_zones
 
     def on_package_change(self) -> None:
-        if self.game_model.game is None:
-            return
-        self.game_model.game.compute_unculled_zones()
         self.reset_unculled_zones()
 
     def reset_unculled_zones(self) -> None:

--- a/qt_ui/widgets/map/model/mapmodel.py
+++ b/qt_ui/widgets/map/model/mapmodel.py
@@ -106,6 +106,12 @@ class MapModel(QObject):
         GameUpdateSignal.get_instance().flight_selection_changed.connect(
             self.set_flight_selection
         )
+        self.game_model.ato_model_for(True).packages_changed.connect(
+            self.on_package_change
+        ),
+        self.game_model.ato_model_for(False).packages_changed.connect(
+            self.on_package_change
+        ),
         sim_controller.sim_update.connect(self.on_sim_update)
         self.reset()
 
@@ -373,6 +379,12 @@ class MapModel(QObject):
     @Property(MapZonesJs, notify=mapZonesChanged)
     def mapZones(self) -> NavMeshJs:
         return self._map_zones
+
+    def on_package_change(self) -> None:
+        if self.game_model.game is None:
+            return
+        self.game_model.game.compute_unculled_zones()
+        self.reset_unculled_zones()
 
     def reset_unculled_zones(self) -> None:
         self._unculled_zones = list(UnculledZone.each_from_game(self.game))

--- a/qt_ui/windows/settings/QSettingsWindow.py
+++ b/qt_ui/windows/settings/QSettingsWindow.py
@@ -169,6 +169,8 @@ class AutoSettingsLayout(QGridLayout):
     ) -> None:
         def on_changed(value: int) -> None:
             self.settings.__dict__[name] = value
+            if description.causes_expensive_game_update:
+                self.write_full_settings()
 
         spinner = QSpinBox()
         spinner.setMinimum(description.min)
@@ -354,7 +356,7 @@ class QSettingsWindow(QDialog):
             self.cheat_options.show_base_capture_cheat
         )
 
-        self.game.compute_conflicts_position()
+        self.game.compute_unculled_zones()
         GameUpdateSignal.get_instance().updateGame(self.game)
 
     def onSelectionChanged(self):


### PR DESCRIPTION
- on ATO package changes
- on culling zone size setting changed
- rename compute_conflicts_position in game.py to better reflect what it actually does

Fixes #1761, #1034 and possibly others.
