### PR TITLE
Fix issue 1966

### DIFF
--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -20,7 +20,7 @@ class SquadronConfig:
 
     name: Optional[str]
     nickname: Optional[str]
-    female_pilot_ratio: Optional[int]
+    female_pilot_percentage: Optional[int]
 
     @property
     def auto_assignable(self) -> set[FlightType]:
@@ -42,7 +42,7 @@ class SquadronConfig:
             data.get("aircraft", []),
             data.get("name", None),
             data.get("nickname", None),
-            data.get("female_pilot_ratio", None),
+            data.get("female_pilot_percentage", None),
         )
 
     @staticmethod

--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union, Optional
 
 from game.ato.flighttype import FlightType
 from game.theater.controlpoint import ControlPoint
@@ -17,6 +17,10 @@ class SquadronConfig:
     primary: FlightType
     secondary: list[FlightType]
     aircraft: list[str]
+
+    name: Optional[str]
+    nickname: Optional[str]
+    female_pilot_ratio: Optional[int]
 
     @property
     def auto_assignable(self) -> set[FlightType]:
@@ -33,7 +37,12 @@ class SquadronConfig:
             secondary = [FlightType(s) for s in secondary_raw]
 
         return SquadronConfig(
-            FlightType(data["primary"]), secondary, data.get("aircraft", [])
+            FlightType(data["primary"]),
+            secondary,
+            data.get("aircraft", []),
+            data.get("name", None),
+            data.get("nickname", None),
+            data.get("female_pilot_ratio", None),
         )
 
     @staticmethod

--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -77,8 +77,8 @@ class DefaultSquadronAssigner:
                 overrides["name"] = config.name
             if config.nickname is not None:
                 overrides["nickname"] = config.nickname
-            if config.female_pilot_ratio is not None:
-                overrides["female_pilot_ratio"] = config.female_pilot_ratio
+            if config.female_pilot_percentage is not None:
+                overrides["female_pilot_percentage"] = config.female_pilot_percentage
 
             squadron_copy = dataclasses.replace(squadron_def, **overrides)
             return squadron_copy

--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Dict, Union
 
 from game.squadrons import Squadron
 from game.squadrons.squadrondef import SquadronDef
@@ -72,7 +72,7 @@ class DefaultSquadronAssigner:
         # Override squadron def with squadron config parameters from campaign file, if defined
         if squadron_def is not None:
 
-            overrides = {}
+            overrides: Dict[str, Union[str, int]] = {}
             if config.name is not None:
                 overrides["name"] = config.name
             if config.nickname is not None:

--- a/game/campaignloader/squadrondefgenerator.py
+++ b/game/campaignloader/squadrondefgenerator.py
@@ -50,7 +50,7 @@ class SquadronDefGenerator:
             livery=None,
             mission_types=tuple(tasks_for_aircraft(aircraft)),
             operating_bases=OperatingBases.default_for_aircraft(aircraft),
-            female_pilot_ratio=6,
+            female_pilot_percentage=6,
             pilot_pool=[],
         )
 

--- a/game/campaignloader/squadrondefgenerator.py
+++ b/game/campaignloader/squadrondefgenerator.py
@@ -50,6 +50,7 @@ class SquadronDefGenerator:
             livery=None,
             mission_types=tuple(tasks_for_aircraft(aircraft)),
             operating_bases=OperatingBases.default_for_aircraft(aircraft),
+            female_pilot_ratio=6,
             pilot_pool=[],
         )
 

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -33,7 +33,7 @@ class Squadron:
     livery: Optional[str]
     mission_types: tuple[FlightType, ...]
     operating_bases: OperatingBases
-    female_pilot_ratio: int
+    female_pilot_percentage: int
 
     #: The pool of pilots that have not yet been assigned to the squadron. This only
     #: happens when a preset squadron defines more preset pilots than the squadron limit
@@ -162,7 +162,7 @@ class Squadron:
         self.pilot_pool = self.pilot_pool[count:]
         count -= len(new_pilots)
         for _ in range(count):
-            if random.randint(1, 100) > self.female_pilot_ratio:
+            if random.randint(1, 100) > self.female_pilot_percentage:
                 new_pilots.append(Pilot(self.faker.name_male()))
             else:
                 new_pilots.append(Pilot(self.faker.name_female()))
@@ -434,7 +434,7 @@ class Squadron:
             squadron_def.livery,
             squadron_def.mission_types,
             squadron_def.operating_bases,
-            squadron_def.female_pilot_ratio,
+            squadron_def.female_pilot_percentage,
             squadron_def.pilot_pool,
             coalition,
             game.settings,

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Optional, Sequence, TYPE_CHECKING
@@ -32,6 +33,7 @@ class Squadron:
     livery: Optional[str]
     mission_types: tuple[FlightType, ...]
     operating_bases: OperatingBases
+    female_pilot_ratio: int
 
     #: The pool of pilots that have not yet been assigned to the squadron. This only
     #: happens when a preset squadron defines more preset pilots than the squadron limit
@@ -159,7 +161,11 @@ class Squadron:
         new_pilots = self.pilot_pool[:count]
         self.pilot_pool = self.pilot_pool[count:]
         count -= len(new_pilots)
-        new_pilots.extend([Pilot(self.faker.name()) for _ in range(count)])
+        for _ in range(count):
+            if random.randint(1, 100) > self.female_pilot_ratio:
+                new_pilots.append(Pilot(self.faker.name_male()))
+            else:
+                new_pilots.append(Pilot(self.faker.name_female()))
         self.current_roster.extend(new_pilots)
         self.available_pilots.extend(new_pilots)
 
@@ -428,6 +434,7 @@ class Squadron:
             squadron_def.livery,
             squadron_def.mission_types,
             squadron_def.operating_bases,
+            squadron_def.female_pilot_ratio,
             squadron_def.pilot_pool,
             coalition,
             game.settings,

--- a/game/squadrons/squadrondef.py
+++ b/game/squadrons/squadrondef.py
@@ -27,6 +27,7 @@ class SquadronDef:
     livery: Optional[str]
     mission_types: tuple[FlightType, ...]
     operating_bases: OperatingBases
+    female_pilot_ratio: int
     pilot_pool: list[Pilot]
     claimed: bool = False
 
@@ -75,6 +76,7 @@ class SquadronDef:
 
         pilots = [Pilot(n, player=False) for n in data.get("pilots", [])]
         pilots.extend([Pilot(n, player=True) for n in data.get("players", [])])
+        female_pilot_ratio = data.get("female_pilot_ratio", 6)
 
         mission_types = [FlightType.from_name(n) for n in data["mission_types"]]
         tasks = tasks_for_aircraft(unit_type)
@@ -95,5 +97,6 @@ class SquadronDef:
             livery=data.get("livery"),
             mission_types=tuple(mission_types),
             operating_bases=OperatingBases.from_yaml(unit_type, data.get("bases", {})),
+            female_pilot_ratio=female_pilot_ratio,
             pilot_pool=pilots,
         )

--- a/game/squadrons/squadrondef.py
+++ b/game/squadrons/squadrondef.py
@@ -27,7 +27,7 @@ class SquadronDef:
     livery: Optional[str]
     mission_types: tuple[FlightType, ...]
     operating_bases: OperatingBases
-    female_pilot_ratio: int
+    female_pilot_percentage: int
     pilot_pool: list[Pilot]
     claimed: bool = False
 
@@ -76,7 +76,7 @@ class SquadronDef:
 
         pilots = [Pilot(n, player=False) for n in data.get("pilots", [])]
         pilots.extend([Pilot(n, player=True) for n in data.get("players", [])])
-        female_pilot_ratio = data.get("female_pilot_ratio", 6)
+        female_pilot_percentage = data.get("female_pilot_percentage", 6)
 
         mission_types = [FlightType.from_name(n) for n in data["mission_types"]]
         tasks = tasks_for_aircraft(unit_type)
@@ -97,6 +97,6 @@ class SquadronDef:
             livery=data.get("livery"),
             mission_types=tuple(mission_types),
             operating_bases=OperatingBases.from_yaml(unit_type, data.get("bases", {})),
-            female_pilot_ratio=female_pilot_ratio,
+            female_pilot_percentage=female_pilot_percentage,
             pilot_pool=pilots,
         )

--- a/game/version.py
+++ b/game/version.py
@@ -126,6 +126,6 @@ VERSION = _build_version_string()
 #:
 #: Version 9.2
 #: * Squadrons defined in campaign files can optionally setup squadrons' name,
-#:   nickname and/or generated female pilot name ratio
+#:   nickname and/or generated female pilot name percentage
 #:
 CAMPAIGN_FORMAT_VERSION = (9, 2)

--- a/game/version.py
+++ b/game/version.py
@@ -123,4 +123,9 @@ VERSION = _build_version_string()
 #: Version 9.1
 #: * Campaign files can optionally define a start date with
 #:   `recommended_start_date: YYYY-MM-DD`.
