### PR TITLE
fixes #1987 by adding highdpi qt attributes.

### DIFF
--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -69,6 +69,8 @@ def run_ui(game: Optional[Game], new_map: bool, dev: bool) -> None:
     app = QApplication(sys.argv)
 
     app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
+    app.setAttribute(Qt.AA_EnableHighDpiScaling, True)  # enable highdpi scaling
+    app.setAttribute(Qt.AA_UseHighDpiPixmaps, True)  # use highdpi icons
 
     # init the theme and load the stylesheet based on the theme index
     liberation_theme.init()


### PR DESCRIPTION
Adding those two attributes to the main window fixes the ui overscaling issues for me on a 4k screen display and on a 1080p display. Unfortuneatly I do not have other resolutions to test this with. But the issues shown on the screenshot are fixed for me.