### PR TITLE
Support for the AH-64D radios

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Saves from 5.x are not compatible with 6.0.
 
 ## Features/Improvements
 
+* **[Engine]** Support for DCS DCS 2.7.11.21408, including the new Apache AH-64D
 * **[Mission Generation]** Added an option to fast-forward mission generation until the point of first contact (WIP).
 * **[Mission Generation]** Added performance option to not cull IADS when culling would effect how mission is played at target area.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -15,6 +15,7 @@ from game.data.units import UnitClass
 from game.dcs.unitproperty import UnitProperty
 from game.dcs.unittype import UnitType
 from game.radio.channels import (
+    ApacheChannelNamer,
     ChannelNamer,
     CommonRadioChannelAllocator,
     FarmerRadioChannelAllocator,
@@ -100,6 +101,7 @@ class RadioConfig:
             "tomcat": TomcatChannelNamer,
             "viggen": ViggenChannelNamer,
             "viper": ViperChannelNamer,
+            "apache": ApacheChannelNamer,
         }[config.get("namer", "default")]
 
 

--- a/game/radio/channels.py
+++ b/game/radio/channels.py
@@ -258,6 +258,27 @@ class MirageChannelNamer(ChannelNamer):
         return "mirage"
 
 
+class ApacheChannelNamer(ChannelNamer):
+    """Channel namer for the AH-64D Apache"""
+
+    @staticmethod
+    def channel_name(radio_id: int, channel_id: int) -> str:
+        # From the manual: Radio identifier (“VHF” for ARC-186, “UHF” for ARC-164,
+        # “FM1” for first ARC-201D, “FM2” for second ARC-201D, or “HF” for ARC-220).
+        radio_name = [
+            "VHF",  # ARC-186
+            "UHF",  # ARC-164
+            "FM1",  # first ARC-201D
+            "FM2",  # second ARC-201D
+            "HF",  # ARC-220
+        ][radio_id - 1]
+        return f"{radio_name} Ch {channel_id}"
+
+    @classmethod
+    def name(cls) -> str:
+        return "apache"
+
+
 class TomcatChannelNamer(ChannelNamer):
     """Channel namer for the F-14."""
 

--- a/resources/units/aircraft/AH-64D_BLK_II.yaml
+++ b/resources/units/aircraft/AH-64D_BLK_II.yaml
@@ -16,3 +16,13 @@ price: 20
 role: Attack
 variants:
   AH-64D Apache Longbow: {}
+radios:
+  # DCS uses the 2nd Radio AN/ARC-164 (UHF) as the main intra flight for the Apache
+  # so we use this Radio for Intra and Inter Flight for now
+  intra_flight: AN/ARC-164
+  inter_flight: AN/ARC-164
+  channels:
+    type: common
+    namer: apache
+    intra_flight_radio_index: 2
+    inter_flight_radio_index: 2

--- a/resources/units/aircraft/AH-64D_BLK_II.yaml
+++ b/resources/units/aircraft/AH-64D_BLK_II.yaml
@@ -19,6 +19,9 @@ variants:
 radios:
   # DCS uses the 2nd Radio AN/ARC-164 (UHF) as the main intra flight for the Apache
   # so we use this Radio for Intra and Inter Flight for now
+  # The radio frequencies set in the mission editor are in the current state of Early
+  # access not used for radio presets. Only the flight frequency is used. Any other
+  # frequency has to be entered manually atm.
   intra_flight: AN/ARC-164
   inter_flight: AN/ARC-164
   channels:


### PR DESCRIPTION
Information from the manual: Radio identifier (“VHF” for ARC-186, “UHF” for ARC-164, “FM1” for first ARC-201D, “FM2” for second ARC-201D, or “HF” for ARC-220).

The DCS Mission editor uses the Radio 2 (UHF ARC-164) as the flight frequency therefore i am not really sure how to assign the radios correctly. (Maybe we need a special Channel Allocator to work around this).

What i figured out in the mission editor: When you place the unit in the Editor it sets the flight frequency to the Frequency of the first radio but as soon as you modify the frequency of the first channel 2nd radio it modifies the flight frequency. Really strange behaviour. Also it is not possible from Liberation to set the first channel of the 2nd radio other than the flight frequency (example: flight frequency 127, AWACS 228 -> as a result 127 will be set in the flight frequency but the first channel of the UHF radio will have 225 set (because dcs wants to set 127 there but the min freq. is 225)

Feel free to edit this PR and merge as needed!

Besides that the frequencies are set in the mission editor i am not able to find them in the presets:
![grafik](https://user-images.githubusercontent.com/6678803/159680200-a6f3ef2f-ed15-4a05-8f4d-02220b1fec2e.png)

![grafik](https://user-images.githubusercontent.com/6678803/159680147-47043b0f-1a6e-4b95-858e-dc7e89cb8307.png)

![grafik](https://user-images.githubusercontent.com/6678803/159680009-2283b46e-c85d-410e-bae4-eca076869f36.png)