-CAMPAIGN_FORMAT_VERSION = (9, 1)
+#:
+#: Version 9.2
+#: * Squadrons defined in campaign files can optionally setup squadrons' name,
+#:   nickname and/or generated female pilot name ratio
+#:
+CAMPAIGN_FORMAT_VERSION = (9, 2)

--- a/resources/campaigns/golan_heights_lite.yaml
+++ b/resources/campaigns/golan_heights_lite.yaml
@@ -41,13 +41,13 @@ squadrons:
     - primary: CAS
       secondary: air-to-ground
       nickname: Golan Heights Heroes
-      female_pilot_ratio: 15
+      female_pilot_percentage: 15
       aircraft:
         - AH-1W SuperCobra
     - primary: CAS
       secondary: air-to-ground
       nickname: Defenders of Golan
-      female_pilot_ratio: 25
+      female_pilot_percentage: 25
       aircraft:
         - AH-64D Apache Longbow
     - primary: Transport

--- a/resources/campaigns/golan_heights_lite.yaml
+++ b/resources/campaigns/golan_heights_lite.yaml
@@ -40,10 +40,14 @@ squadrons:
   Golan South:
     - primary: CAS
       secondary: air-to-ground
+      nickname: Golan Heights Heroes
+      female_pilot_ratio: 15
       aircraft:
         - AH-1W SuperCobra
     - primary: CAS
       secondary: air-to-ground
+      nickname: Defenders of Golan
+      female_pilot_ratio: 25
       aircraft:
         - AH-64D Apache Longbow
     - primary: Transport

--- a/resources/squadrons/A-10C Warthog I/104th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/104th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 104th FS
 nickname: Eagles
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/104th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/104th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 104th FS
 nickname: Eagles
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/118th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/118th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 118th FS
 nickname: Flying Yankees
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/118th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/118th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 118th FS
 nickname: Flying Yankees
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/172nd FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/172nd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 172nd FS
-nickname: 
+nickname:
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/172nd FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/172nd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 172nd FS
 nickname:
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/184th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/184th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 184th FS
 nickname: Flying Razorbacks
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/184th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/184th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 184th FS
 nickname: Flying Razorbacks
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/190th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/190th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 190th FS
 nickname: Skull Bangers
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/190th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/190th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 190th FS
 nickname: Skull Bangers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/25th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/25th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 25th FS
 nickname: Assam Draggins
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/25th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/25th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 25th FS
 nickname: Assam Draggins
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/354th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/354th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 354th FS
 nickname: Bulldogs
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/354th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/354th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 354th FS
 nickname: Bulldogs
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/355th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/355th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 355th FS
 nickname: Fightin' Falcons
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/355th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/355th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 355th FS
 nickname: Fightin' Falcons
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/357th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/357th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 357th FS
 nickname: Dragons
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/357th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/357th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 357th FS
 nickname: Dragons
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/358th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/358th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 358th FS
 nickname: Lobos
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/358th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/358th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 358th FS
 nickname: Lobos
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/47th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/47th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 47th FS
 nickname: Termites
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/47th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/47th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 47th FS
 nickname: Termites
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/74th TFS.yaml
+++ b/resources/squadrons/A-10C Warthog I/74th TFS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 74th TFS
 nickname: Flying Tigers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/74th TFS.yaml
+++ b/resources/squadrons/A-10C Warthog I/74th TFS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 74th TFS
 nickname: Flying Tigers
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/81st FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/81st FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 81st FS
 nickname: Termites
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog I/81st FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/81st FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 81st FS
 nickname: Termites
+female_pilot_ratio: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)

--- a/resources/squadrons/A-10C Warthog II/25th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/25th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 25th FS
 nickname: Assam Draggins
+female_pilot_ratio: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/25th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/25th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 25th FS
 nickname: Assam Draggins
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/354th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/354th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 354th FS
 nickname: Bulldogs
+female_pilot_ratio: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/354th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/354th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 354th FS
 nickname: Bulldogs
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/355th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/355th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 355th FS
 nickname: Fightin' Falcons
+female_pilot_ratio: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/355th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/355th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 355th FS
 nickname: Fightin' Falcons
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/357th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/357th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 357th FS
 nickname: Dragons
+female_pilot_ratio: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/357th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/357th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 357th FS
 nickname: Dragons
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/358th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/358th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 358th FS
 nickname: Lobos
+female_pilot_ratio: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/358th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/358th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 358th FS
 nickname: Lobos
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/81st FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/81st FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 81st FS
 nickname: Termites
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-10C Warthog II/81st FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/81st FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 81st FS
 nickname: Termites
+female_pilot_ratio: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)

--- a/resources/squadrons/A-4E Skyhawk/IAF 110th Sqn.yaml
+++ b/resources/squadrons/A-4E Skyhawk/IAF 110th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 110th Squadron
 nickname: Knights of the North
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Israel
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/IAF 110th Sqn.yaml
+++ b/resources/squadrons/A-4E Skyhawk/IAF 110th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 110th Squadron
 nickname: Knights of the North
+female_pilot_ratio: 0
 country: Israel
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-144.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-144.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-144
 nickname: Roadrunners
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-144.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-144.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-144
 nickname: Roadrunners
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-153.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-153.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-153
 nickname: Blue Tail Flies
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-153.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-153.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-153
 nickname: Blue Tail Flies
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-163.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-163.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-163
 nickname: Saints
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-163.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-163.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-163
 nickname: Saints
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-164.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-164.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-164
 nickname: Ghostriders
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-164.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-164.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-164
 nickname: Ghostriders
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-195.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-195.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-195
 nickname: Dambusters
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-195.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-195.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-195
 nickname: Dambusters
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-212.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-212.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-212
 nickname: Rampant Raiders
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-212.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-212.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-212
 nickname: Rampant Raiders
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-45.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-45.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-45
 nickname: Blackbirds
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-45.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-45.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-45
 nickname: Blackbirds
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-55.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-55.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-55
 nickname: Warhorses
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-55.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-55.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-55
 nickname: Warhorses
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-64.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-64.yaml
@@ -1,6 +1,7 @@
 ---
 name: VA-64
 nickname: Black Lancers
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VA-64.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-64.yaml
@@ -1,7 +1,7 @@
 ---
 name: VA-64
 nickname: Black Lancers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-121.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-121.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-121
 nickname: Green Knights
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-121.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-121.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-121
 nickname: Green Knights
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-124.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-124.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-124
 nickname: Memphis Marines
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-124.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-124.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-124
 nickname: Memphis Marines
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-131.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-131.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-131
 nickname: Diamondbacks
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-131.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-131.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-131
 nickname: Diamondbacks
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-142.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-142.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-142
 nickname: Flying Gators
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-142.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-142.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-142
 nickname: Flying Gators
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-211.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-211.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-211
 nickname: Avengers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-211.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-211.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-211
 nickname: Avengers
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-311.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-311.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-311
 nickname: Tomcats
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-311.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-311.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-311
 nickname: Tomcats
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-322.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-322.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-322
 nickname: Fighting Gamecocks
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A-4E Skyhawk/VMA-322.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-322.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-322
 nickname: Fighting Gamecocks
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack/Light Fighter
 aircraft: A-4E Skyhawk

--- a/resources/squadrons/A20/no_107_squadron_raf.yaml
+++ b/resources/squadrons/A20/no_107_squadron_raf.yaml
@@ -1,7 +1,7 @@
 ---
 name: RAF, No. 107 Squadron
 nickname: Lowestoft's 'own' Squadron
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: UK
 role: Medium Bomber
 aircraft: Boston Mk.III

--- a/resources/squadrons/A20/no_107_squadron_raf.yaml
+++ b/resources/squadrons/A20/no_107_squadron_raf.yaml
@@ -1,6 +1,7 @@
 ---
 name: RAF, No. 107 Squadron
 nickname: Lowestoft's 'own' Squadron
+female_pilot_ratio: 0
 country: UK
 role: Medium Bomber
 aircraft: Boston Mk.III

--- a/resources/squadrons/AH-1X/HMLA-169-AH1W.yaml
+++ b/resources/squadrons/AH-1X/HMLA-169-AH1W.yaml
@@ -1,7 +1,7 @@
 ---
 name: HMLA-169 (AH-1W)
 nickname: Vipers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Attack
 aircraft: AH-1W SuperCobra

--- a/resources/squadrons/AH-1X/HMLA-169-AH1W.yaml
+++ b/resources/squadrons/AH-1X/HMLA-169-AH1W.yaml
@@ -1,6 +1,7 @@
 ---
 name: HMLA-169 (AH-1W)
 nickname: Vipers
+female_pilot_ratio: 0
 country: USA
 role: Attack
 aircraft: AH-1W SuperCobra

--- a/resources/squadrons/AH-1X/HMLA-269-AH1W.yaml
+++ b/resources/squadrons/AH-1X/HMLA-269-AH1W.yaml
@@ -1,7 +1,7 @@
 ---
 name: HMLA-269 (AH-1W)
 nickname: Gunrunners
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Attack
 aircraft: AH-1W SuperCobra

