### PR TITLE
Fixes #1774 by adding a logmessage for non ascii install path.

### DIFF
--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -335,6 +335,11 @@ def main():
 
     logging.debug("Python version %s", sys.version)
 
+    if not str(Path(__file__)).isascii():
+        logging.warning(
+            "Installation path contains non-ASCII characters. This is known to cause problems."
+        )
+
     game: Optional[Game] = None
 
     args = parse_args()


### PR DESCRIPTION
Logs a warning in the applications logfile before creating the qt windows if dcs liberation is installed in a path which contains non-ascii characters.
