### PR TITLE
Fix for TheaterGroundObject max_threat_range "ValueError: max() arg is an empty sequence"

### DIFF
--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -173,7 +173,9 @@ class TheaterGroundObject(MissionTarget, Generic[GroupT]):
         return self._max_range_of_type(group, "detection_range")
 
     def max_threat_range(self) -> Distance:
-        return max(self.threat_range(g) for g in self.groups)
+        return (
+            max(self.threat_range(g) for g in self.groups) if self.groups else meters(0)
+        )
 
     def threat_range(self, group: GroupT, radar_only: bool = False) -> Distance:
         return self._max_range_of_type(group, "threat_range")


### PR DESCRIPTION
Prevents the "ValueError: max() arg is an empty sequence" error from appearing when using time acceleration, when the error was caused by an empty group being interrogated for the max_threat_range. The method now returns zero if the group is empty.

Resolves #1944