--- a/resources/squadrons/AH-1X/HMLA-269-AH1W.yaml
+++ b/resources/squadrons/AH-1X/HMLA-269-AH1W.yaml
@@ -1,6 +1,7 @@
 ---
 name: HMLA-269 (AH-1W)
 nickname: Gunrunners
+female_pilot_ratio: 0
 country: USA
 role: Attack
 aircraft: AH-1W SuperCobra

--- a/resources/squadrons/AH-1X/IAF 160th Sqn.yaml
+++ b/resources/squadrons/AH-1X/IAF 160th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 160th Squadron
 nickname: Northern Cobra Squadron
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Israel
 role: Attack Helicopter
 aircraft: AH-1W SuperCobra

--- a/resources/squadrons/AH-1X/IAF 160th Sqn.yaml
+++ b/resources/squadrons/AH-1X/IAF 160th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 160th Squadron
 nickname: Northern Cobra Squadron
+female_pilot_ratio: 0
 country: Israel
 role: Attack Helicopter
 aircraft: AH-1W SuperCobra

--- a/resources/squadrons/AH-64D/IAF 113th Sqn.yaml
+++ b/resources/squadrons/AH-64D/IAF 113th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 113th Squadron
 nickname: The Hornet Squadron
+female_pilot_ratio: 5
 country: Israel
 role: Attack Helicopter
 aircraft: AH-64D Apache Longbow

--- a/resources/squadrons/AH-64D/IAF 113th Sqn.yaml
+++ b/resources/squadrons/AH-64D/IAF 113th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 113th Squadron
 nickname: The Hornet Squadron
-female_pilot_ratio: 5
+female_pilot_percentage: 5
 country: Israel
 role: Attack Helicopter
 aircraft: AH-64D Apache Longbow

--- a/resources/squadrons/AH-64D/US Army 229th Aviation Battalion.yaml
+++ b/resources/squadrons/AH-64D/US Army 229th Aviation Battalion.yaml
@@ -1,7 +1,7 @@
 ---
 name: 229th Aviation Battalion
 nickname: Serpents
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Attack Helicopter
 aircraft: AH-64D Apache Longbow

--- a/resources/squadrons/AH-64D/US Army 229th Aviation Battalion.yaml
+++ b/resources/squadrons/AH-64D/US Army 229th Aviation Battalion.yaml
@@ -1,6 +1,7 @@
 ---
 name: 229th Aviation Battalion
 nickname: Serpents
+female_pilot_ratio: 6
 country: USA
 role: Attack Helicopter
 aircraft: AH-64D Apache Longbow

--- a/resources/squadrons/AV-8BNA/VMA-214.yaml
+++ b/resources/squadrons/AV-8BNA/VMA-214.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-214
 nickname: Black Sheep
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: V/STOL Attack
 aircraft: AV-8B Harrier II Night Attack

--- a/resources/squadrons/AV-8BNA/VMA-214.yaml
+++ b/resources/squadrons/AV-8BNA/VMA-214.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-214
 nickname: Black Sheep
+female_pilot_ratio: 0
 country: USA
 role: V/STOL Attack
 aircraft: AV-8B Harrier II Night Attack

--- a/resources/squadrons/AV-8BNA/VMA-223.yaml
+++ b/resources/squadrons/AV-8BNA/VMA-223.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMA-223
 nickname: Bulldogs
+female_pilot_ratio: 0
 country: USA
 role: V/STOL Attack
 aircraft: AV-8B Harrier II Night Attack

--- a/resources/squadrons/AV-8BNA/VMA-223.yaml
+++ b/resources/squadrons/AV-8BNA/VMA-223.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMA-223
 nickname: Bulldogs
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: V/STOL Attack
 aircraft: AV-8B Harrier II Night Attack

--- a/resources/squadrons/BF-109K4/Jagdgeschwader_53.yaml
+++ b/resources/squadrons/BF-109K4/Jagdgeschwader_53.yaml
@@ -1,6 +1,6 @@
 name: Jagdgeschwader 53
 nickname: Pik As
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Third Reich
 role: Fighter
 aircraft: Bf 109 K-4 Kurfürst

--- a/resources/squadrons/BF-109K4/Jagdgeschwader_53.yaml
+++ b/resources/squadrons/BF-109K4/Jagdgeschwader_53.yaml
@@ -1,5 +1,6 @@
 name: Jagdgeschwader 53
 nickname: Pik As
+female_pilot_ratio: 0
 country: Third Reich
 role: Fighter
 aircraft: Bf 109 K-4 Kurfürst

--- a/resources/squadrons/E-2 Hawkeye/VAW-125.yaml
+++ b/resources/squadrons/E-2 Hawkeye/VAW-125.yaml
@@ -1,6 +1,7 @@
 ---
 name: VAW-125
 nickname: Tigertails
+female_pilot_ratio: 6
 country: USA
 role: AEW&C
 aircraft: E-2C Hawkeye

--- a/resources/squadrons/E-2 Hawkeye/VAW-125.yaml
+++ b/resources/squadrons/E-2 Hawkeye/VAW-125.yaml
@@ -1,7 +1,7 @@
 ---
 name: VAW-125
 nickname: Tigertails
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: AEW&C
 aircraft: E-2C Hawkeye

--- a/resources/squadrons/E-3 Sentry/USAF 960th AACS.yaml
+++ b/resources/squadrons/E-3 Sentry/USAF 960th AACS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 960th AAC Squadron
 nickname: Vikings
+female_pilot_ratio: 6
 country: USA
 role: AEW&C
 aircraft: E-3A

--- a/resources/squadrons/E-3 Sentry/USAF 960th AACS.yaml
+++ b/resources/squadrons/E-3 Sentry/USAF 960th AACS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 960th AAC Squadron
 nickname: Vikings
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: AEW&C
 aircraft: E-3A

--- a/resources/squadrons/Eagle/IAF 106th Sqn.yaml
+++ b/resources/squadrons/Eagle/IAF 106th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 106th Squadron
 nickname: Spearhead
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Israel
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/IAF 106th Sqn.yaml
+++ b/resources/squadrons/Eagle/IAF 106th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 106th Squadron
 nickname: Spearhead
+female_pilot_ratio: 6
 country: Israel
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 12th FS.yaml
+++ b/resources/squadrons/Eagle/USAF 12th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 12th FS
 nickname: Dirty Dozen
+female_pilot_ratio: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 12th FS.yaml
+++ b/resources/squadrons/Eagle/USAF 12th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 12th FS
 nickname: Dirty Dozen
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 390th FS.yaml
+++ b/resources/squadrons/Eagle/USAF 390th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 390th FS
 nickname: Wild Boars
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 390th FS.yaml
+++ b/resources/squadrons/Eagle/USAF 390th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 390th FS
 nickname: Wild Boars
+female_pilot_ratio: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 493rd FS.yaml
+++ b/resources/squadrons/Eagle/USAF 493rd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 493rd FS
 nickname: Grim Reapers
+female_pilot_ratio: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 493rd FS.yaml
+++ b/resources/squadrons/Eagle/USAF 493rd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 493rd FS
 nickname: Grim Reapers
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 58th FS.yaml
+++ b/resources/squadrons/Eagle/USAF 58th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 58th FS
 nickname: Gorillas
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/Eagle/USAF 58th FS.yaml
+++ b/resources/squadrons/Eagle/USAF 58th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 58th FS
 nickname: Gorillas
+female_pilot_ratio: 6
 country: USA
 role: Air Superiority Fighter
 aircraft: F-15C Eagle

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-11.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-11.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-11
 nickname: Red Rippers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-11.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-11.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-11
 nickname: Red Rippers
+female_pilot_ratio: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-111.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-111.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-111
 nickname: Sundowners
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-111.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-111.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-111
 nickname: Sundowners
+female_pilot_ratio: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-21.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-21.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-21
 nickname: Freelancers
+female_pilot_ratio: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-21.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-21.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-21
 nickname: Freelancers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-211.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-211.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-211
 nickname: Fighting Checkmates
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-211.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-211.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-211
 nickname: Fighting Checkmates
+female_pilot_ratio: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-33.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-33.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-33
 nickname: Starfighters
+female_pilot_ratio: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-33.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-33.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-33
 nickname: Starfighters
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)

--- a/resources/squadrons/F-14B Tomcat/VF-101.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-101.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-101
 nickname: Grim Reapers
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-101.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-101.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-101
 nickname: Grim Reapers
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-102.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-102.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-102
 nickname: Diamond Backs
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-102.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-102.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-102
 nickname: Diamond Backs
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-142.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-142.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-142
 nickname: Ghostriders
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-142.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-142.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-142
 nickname: Ghostriders
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-143.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-143.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-143
 nickname: Pukin' Dogs
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-143.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-143.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-143
 nickname: Pukin' Dogs
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-211.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-211.yaml
@@ -1,7 +1,7 @@
 ---
 name: VF-211
 nickname: Fighting Checkmates
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-14B Tomcat/VF-211.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-211.yaml
@@ -1,6 +1,7 @@
 ---
 name: VF-211
 nickname: Fighting Checkmates
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat

