### PR TITLE
Do not return airfields with no runways as operable

### DIFF
--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -983,7 +983,12 @@ class Airfield(ControlPoint):
         # TODO: Allow harrier.
         # Needs ground spawns just like helos do, but also need to be able to
         # limit takeoff weight to ~20500 lbs or it won't be able to take off.
-        return self.runway_is_operational()
+
+        # return false if aircraft is fixed wing and airport has no runways
+        if not aircraft.helicopter and not self.airport.runways:
+            return False
+        else:
+            return self.runway_is_operational()
 
     def mission_types(self, for_player: bool) -> Iterator[FlightType]:
         from game.ato import FlightType


### PR DESCRIPTION
This fix changes the can_operate method of airfield controlpoints to return false if the aircraft tpye is fixed wing and the airfield has no runways.
fixes #2110
Note: This fix will not fix the broken savegame in the isuse, because it already contains an ATO with flights that are assigned a non working divert. But if you skip the turn, it will prevent the ATO from assigning wrong airfields ever again.

