### PR TITLE
Adds NASAMS to Blufor Modern

### DIFF
--- a/resources/factions/bluefor_modern.json
+++ b/resources/factions/bluefor_modern.json
@@ -71,7 +71,8 @@
   "air_defenses": [
     "AvengerGenerator",
     "HawkGenerator",
-    "PatriotGenerator"
+    "PatriotGenerator",
+    "NasamCGenerator"
   ],
   "ewrs": [
     "PatriotEwrGenerator"


### PR DESCRIPTION
I realised Blufor Modern was missing the NASAMS generator.
