### PR TITLE
Fix #1988 broken stored heading in Payload editor

### DIFF
--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -367,7 +367,10 @@ class AircraftType(UnitType[Type[FlyingType]]):
             units = ImperialUnits()
         if units_data == "metric":
             units = MetricUnits()
-
+        prop_overrides = data.get("default_overrides")
+        if prop_overrides and aircraft.property_defaults:
+            for k in prop_overrides:
+                aircraft.property_defaults[k] = prop_overrides[k]
         for variant in data.get("variants", [aircraft.id]):
             yield AircraftType(
                 dcs_unit_type=aircraft,

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -368,7 +368,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
         if units_data == "metric":
             units = MetricUnits()
         prop_overrides = data.get("default_overrides")
-        if prop_overrides and aircraft.property_defaults:
+        if prop_overrides and aircraft.property_defaults is not None:
             for k in prop_overrides:
                 aircraft.property_defaults[k] = prop_overrides[k]
         for variant in data.get("variants", [aircraft.id]):

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -319,7 +319,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
 
     @staticmethod
     def _set_props_overrides(
-        config: Dict[str, any], aircraft: Type[FlyingType], data_path: Path
+        config: Dict[str, Any], aircraft: Type[FlyingType], data_path: Path
     ) -> None:
         if aircraft.property_defaults is None:
             logging.warning(

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -116,10 +116,6 @@ class FlightGroupConfigurator:
             laser_codes.append(self.laser_code_registry.get_next_laser_code())
         else:
             laser_codes.append(None)
-        if unit.unit_type is F_14B:
-            unit.set_property(F_14B.Properties.INSAlignmentStored.id, True)
-        elif unit.unit_type is F_14A_135_GR:
-            unit.set_property(F_14A_135_GR.Properties.INSAlignmentStored.id, True)
 
     def setup_radios(self) -> RadioFrequency:
         if self.flight.flight_type in {FlightType.AEWC, FlightType.REFUELING}:

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -6,7 +6,6 @@ from typing import Any, Optional, TYPE_CHECKING
 
 from dcs import Mission
 from dcs.flyingunit import FlyingUnit
-from dcs.planes import F_14A_135_GR, F_14B
 from dcs.unit import Skill
 from dcs.unitgroup import FlyingGroup
 

--- a/resources/units/aircraft/F-14A-135-GR.yaml
+++ b/resources/units/aircraft/F-14A-135-GR.yaml
@@ -32,3 +32,5 @@ radios:
     namer: tomcat
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
+default_overrides:
+  INSAlignmentStored: true

--- a/resources/units/aircraft/F-14B.yaml
+++ b/resources/units/aircraft/F-14B.yaml
@@ -32,3 +32,5 @@ radios:
     namer: tomcat
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
+default_overrides:
+  INSAlignmentStored: true

--- a/resources/units/aircraft/F-14B.yaml
+++ b/resources/units/aircraft/F-14B.yaml
@@ -34,3 +34,4 @@ radios:
     inter_flight_radio_index: 1
 default_overrides:
   INSAlignmentStored: true
+ 


### PR DESCRIPTION
Fixes #1988 . 

Stored heading setting in .miz will match GUI setting.  Stored heading now defaults to false, which some won't like.  If it's desired to be true that should probably be done through changing default loadout.
