### PR TITLE
Fix for unauthenticated git protocol no longer supported

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Pillow==8.3.2
 pluggy==0.13.1
 pre-commit==2.10.1
 py==1.10.0
--e git://github.com/pydcs/dcs@5d1f581b260fdc6091744ab927a58cdee586e681#egg=pydcs
+-e git+https://github.com/pydcs/dcs@5d1f581b260fdc6091744ab927a58cdee586e681#egg=pydcs
 pyinstaller==4.3
 pyinstaller-hooks-contrib==2021.1
 pyparsing==2.4.7


### PR DESCRIPTION
Added https protocol to pip pydcs install url to fix "The unauthenticated git protocol on port 9418 is no longer supported." error: https://github.blog/2021-09-01-improving-git-protocol-security-github/