--- a/resources/squadrons/F-4E/IAF 201th Sqn.yaml
+++ b/resources/squadrons/F-4E/IAF 201th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 201th Squadron
 nickname: The One
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Israel
 role: Air Superiority Fighter
 aircraft: F-4E Phantom II

--- a/resources/squadrons/F-4E/IAF 201th Sqn.yaml
+++ b/resources/squadrons/F-4E/IAF 201th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 201th Squadron
 nickname: The One
+female_pilot_ratio: 0
 country: Israel
 role: Air Superiority Fighter
 aircraft: F-4E Phantom II

--- a/resources/squadrons/F-4E/IRIAF 32nd TFW.yaml
+++ b/resources/squadrons/F-4E/IRIAF 32nd TFW.yaml
@@ -1,7 +1,7 @@
 ---
 name: IRIAF 32nd TFW
 nickname: 32nd TFW
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Iran
 role: Air Superiority Fighter
 aircraft: F-4E Phantom II

--- a/resources/squadrons/F-4E/IRIAF 32nd TFW.yaml
+++ b/resources/squadrons/F-4E/IRIAF 32nd TFW.yaml
@@ -1,6 +1,7 @@
 ---
 name: IRIAF 32nd TFW
 nickname: 32nd TFW
+female_pilot_ratio: 0
 country: Iran
 role: Air Superiority Fighter
 aircraft: F-4E Phantom II

--- a/resources/squadrons/FW-190A8/Jagdgeschwader_26.yaml
+++ b/resources/squadrons/FW-190A8/Jagdgeschwader_26.yaml
@@ -1,5 +1,6 @@
 name: Jagdgeschwader 26
 nickname: Schlageter
+female_pilot_ratio: 0
 country: Third Reich
 role: Fighter
 aircraft: Fw 190 A-8 Anton

--- a/resources/squadrons/FW-190A8/Jagdgeschwader_26.yaml
+++ b/resources/squadrons/FW-190A8/Jagdgeschwader_26.yaml
@@ -1,6 +1,6 @@
 name: Jagdgeschwader 26
 nickname: Schlageter
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Third Reich
 role: Fighter
 aircraft: Fw 190 A-8 Anton

--- a/resources/squadrons/FW-190D9/Jagdgeschwader_54.yaml
+++ b/resources/squadrons/FW-190D9/Jagdgeschwader_54.yaml
@@ -1,6 +1,6 @@
 name: Jagdgeschwader 54
 nickname: Grünherz
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Third Reich
 role: Fighter
 aircraft: Fw 190 D-9 Dora

--- a/resources/squadrons/FW-190D9/Jagdgeschwader_54.yaml
+++ b/resources/squadrons/FW-190D9/Jagdgeschwader_54.yaml
@@ -1,5 +1,6 @@
 name: Jagdgeschwader 54
 nickname: Grünherz
+female_pilot_ratio: 0
 country: Third Reich
 role: Fighter
 aircraft: Fw 190 D-9 Dora

--- a/resources/squadrons/Ju88A4/Kustenfliegergruppe_106.yaml
+++ b/resources/squadrons/Ju88A4/Kustenfliegergruppe_106.yaml
@@ -1,9 +1,11 @@
 ---
 name: Küstenfliegergruppe 106
 nickname: Kü.Fl.Gr.206.
+female_pilot_ratio: 0
 country: Third Reich
 role: Medium Bomber
 aircraft: Ju 88 A-4
+female_pilot_ratio: 0
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/Ju88A4/Kustenfliegergruppe_106.yaml
+++ b/resources/squadrons/Ju88A4/Kustenfliegergruppe_106.yaml
@@ -1,11 +1,11 @@
 ---
 name: Küstenfliegergruppe 106
 nickname: Kü.Fl.Gr.206.
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Third Reich
 role: Medium Bomber
 aircraft: Ju 88 A-4
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/KC-130/VMGR-352.yaml
+++ b/resources/squadrons/KC-130/VMGR-352.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMGR-352
 nickname: Raiders
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-130

--- a/resources/squadrons/KC-130/VMGR-352.yaml
+++ b/resources/squadrons/KC-130/VMGR-352.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMGR-352
 nickname: Raiders
+female_pilot_ratio: 6
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-130

--- a/resources/squadrons/KC-135/18th ARS.yaml
+++ b/resources/squadrons/KC-135/18th ARS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 18th Air Refueling Squadron
 nickname: Kanza
+female_pilot_ratio: 6
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker

--- a/resources/squadrons/KC-135/18th ARS.yaml
+++ b/resources/squadrons/KC-135/18th ARS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 18th Air Refueling Squadron
 nickname: Kanza
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker

--- a/resources/squadrons/KC-135/TuAF 101st Tanker Squadron.yaml
+++ b/resources/squadrons/KC-135/TuAF 101st Tanker Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 101st Tanker Squadron
 nickname: Asena
+female_pilot_ratio: 6
 country: Turkey
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker

--- a/resources/squadrons/KC-135/TuAF 101st Tanker Squadron.yaml
+++ b/resources/squadrons/KC-135/TuAF 101st Tanker Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 101st Tanker Squadron
 nickname: Asena
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Turkey
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker

--- a/resources/squadrons/KC-135MPRS/340th EARS.yaml
+++ b/resources/squadrons/KC-135MPRS/340th EARS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 340th Expeditionary Air Refueling Squadron
 nickname: Pythons
+female_pilot_ratio: 6
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker MPRS

--- a/resources/squadrons/KC-135MPRS/340th EARS.yaml
+++ b/resources/squadrons/KC-135MPRS/340th EARS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 340th Expeditionary Air Refueling Squadron
 nickname: Pythons
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Air-to-Air Refueling
 aircraft: KC-135 Stratotanker MPRS

--- a/resources/squadrons/Mi-24/SAAF 765th Sqn.yaml
+++ b/resources/squadrons/Mi-24/SAAF 765th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 765th Squadron
 nickname: 765th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Attack Helicopter
 aircraft: Mi-24P Hind-F

--- a/resources/squadrons/Mi-24/SAAF 765th Sqn.yaml
+++ b/resources/squadrons/Mi-24/SAAF 765th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 765th Squadron
 nickname: 765th
+female_pilot_ratio: 0
 country: Syria
 role: Attack Helicopter
 aircraft: Mi-24P Hind-F

--- a/resources/squadrons/Mi-24/SAAF 766th Sqn.yaml
+++ b/resources/squadrons/Mi-24/SAAF 766th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 766th Squadron
 nickname: 766th
+female_pilot_ratio: 0
 country: Syria
 role: Attack Helicopter
 aircraft: Mi-24V Hind-E

--- a/resources/squadrons/Mi-24/SAAF 766th Sqn.yaml
+++ b/resources/squadrons/Mi-24/SAAF 766th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 766th Squadron
 nickname: 766th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Attack Helicopter
 aircraft: Mi-24V Hind-E

--- a/resources/squadrons/Mi-8/SAAF 253th Sqn.yaml
+++ b/resources/squadrons/Mi-8/SAAF 253th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 253th Squadron
 nickname: 253th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Transport Helicopter
 aircraft: Mi-8MTV2 Hip

--- a/resources/squadrons/Mi-8/SAAF 253th Sqn.yaml
+++ b/resources/squadrons/Mi-8/SAAF 253th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 253th Squadron
 nickname: 253th
+female_pilot_ratio: 0
 country: Syria
 role: Transport Helicopter
 aircraft: Mi-8MTV2 Hip

--- a/resources/squadrons/Mi-8/SAAF 255th Sqn.yaml
+++ b/resources/squadrons/Mi-8/SAAF 255th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 255th Squadron
 nickname: 255th
+female_pilot_ratio: 0
 country: Syria
 role: Transport Helicopter
 aircraft: Mi-8MTV2 Hip

--- a/resources/squadrons/Mi-8/SAAF 255th Sqn.yaml
+++ b/resources/squadrons/Mi-8/SAAF 255th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 255th Squadron
 nickname: 255th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Transport Helicopter
 aircraft: Mi-8MTV2 Hip

--- a/resources/squadrons/Mig-21/SAAF 679th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 679th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 679th Squadron
 nickname: 679th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 679th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 679th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 679th Squadron
 nickname: 679th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 680th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 680th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 680th Squadron
 nickname: 680th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 680th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 680th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 680th Squadron
 nickname: 680th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 825th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 825th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 825th Squadron
 nickname: 825th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 825th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 825th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 825th Squadron
 nickname: 825th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 8th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 8th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 8th Squadron
 nickname: 8th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-21/SAAF 8th Sqn.yaml
+++ b/resources/squadrons/Mig-21/SAAF 8th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 8th Squadron
 nickname: 8th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-21bis Fishbed-N

