### PR TITLE
Allow squadron transfers when number of free slots matches size of squadron

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed an issue which prevented the mission generation if two controlpoints are really close to each other (e.g. Marianas campaigns)
 * **[Mission Generation]** Fixed the SA-5 Generator to use the P-19 FlatFace SR as a Fallback radar if the faction does not have access to the TinShield SR.
 * **[Mission Generation]** Fixed incorrect SA-5 threat range when TR destroyed. It will not count as threat anymore when the TR is dead.
+* **[Mission Planner]** Now allows squadron transfers to control points where the number of free slots matches exactly the expected size of the transferring squadron next turn.
 * **[UI]** Enable / Disable the settings, save and stats actions if no game is loaded to prevent an error as these functions can only be used on a valid game.
 * **[UI]** Added missing icons for Tornado GR4, and Tornado IDS.
 

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -339,7 +339,7 @@ class Squadron:
             )
             return
 
-        if self.expected_size_next_turn >= destination.unclaimed_parking():
+        if self.expected_size_next_turn > destination.unclaimed_parking():
             raise RuntimeError(f"Not enough parking for {self} at {destination}.")
         if not destination.can_operate(self.aircraft):
             raise RuntimeError(f"{self} cannot operate at {destination}.")


### PR DESCRIPTION
Now allows squadron transfers to control points where the number of free slots matches exactly the expected size of the transferring squadron next turn.

Resolves #1952