### PR TITLE
Make Apache LHA capable

### DIFF
--- a/resources/units/aircraft/AH-64D.yaml
+++ b/resources/units/aircraft/AH-64D.yaml
@@ -1,4 +1,5 @@
 always_keeps_gun: true
+lha_capable: true
 description: The legendary 'Apache' is an US twin-turboshaft attack helicopter for
   a crew of two. It features a nose-mounted sensor suite for target acquisition and
   night vision systems. It is armed with a 30 mm (1.18 in) M230 chain gun carried

--- a/resources/units/aircraft/AH-64D_BLK_II.yaml
+++ b/resources/units/aircraft/AH-64D_BLK_II.yaml
@@ -1,4 +1,5 @@
 always_keeps_gun: true
+lha_capable: true
 description: The legendary 'Apache' is an US twin-turboshaft attack helicopter for
   a crew of two. It features a nose-mounted sensor suite for target acquisition and
   night vision systems. It is armed with a 30 mm (1.18 in) M230 chain gun carried


### PR DESCRIPTION
This PR makes the AH-64D Apache and the AI variant LHA capable, so that it can be used in campaigns with LHA support.
Checked if the apache AI is able to handle LHA missions. Made a 4 heli CAS on scenic route campaign. Flight was able to take off fly a patrol on the FLOT and return to the carrier and land there. One Apache was lost because it did crash in the mountains.
So LHA-handling for this PR seems descent enough.
implements #2113.