### PR TITLE
Fix JTAC names

### DIFF
--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -141,10 +141,8 @@ class FlotGenerator:
 
         # Add JTAC
         if self.game.blue.faction.has_jtac:
-            n = "JTAC" + str(self.conflict.blue_cp.id) + str(self.conflict.red_cp.id)
             code: int
             freq = self.radio_registry.alloc_uhf()
-
             # If the option fc3LaserCode is enabled, force all JTAC
             # laser codes to 1113 to allow lasing for Su-25 Frogfoots and A-10A Warthogs.
             # Otherwise use 1688 for the first JTAC, 1687 for the second etc.
@@ -159,7 +157,7 @@ class FlotGenerator:
 
             jtac = self.mission.flight_group(
                 country=self.mission.country(self.game.blue.country_name),
-                name=n,
+                name=namegen.next_jtac_name(),
                 aircraft_type=utype.dcs_unit_type,
                 position=position[0],
                 airport=None,
@@ -181,8 +179,8 @@ class FlotGenerator:
             callsign = callsign_for_support_unit(jtac)
             self.air_support.jtacs.append(
                 JtacInfo(
-                    str(jtac.name),
-                    n,
+                    jtac.name,
+                    jtac.name,
                     callsign,
                     frontline,
                     str(code),

--- a/game/naming.py
+++ b/game/naming.py
@@ -452,6 +452,7 @@ class NameGenerator:
     aircraft_number = 0
     convoy_number = 0
     cargo_ship_number = 0
+    jtac_number = 0
 
     animals: list[str] = list(ANIMALS)
     existing_alphas: List[str] = []
@@ -462,6 +463,7 @@ class NameGenerator:
         cls.infantry_number = 0
         cls.convoy_number = 0
         cls.cargo_ship_number = 0
+        cls.jtac_number = 0
         cls.animals = list(ANIMALS)
         cls.existing_alphas = []
 
@@ -472,6 +474,7 @@ class NameGenerator:
         cls.aircraft_number = 0
         cls.convoy_number = 0
         cls.cargo_ship_number = 0
+        cls.jtac_number = 0
 
     @classmethod
     def next_aircraft_name(cls, country: Country, flight: Flight) -> str:
@@ -522,6 +525,16 @@ class NameGenerator:
     def next_cargo_ship_name(cls) -> str:
         cls.cargo_ship_number += 1
         return f"Cargo Ship {cls.cargo_ship_number:03}"
+
+    @classmethod
+    def next_jtac_name(cls) -> str:
+        name = (
+            ALPHA_MILITARY[cls.jtac_number]
+            if cls.jtac_number < len(ALPHA_MILITARY)
+            else str(cls.jtac_number + 1)
+        )
+        cls.jtac_number += 1
+        return f"JTAC {name}"
 
     @classmethod
     def random_objective_name(cls) -> str:


### PR DESCRIPTION
- Add additional naming method to naming.py
- JTACs now use the ALPHA_MILITARY. So first JTAC is called JTAC Alpha, 2nd JTAC is called JTAC Bravo and so on

closes #2120 