--- a/resources/squadrons/Mig-23/SAAF 678th Sqn.yaml
+++ b/resources/squadrons/Mig-23/SAAF 678th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 678th Squadron
 nickname: 678th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-23MLD Flogger-K

--- a/resources/squadrons/Mig-23/SAAF 678th Sqn.yaml
+++ b/resources/squadrons/Mig-23/SAAF 678th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 678th Squadron
 nickname: 678th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-23MLD Flogger-K

--- a/resources/squadrons/Mig-25/SAAF 1st Sqn.yaml
+++ b/resources/squadrons/Mig-25/SAAF 1st Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 1st Squadron
 nickname: 1st
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-25PD Foxbat-E

--- a/resources/squadrons/Mig-25/SAAF 1st Sqn.yaml
+++ b/resources/squadrons/Mig-25/SAAF 1st Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 1st Squadron
 nickname: 1st
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-25PD Foxbat-E

--- a/resources/squadrons/Mig-29/Russia VVS 115th GvIAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 115th GvIAP.yaml
@@ -1,7 +1,7 @@
 ---
 name: 115th Guards Aviation Regiment
 nickname: 115th GvIAP
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 115th GvIAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 115th GvIAP.yaml
@@ -1,6 +1,7 @@
 ---
 name: 115th Guards Aviation Regiment
 nickname: 115th GvIAP
+female_pilot_ratio: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 28th GvIAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 28th GvIAP.yaml
@@ -1,6 +1,7 @@
 ---
 name: 28th Guards Aviation Regiment
 nickname: 28th GvIAP
+female_pilot_ratio: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 28th GvIAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 28th GvIAP.yaml
@@ -1,7 +1,7 @@
 ---
 name: 28th Guards Aviation Regiment
 nickname: 28th GvIAP
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 31st GvIAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 31st GvIAP.yaml
@@ -1,7 +1,7 @@
 ---
 name: 31st Guards Aviation Regiment
 nickname: 31st GvIAP
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 31st GvIAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 31st GvIAP.yaml
@@ -1,6 +1,7 @@
 ---
 name: 31st Guards Aviation Regiment
 nickname: 31st GvIAP
+female_pilot_ratio: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 773rd IAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 773rd IAP.yaml
@@ -1,6 +1,7 @@
 ---
 name: 773rd Aviation Regiment
 nickname: 773rd IAP
+female_pilot_ratio: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/Russia VVS 773rd IAP.yaml
+++ b/resources/squadrons/Mig-29/Russia VVS 773rd IAP.yaml
@@ -1,7 +1,7 @@
 ---
 name: 773rd Aviation Regiment
 nickname: 773rd IAP
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Russia
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/SAAF 697th Sqn.yaml
+++ b/resources/squadrons/Mig-29/SAAF 697th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 697th Squadron
 nickname: 697th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/SAAF 697th Sqn.yaml
+++ b/resources/squadrons/Mig-29/SAAF 697th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 697th Squadron
 nickname: 697th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/SAAF 699th Sqn.yaml
+++ b/resources/squadrons/Mig-29/SAAF 699th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 699th Squadron
 nickname: 699th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/Mig-29/SAAF 699th Sqn.yaml
+++ b/resources/squadrons/Mig-29/SAAF 699th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 699th Squadron
 nickname: 699th
+female_pilot_ratio: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C

--- a/resources/squadrons/MosquitoFBMkVI/no_21_squadron_raf.yaml
+++ b/resources/squadrons/MosquitoFBMkVI/no_21_squadron_raf.yaml
@@ -1,7 +1,7 @@
 ---
 name: RAF, No. 21 Squadron
 nickname: No. 21
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: UK
 role: Fighter Bomber
 aircraft: MosquitoFBMkVI

--- a/resources/squadrons/MosquitoFBMkVI/no_21_squadron_raf.yaml
+++ b/resources/squadrons/MosquitoFBMkVI/no_21_squadron_raf.yaml
@@ -1,6 +1,7 @@
 ---
 name: RAF, No. 21 Squadron
 nickname: No. 21
+female_pilot_ratio: 0
 country: UK
 role: Fighter Bomber
 aircraft: MosquitoFBMkVI

--- a/resources/squadrons/S-3B/VS-35.yaml
+++ b/resources/squadrons/S-3B/VS-35.yaml
@@ -1,6 +1,7 @@
 ---
 name: VS-35
 nickname: Blue Wolves
+female_pilot_ratio: 0
 country: USA
 role: Carrier-based Attack
 aircraft: S-3B Viking

--- a/resources/squadrons/S-3B/VS-35.yaml
+++ b/resources/squadrons/S-3B/VS-35.yaml
@@ -1,7 +1,7 @@
 ---
 name: VS-35
 nickname: Blue Wolves
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Carrier-based Attack
 aircraft: S-3B Viking

--- a/resources/squadrons/S-3B/VS-35F.yaml
+++ b/resources/squadrons/S-3B/VS-35F.yaml
@@ -1,6 +1,7 @@
 ---
 name: VS-35 (Tanker)
 nickname: Blue Wolves
+female_pilot_ratio: 0
 country: USA
 role: Tanker
 aircraft: S-3B Tanker

--- a/resources/squadrons/S-3B/VS-35F.yaml
+++ b/resources/squadrons/S-3B/VS-35F.yaml
@@ -1,7 +1,7 @@
 ---
 name: VS-35 (Tanker)
 nickname: Blue Wolves
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Tanker
 aircraft: S-3B Tanker

--- a/resources/squadrons/SH-60B/HSM-40.yaml
+++ b/resources/squadrons/SH-60B/HSM-40.yaml
@@ -1,6 +1,7 @@
 ---
 name: HSM-40
 nickname: Airwolves
+female_pilot_ratio: 0
 country: USA
 role: Transport/Anti-Ship
 aircraft: SH-60B Seahawk

--- a/resources/squadrons/SH-60B/HSM-40.yaml
+++ b/resources/squadrons/SH-60B/HSM-40.yaml
@@ -1,7 +1,7 @@
 ---
 name: HSM-40
 nickname: Airwolves
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Transport/Anti-Ship
 aircraft: SH-60B Seahawk

--- a/resources/squadrons/SpitfireLFMkIX/no_145_squadron_raf.yaml
+++ b/resources/squadrons/SpitfireLFMkIX/no_145_squadron_raf.yaml
@@ -1,7 +1,7 @@
 ---
 name: RAF, No. 145 Squadron
 nickname: No. 145
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: UK
 role: Fighter
 aircraft: Spitfire LF Mk IX

--- a/resources/squadrons/SpitfireLFMkIX/no_145_squadron_raf.yaml
+++ b/resources/squadrons/SpitfireLFMkIX/no_145_squadron_raf.yaml
@@ -1,6 +1,7 @@
 ---
 name: RAF, No. 145 Squadron
 nickname: No. 145
+female_pilot_ratio: 0
 country: UK
 role: Fighter
 aircraft: Spitfire LF Mk IX

--- a/resources/squadrons/SpitfireLFMkIX/no_16_squadron_raf.yaml
+++ b/resources/squadrons/SpitfireLFMkIX/no_16_squadron_raf.yaml
@@ -1,6 +1,7 @@
 ---
 name: RAF, No. 16 Squadron
 nickname: No. 16
+female_pilot_ratio: 0
 country: UK
 role: Fighter
 aircraft: Spitfire LF Mk IX

--- a/resources/squadrons/SpitfireLFMkIX/no_16_squadron_raf.yaml
+++ b/resources/squadrons/SpitfireLFMkIX/no_16_squadron_raf.yaml
@@ -1,7 +1,7 @@
 ---
 name: RAF, No. 16 Squadron
 nickname: No. 16
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: UK
 role: Fighter
 aircraft: Spitfire LF Mk IX

--- a/resources/squadrons/SpitfireLFMkIXCW/no_126_squadron_raf.yaml
+++ b/resources/squadrons/SpitfireLFMkIXCW/no_126_squadron_raf.yaml
@@ -1,7 +1,7 @@
 ---
 name: RAF, No. 126 Squadron
 nickname: Harrowbeer
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: UK
 role: Fighter
 aircraft: Spitfire LF Mk IX (Clipped Wings)

--- a/resources/squadrons/SpitfireLFMkIXCW/no_126_squadron_raf.yaml
+++ b/resources/squadrons/SpitfireLFMkIXCW/no_126_squadron_raf.yaml
@@ -1,6 +1,7 @@
 ---
 name: RAF, No. 126 Squadron
 nickname: Harrowbeer
+female_pilot_ratio: 0
 country: UK
 role: Fighter
 aircraft: Spitfire LF Mk IX (Clipped Wings)

--- a/resources/squadrons/Strike Eagle/335th FS.yaml
+++ b/resources/squadrons/Strike Eagle/335th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 335th FS
 nickname: Chiefs
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-15E Strike Eagle

--- a/resources/squadrons/Strike Eagle/335th FS.yaml
+++ b/resources/squadrons/Strike Eagle/335th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 335th FS
 nickname: Chiefs
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-15E Strike Eagle

