### PR TITLE
Fixed 492nd FS using 335th FS's nickname

### DIFF
--- a/resources/squadrons/Strike Eagle/492nd FS.yaml
+++ b/resources/squadrons/Strike Eagle/492nd FS.yaml
@@ -1,6 +1,6 @@
 ---
 name: 492nd FS
-nickname: Chiefs
+nickname: Bolars
 female_pilot_percentage: 6
 country: USA
 role: Strike Fighter


### PR DESCRIPTION
Fixed incorrect nickname. Looks like the nickname wasn't updated when the contents were copy-pasted over from the other squadron.