### PR TITLE
Another 4k fix

### DIFF
--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -69,6 +69,8 @@ def run_ui(game: Optional[Game], new_map: bool, dev: bool) -> None:
     app = QApplication(sys.argv)
 
     app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
+    app.setAttribute(Qt.AA_EnableHighDpiScaling, True)  # enable highdpi scaling
+    app.setAttribute(Qt.AA_UseHighDpiPixmaps, True)  # use highdpi icons
 
     # init the theme and load the stylesheet based on the theme index
     liberation_theme.init()

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -65,7 +65,11 @@ def on_game_load(game: Game | None) -> None:
 
 
 def run_ui(game: Optional[Game], new_map: bool, dev: bool) -> None:
-    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"  # Potential fix for 4K screens
+    os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"  # Potential fix for 4K screens
+    QApplication.setHighDpiScaleFactorRoundingPolicy(
+        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+    )
+
     app = QApplication(sys.argv)
 
     app.setAttribute(Qt.AA_DisableWindowContextHelpButton)


### PR DESCRIPTION
This fix switches the old 4k fix with a newer qt method. The old method just emulates a 1080p display for the application, which results in a huge gui which has exactly the same screen size as on 1080p. The new version does a more gradual scaling (like 150% on 4k). This results in better readability on 4k displays, but results in more screen space as well.