--- a/resources/squadrons/Strike Eagle/492nd FS.yaml
+++ b/resources/squadrons/Strike Eagle/492nd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 492nd FS
 nickname: Chiefs
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-15E Strike Eagle

--- a/resources/squadrons/Strike Eagle/492nd FS.yaml
+++ b/resources/squadrons/Strike Eagle/492nd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 492nd FS
 nickname: Chiefs
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-15E Strike Eagle

--- a/resources/squadrons/Strike Eagle/IAF 69th Sqn.yaml
+++ b/resources/squadrons/Strike Eagle/IAF 69th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 69th Squadron
 nickname: Hammers
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-15E Strike Eagle

--- a/resources/squadrons/Strike Eagle/IAF 69th Sqn.yaml
+++ b/resources/squadrons/Strike Eagle/IAF 69th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 69th Squadron
 nickname: Hammers
+female_pilot_ratio: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-15E Strike Eagle

--- a/resources/squadrons/Su-17/SAAF 677th Sqn.yaml
+++ b/resources/squadrons/Su-17/SAAF 677th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 677th Squadron
 nickname: 677th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Bomber
 aircraft: Su-17M4 Fitter-K

--- a/resources/squadrons/Su-17/SAAF 677th Sqn.yaml
+++ b/resources/squadrons/Su-17/SAAF 677th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 677th Squadron
 nickname: 677th
+female_pilot_ratio: 0
 country: Syria
 role: Bomber
 aircraft: Su-17M4 Fitter-K

--- a/resources/squadrons/Su-17/SAAF 685th Sqn.yaml
+++ b/resources/squadrons/Su-17/SAAF 685th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 685th Squadron
 nickname: 685th
+female_pilot_ratio: 0
 country: Syria
 role: Bomber
 aircraft: Su-17M4 Fitter-K

--- a/resources/squadrons/Su-17/SAAF 685th Sqn.yaml
+++ b/resources/squadrons/Su-17/SAAF 685th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 685th Squadron
 nickname: 685th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Bomber
 aircraft: Su-17M4 Fitter-K

--- a/resources/squadrons/Su-17/SAAF 827th Sqn.yaml
+++ b/resources/squadrons/Su-17/SAAF 827th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 827th Squadron
 nickname: 827th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Bomber
 aircraft: Su-17M4 Fitter-K

--- a/resources/squadrons/Su-17/SAAF 827th Sqn.yaml
+++ b/resources/squadrons/Su-17/SAAF 827th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 827th Squadron
 nickname: 827th
+female_pilot_ratio: 0
 country: Syria
 role: Bomber
 aircraft: Su-17M4 Fitter-K

--- a/resources/squadrons/Su-24/SAAF 819th Sqn.yaml
+++ b/resources/squadrons/Su-24/SAAF 819th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 819th Squadron
 nickname: 819th
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: Syria
 role: Bomber
 aircraft: Su-24M Fencer-D

--- a/resources/squadrons/Su-24/SAAF 819th Sqn.yaml
+++ b/resources/squadrons/Su-24/SAAF 819th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 819th Squadron
 nickname: 819th
+female_pilot_ratio: 0
 country: Syria
 role: Bomber
 aircraft: Su-24M Fencer-D

--- a/resources/squadrons/Tornado/RAF No12 Squadron.yaml
+++ b/resources/squadrons/Tornado/RAF No12 Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: No. 12 Squadron
 nickname: Shiny Twelve
+female_pilot_ratio: 6
 country: UK
 role: Strike Fighter
 aircraft: Tornado GR4

--- a/resources/squadrons/Tornado/RAF No12 Squadron.yaml
+++ b/resources/squadrons/Tornado/RAF No12 Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: No. 12 Squadron
 nickname: Shiny Twelve
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: UK
 role: Strike Fighter
 aircraft: Tornado GR4

--- a/resources/squadrons/UH-1/HMLA-169-UH1H.yaml
+++ b/resources/squadrons/UH-1/HMLA-169-UH1H.yaml
@@ -1,7 +1,7 @@
 ---
 name: HMLA-169 (UH-1H)
 nickname: Vipers
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Transport/Light Attack
 aircraft: UH-1H Iroquois

--- a/resources/squadrons/UH-1/HMLA-169-UH1H.yaml
+++ b/resources/squadrons/UH-1/HMLA-169-UH1H.yaml
@@ -1,6 +1,7 @@
 ---
 name: HMLA-169 (UH-1H)
 nickname: Vipers
+female_pilot_ratio: 0
 country: USA
 role: Transport/Light Attack
 aircraft: UH-1H Iroquois

--- a/resources/squadrons/UH-1/HMLA-269-UH1H.yaml
+++ b/resources/squadrons/UH-1/HMLA-269-UH1H.yaml
@@ -1,6 +1,7 @@
 ---
 name: HMLA-269 (UH-1H)
 nickname: Gunrunners
+female_pilot_ratio: 0
 country: USA
 role: Transport/Light Attack
 aircraft: UH-1H Iroquois

--- a/resources/squadrons/UH-1/HMLA-269-UH1H.yaml
+++ b/resources/squadrons/UH-1/HMLA-269-UH1H.yaml
@@ -1,7 +1,7 @@
 ---
 name: HMLA-269 (UH-1H)
 nickname: Gunrunners
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Transport/Light Attack
 aircraft: UH-1H Iroquois

--- a/resources/squadrons/UH-60/US Army 101st Combat Aviation Brigade.yaml
+++ b/resources/squadrons/UH-60/US Army 101st Combat Aviation Brigade.yaml
@@ -1,6 +1,7 @@
 ---
 name: 101st Combat Aviation Brigade
 nickname: Bearcats
+female_pilot_ratio: 0
 country: USA
 role: Transport/Light Attack
 aircraft: UH-60A

--- a/resources/squadrons/UH-60/US Army 101st Combat Aviation Brigade.yaml
+++ b/resources/squadrons/UH-60/US Army 101st Combat Aviation Brigade.yaml
@@ -1,7 +1,7 @@
 ---
 name: 101st Combat Aviation Brigade
 nickname: Bearcats
-female_pilot_ratio: 0
+female_pilot_percentage: 0
 country: USA
 role: Transport/Light Attack
 aircraft: UH-60A

--- a/resources/squadrons/globemaster/15th-Airlift.yaml
+++ b/resources/squadrons/globemaster/15th-Airlift.yaml
@@ -1,7 +1,7 @@
 ---
 name: 15th Airlift Squadron
 nickname: Global Eagles
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Airlift
 aircraft: C-17A

--- a/resources/squadrons/globemaster/15th-Airlift.yaml
+++ b/resources/squadrons/globemaster/15th-Airlift.yaml
@@ -1,6 +1,7 @@
 ---
 name: 15th Airlift Squadron
 nickname: Global Eagles
+female_pilot_ratio: 6
 country: USA
 role: Airlift
 aircraft: C-17A

--- a/resources/squadrons/hornet/VFA-106.yaml
+++ b/resources/squadrons/hornet/VFA-106.yaml
@@ -1,7 +1,7 @@
 ---
 name: VFA-106
 nickname: Gladiators
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VFA-106.yaml
+++ b/resources/squadrons/hornet/VFA-106.yaml
@@ -1,6 +1,7 @@
 ---
 name: VFA-106
 nickname: Gladiators
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VFA-113.yaml
+++ b/resources/squadrons/hornet/VFA-113.yaml
@@ -1,6 +1,7 @@
 ---
 name: VFA-113
 nickname: Stingers
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VFA-113.yaml
+++ b/resources/squadrons/hornet/VFA-113.yaml
@@ -1,7 +1,7 @@
 ---
 name: VFA-113
 nickname: Stingers
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VFA-192.yaml
+++ b/resources/squadrons/hornet/VFA-192.yaml
@@ -1,6 +1,7 @@
 ---
 name: VFA-192
 nickname: Golden Dragons
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VFA-192.yaml
+++ b/resources/squadrons/hornet/VFA-192.yaml
@@ -1,7 +1,7 @@
 ---
 name: VFA-192
 nickname: Golden Dragons
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VMFA-122.yaml
+++ b/resources/squadrons/hornet/VMFA-122.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMFA-122
 nickname: Werewolves
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VMFA-122.yaml
+++ b/resources/squadrons/hornet/VMFA-122.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMFA-122
 nickname: Werewolves
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VMFA-251.yaml
+++ b/resources/squadrons/hornet/VMFA-251.yaml
@@ -1,7 +1,7 @@
 ---
 name: VMFA-251
 nickname: Thunderbolts
-female_pilot_ratio: 7
+female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/hornet/VMFA-251.yaml
+++ b/resources/squadrons/hornet/VMFA-251.yaml
@@ -1,6 +1,7 @@
 ---
 name: VMFA-251
 nickname: Thunderbolts
