### PR TITLE
Make the flight creation/edition dialog modal

### DIFF
--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -42,6 +42,9 @@ class QFlightCreator(QDialog):
         self.custom_name_text = None
         self.country = self.game.blue.country_name
 
+        # Make dialog modal to prevent background windows to close unexpectedly.
+        self.setModal(True)
+
         self.setWindowTitle("Create flight")
         self.setWindowIcon(EVENT_ICONS["strike"])
 


### PR DESCRIPTION
Make the flight creation/edition dialog modal. to prevent the user from closing other parent dialogs (e.g. package creation/edit). Fixes #1971