+female_pilot_ratio: 7
 country: USA
 role: Strike Fighter
 aircraft: F/A-18C Hornet (Lot 20)

--- a/resources/squadrons/m2000-5/ADA_EscadronDeChasse_1-2_Cigognes.yaml
+++ b/resources/squadrons/m2000-5/ADA_EscadronDeChasse_1-2_Cigognes.yaml
@@ -1,6 +1,7 @@
 ---
 name: Escadron de chasse 1/2
 nickname: Cigognes
+female_pilot_ratio: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000-5

--- a/resources/squadrons/m2000-5/ADA_EscadronDeChasse_1-2_Cigognes.yaml
+++ b/resources/squadrons/m2000-5/ADA_EscadronDeChasse_1-2_Cigognes.yaml
@@ -1,7 +1,7 @@
 ---
 name: Escadron de chasse 1/2
 nickname: Cigognes
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000-5

--- a/resources/squadrons/m2000-5/ADA_EscadronDeChasse_2-2_CoteDOr.yaml
+++ b/resources/squadrons/m2000-5/ADA_EscadronDeChasse_2-2_CoteDOr.yaml
@@ -1,6 +1,7 @@
 ---
 name: Escadron de chasse 2/2
 nickname: Côte d'Or
+female_pilot_ratio: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000-5

--- a/resources/squadrons/m2000-5/ADA_EscadronDeChasse_2-2_CoteDOr.yaml
+++ b/resources/squadrons/m2000-5/ADA_EscadronDeChasse_2-2_CoteDOr.yaml
@@ -1,7 +1,7 @@
 ---
 name: Escadron de chasse 2/2
 nickname: Côte d'Or
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000-5

--- a/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-12_Cambresis.yaml
+++ b/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-12_Cambresis.yaml
@@ -1,6 +1,7 @@
 ---
 name: Escadron de chasse 1/12
 nickname: Cambrésis
+female_pilot_ratio: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000C

--- a/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-12_Cambresis.yaml
+++ b/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-12_Cambresis.yaml
@@ -1,7 +1,7 @@
 ---
 name: Escadron de chasse 1/12
 nickname: Cambrésis
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000C

--- a/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-30_Alsace.yaml
+++ b/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-30_Alsace.yaml
@@ -1,7 +1,7 @@
 ---
 name: Escadron de chasse 1/30
 nickname: Alsace
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000C

--- a/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-30_Alsace.yaml
+++ b/resources/squadrons/m2000c/ADA_EscadronDeChasse_1-30_Alsace.yaml
@@ -1,6 +1,7 @@
 ---
 name: Escadron de chasse 1/30
 nickname: Alsace
+female_pilot_ratio: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000C

--- a/resources/squadrons/m2000c/ADA_EscadronDeChasse_2-5_IleDeFrance.yaml
+++ b/resources/squadrons/m2000c/ADA_EscadronDeChasse_2-5_IleDeFrance.yaml
@@ -1,7 +1,7 @@
 ---
 name: Escadron de chasse 2/5
 nickname: Île De France
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000C

--- a/resources/squadrons/m2000c/ADA_EscadronDeChasse_2-5_IleDeFrance.yaml
+++ b/resources/squadrons/m2000c/ADA_EscadronDeChasse_2-5_IleDeFrance.yaml
@@ -1,6 +1,7 @@
 ---
 name: Escadron de chasse 2/5
 nickname: Île De France
+female_pilot_ratio: 6
 country: France
 role: Fighter
 aircraft: Mirage 2000C

--- a/resources/squadrons/sa342/ALAT_1er_RHC.yaml
+++ b/resources/squadrons/sa342/ALAT_1er_RHC.yaml
@@ -1,7 +1,7 @@
 ---
 name: 1er régiment d'hélicoptères de combat
 nickname:
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Anti-Aircraft Helicopter
 aircraft: SA 342M Gazelle Mistral

--- a/resources/squadrons/sa342/ALAT_1er_RHC.yaml
+++ b/resources/squadrons/sa342/ALAT_1er_RHC.yaml
@@ -1,6 +1,7 @@
 ---
 name: 1er régiment d'hélicoptères de combat
 nickname:
+female_pilot_ratio: 6
 country: France
 role: Anti-Aircraft Helicopter
 aircraft: SA 342M Gazelle Mistral

--- a/resources/squadrons/sa342/ALAT_3eme_RHC.yaml
+++ b/resources/squadrons/sa342/ALAT_3eme_RHC.yaml
@@ -1,6 +1,7 @@
 ---
 name: 3ème régiment d'hélicoptères de combat
 nickname: Grand 3
+female_pilot_ratio: 6
 country: France
 role: Anti-Tank Helicopter
 aircraft: SA 342M Gazelle

--- a/resources/squadrons/sa342/ALAT_3eme_RHC.yaml
+++ b/resources/squadrons/sa342/ALAT_3eme_RHC.yaml
@@ -1,7 +1,7 @@
 ---
 name: 3ème régiment d'hélicoptères de combat
 nickname: Grand 3
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Anti-Tank Helicopter
 aircraft: SA 342M Gazelle

--- a/resources/squadrons/sa342/ALAT_5eme_RHC.yaml
+++ b/resources/squadrons/sa342/ALAT_5eme_RHC.yaml
@@ -1,7 +1,7 @@
 ---
 name: 5ème régiment d'hélicoptères de combat
 nickname: Le régiment du Béarn
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Combat Helicopter
 aircraft: SA 342L Gazelle

--- a/resources/squadrons/sa342/ALAT_5eme_RHC.yaml
+++ b/resources/squadrons/sa342/ALAT_5eme_RHC.yaml
@@ -1,6 +1,7 @@
 ---
 name: 5ème régiment d'hélicoptères de combat
 nickname: Le régiment du Béarn
+female_pilot_ratio: 6
 country: France
 role: Combat Helicopter
 aircraft: SA 342L Gazelle

--- a/resources/squadrons/sa342/ALAT_DOAS.yaml
+++ b/resources/squadrons/sa342/ALAT_DOAS.yaml
@@ -1,7 +1,7 @@
 ---
 name: Détachement ALAT des opérations spéciales
 nickname: DOAS
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: France
 role: Combat Helicopter
 aircraft: SA342Minigun

--- a/resources/squadrons/sa342/ALAT_DOAS.yaml
+++ b/resources/squadrons/sa342/ALAT_DOAS.yaml
@@ -1,6 +1,7 @@
 ---
 name: Détachement ALAT des opérations spéciales
 nickname: DOAS
+female_pilot_ratio: 6
 country: France
 role: Combat Helicopter
 aircraft: SA342Minigun

--- a/resources/squadrons/sa342/SAAF 976th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 976th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 976th Squadron
 nickname: 976th
+female_pilot_ratio: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342L Gazelle

--- a/resources/squadrons/sa342/SAAF 976th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 976th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 976th Squadron
 nickname: 976th
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342L Gazelle

--- a/resources/squadrons/sa342/SAAF 977th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 977th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 977th Squadron
 nickname: 977th
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342L Gazelle

--- a/resources/squadrons/sa342/SAAF 977th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 977th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 977th Squadron
 nickname: 977th
+female_pilot_ratio: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342L Gazelle

--- a/resources/squadrons/sa342/SAAF 988th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 988th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 988th Squadron
 nickname: 988th
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342M Gazelle

--- a/resources/squadrons/sa342/SAAF 988th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 988th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 988th Squadron
 nickname: 988th
+female_pilot_ratio: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342M Gazelle

--- a/resources/squadrons/sa342/SAAF 989th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 989th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 989th Squadron
 nickname: 989th
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342M Gazelle

--- a/resources/squadrons/sa342/SAAF 989th Sqn.yaml
+++ b/resources/squadrons/sa342/SAAF 989th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 989th Squadron
 nickname: 989th
+female_pilot_ratio: 6
 country: Syria
 role: Anti-Tank Helicopter
 aircraft: SA 342M Gazelle

--- a/resources/squadrons/viper/191-Filo.yaml
+++ b/resources/squadrons/viper/191-Filo.yaml
@@ -1,7 +1,7 @@
 ---
 name: 191. Filo
 nickname: Kobra
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Turkey
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/191-Filo.yaml
+++ b/resources/squadrons/viper/191-Filo.yaml
@@ -1,6 +1,7 @@
 ---
 name: 191. Filo
 nickname: Kobra
+female_pilot_ratio: 6
 country: Turkey
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 335 Tiger Squadron.yaml
+++ b/resources/squadrons/viper/HAF 335 Tiger Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 335 Squadron
 nickname: Tiger
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 335 Tiger Squadron.yaml
+++ b/resources/squadrons/viper/HAF 335 Tiger Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 335 Squadron
 nickname: Tiger
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 336 Olympus Squadron.yaml
+++ b/resources/squadrons/viper/HAF 336 Olympus Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 336 Squadron
 nickname: Olympus
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 336 Olympus Squadron.yaml
+++ b/resources/squadrons/viper/HAF 336 Olympus Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 336 Squadron
 nickname: Olympus
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 337 Ghost Squadron.yaml
+++ b/resources/squadrons/viper/HAF 337 Ghost Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 337 Squadron
 nickname: Ghost
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 337 Ghost Squadron.yaml
+++ b/resources/squadrons/viper/HAF 337 Ghost Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 337 Squadron
 nickname: Ghost
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 340 Fox Squadron.yaml
+++ b/resources/squadrons/viper/HAF 340 Fox Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 340 Squadron
 nickname: Fox
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 340 Fox Squadron.yaml
+++ b/resources/squadrons/viper/HAF 340 Fox Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 340 Squadron
 nickname: Fox
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 341 Arrow Squadron.yaml
+++ b/resources/squadrons/viper/HAF 341 Arrow Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 341 Squadron
 nickname: Arrow
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 341 Arrow Squadron.yaml
+++ b/resources/squadrons/viper/HAF 341 Arrow Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 341 Squadron
 nickname: Arrow
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 343 Star Squadron.yaml
+++ b/resources/squadrons/viper/HAF 343 Star Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 343 Squadron
 nickname: Star
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 343 Star Squadron.yaml
+++ b/resources/squadrons/viper/HAF 343 Star Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 343 Squadron
 nickname: Star
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 346 Jason Squadron.yaml
+++ b/resources/squadrons/viper/HAF 346 Jason Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 346 Squadron
 nickname: Jason
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 346 Jason Squadron.yaml
+++ b/resources/squadrons/viper/HAF 346 Jason Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 346 Squadron
 nickname: Jason
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 347 Perseus Squadron.yaml
+++ b/resources/squadrons/viper/HAF 347 Perseus Squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 347 Squadron
 nickname: Perseus
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF 347 Perseus Squadron.yaml
+++ b/resources/squadrons/viper/HAF 347 Perseus Squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 347 Squadron
 nickname: Perseus
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF_330_Thunder_squadron.yaml
+++ b/resources/squadrons/viper/HAF_330_Thunder_squadron.yaml
@@ -1,6 +1,7 @@
 ---
 name: 330 Squadron
 nickname: Thunder
+female_pilot_ratio: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/HAF_330_Thunder_squadron.yaml
+++ b/resources/squadrons/viper/HAF_330_Thunder_squadron.yaml
@@ -1,7 +1,7 @@
 ---
 name: 330 Squadron
 nickname: Thunder
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Greece
 role: Multirole Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/IAF 101st Sqn.yaml
+++ b/resources/squadrons/viper/IAF 101st Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 101st Squadron
 nickname: First Fighter
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/IAF 101st Sqn.yaml
+++ b/resources/squadrons/viper/IAF 101st Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 101st Squadron
 nickname: First Fighter
+female_pilot_ratio: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/IAF 110th Sqn.yaml
+++ b/resources/squadrons/viper/IAF 110th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 110th Squadron
 nickname: Knights of the North
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/IAF 110th Sqn.yaml
+++ b/resources/squadrons/viper/IAF 110th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 110th Squadron
 nickname: Knights of the North
+female_pilot_ratio: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/IAF 117th Sqn.yaml
+++ b/resources/squadrons/viper/IAF 117th Sqn.yaml
@@ -1,7 +1,7 @@
 ---
 name: 117th Squadron
 nickname: First Jet
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/IAF 117th Sqn.yaml
+++ b/resources/squadrons/viper/IAF 117th Sqn.yaml
@@ -1,6 +1,7 @@
 ---
 name: 117th Squadron
 nickname: First Jet
+female_pilot_ratio: 6
 country: Israel
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 132nd WG.yaml
+++ b/resources/squadrons/viper/USAF 132nd WG.yaml
@@ -1,6 +1,7 @@
 ---
 name: 132nd FW
 nickname: Hawkeyes
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 132nd WG.yaml
+++ b/resources/squadrons/viper/USAF 132nd WG.yaml
@@ -1,7 +1,7 @@
 ---
 name: 132nd FW
 nickname: Hawkeyes
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 13th FS.yaml
+++ b/resources/squadrons/viper/USAF 13th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 13th FS
 nickname: Panthers
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 13th FS.yaml
+++ b/resources/squadrons/viper/USAF 13th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 13th FS
 nickname: Panthers
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 14th FS.yaml
+++ b/resources/squadrons/viper/USAF 14th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 14th FS
 nickname: Samurais
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 14th FS.yaml
+++ b/resources/squadrons/viper/USAF 14th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 14th FS
 nickname: Samurais
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 152nd FS.yaml
+++ b/resources/squadrons/viper/USAF 152nd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 152nd FS
 nickname: Las Vaqueros
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 152nd FS.yaml
+++ b/resources/squadrons/viper/USAF 152nd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 152nd FS
 nickname: Las Vaqueros
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 174th FS.yaml
+++ b/resources/squadrons/viper/USAF 174th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 174th FS
 nickname: Bulldogs
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 174th FS.yaml
+++ b/resources/squadrons/viper/USAF 174th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 174th FS
 nickname: Bulldogs
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 179th FS.yaml
+++ b/resources/squadrons/viper/USAF 179th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 179th FS
 nickname: Bulldogs
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 179th FS.yaml
+++ b/resources/squadrons/viper/USAF 179th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 179th FS
 nickname: Bulldogs
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 22nd FS.yaml
+++ b/resources/squadrons/viper/USAF 22nd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 22nd FS
 nickname: Stingers
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 22nd FS.yaml
+++ b/resources/squadrons/viper/USAF 22nd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 22nd FS
 nickname: Stingers
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 23rd FS.yaml
+++ b/resources/squadrons/viper/USAF 23rd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 23rd FS
 nickname: Fighting Hawks
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 23rd FS.yaml
+++ b/resources/squadrons/viper/USAF 23rd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 23rd FS
 nickname: Fighting Hawks
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 36th FS.yaml
+++ b/resources/squadrons/viper/USAF 36th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 36th FS
 nickname: Flying Fiends
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 36th FS.yaml
+++ b/resources/squadrons/viper/USAF 36th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 36th FS
 nickname: Flying Fiends
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 480th FS.yaml
+++ b/resources/squadrons/viper/USAF 480th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 480th FS
 nickname: Warhawks
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 480th FS.yaml
+++ b/resources/squadrons/viper/USAF 480th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 480th FS
 nickname: Warhawks
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 522nd FS.yaml
+++ b/resources/squadrons/viper/USAF 522nd FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 522nd FS
 nickname: Fireballs
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 522nd FS.yaml
+++ b/resources/squadrons/viper/USAF 522nd FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 522nd FS
 nickname: Fireballs
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 55th FS.yaml
+++ b/resources/squadrons/viper/USAF 55th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 55th FS
 nickname: Fifty Fifth
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 55th FS.yaml
+++ b/resources/squadrons/viper/USAF 55th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 55th FS
 nickname: Fifty Fifth
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 77th FS.yaml
+++ b/resources/squadrons/viper/USAF 77th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 77th FS
 nickname: Gamblers
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 77th FS.yaml
+++ b/resources/squadrons/viper/USAF 77th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 77th FS
 nickname: Gamblers
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 79th FS.yaml
+++ b/resources/squadrons/viper/USAF 79th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 79th FS
 nickname: Tigers
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 79th FS.yaml
+++ b/resources/squadrons/viper/USAF 79th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 79th FS
 nickname: Tigers
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 80th FS.yaml
+++ b/resources/squadrons/viper/USAF 80th FS.yaml
@@ -1,7 +1,7 @@
 ---
 name: 80th FS
 nickname: Headhunters
-female_pilot_ratio: 6
+female_pilot_percentage: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)

--- a/resources/squadrons/viper/USAF 80th FS.yaml
+++ b/resources/squadrons/viper/USAF 80th FS.yaml
@@ -1,6 +1,7 @@
 ---
 name: 80th FS
 nickname: Headhunters
+female_pilot_ratio: 6
 country: USA
 role: Strike Fighter
 aircraft: F-16CM Fighting Falcon (Block 50)


### PR DESCRIPTION
This PR fixes issue #1966, and introduce a parameter to setup female/male pilot name ratio in squadrons.

Default ratio is now 6% female pilot per squadron, which is from USAF 2020 status. (Source : https://www.airforcetimes.com/news/your-air-force/2021/03/19/heres-the-air-forces-plan-to-diversify-its-pilot-corps/)

The parameter "female_pilot_ratio" is introduced in squadrons definition files :

```yaml
---
name: Escadron de chasse 1/12
nickname: Cambrésis
female_pilot_ratio: 6
country: France
role: Fighter
aircraft: Mirage 2000C
livery: Cambresis
mission_types:
  - BARCAP
  - Escort
[...]
```

The campaign file SquadronConfig object can now also force squadron name, nickname and female_pilot_ratio : 

```yaml
  Golan South:
    - primary: CAS
      secondary: air-to-ground
      nickname: Golan Heights Heroes
      female_pilot_ratio: 15
      aircraft:
        - AH-1W SuperCobra
```