### PR TITLE
PoC: Rework SEAD flight to fix issues with skynet

### DIFF
--- a/game/ato/flightplans/sead.py
+++ b/game/ato/flightplans/sead.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
+from dataclasses import dataclass
 
 from datetime import timedelta
-from typing import Type
+from typing import Iterator, Type
+from game.ato.flightplans.patrolling import PatrollingFlightPlan, PatrollingLayout
+from game.ato.flightplans.waypointbuilder import StrikeTarget, WaypointBuilder
+
+from game.ato.flightwaypoint import FlightWaypoint
+from game.theater.theatergroundobject import TheaterGroundObject
+from game.utils import Distance, Speed, knots, meters
 
 from .formationattack import (
     FormationAttackBuilder,
@@ -12,8 +19,29 @@ from .. import Flight
 from ..flightwaypointtype import FlightWaypointType
 
 
-class SeadFlightPlan(FormationAttackFlightPlan):
-    def __init__(self, flight: Flight, layout: FormationAttackLayout) -> None:
+@dataclass(frozen=True)
+class SeadLayout(FormationAttackLayout, PatrollingLayout):
+    def iter_waypoints(self) -> Iterator[FlightWaypoint]:
+        yield self.departure
+        yield self.hold
+        yield from self.nav_to
+        yield self.join
+        yield self.ingress
+        yield self.patrol_start
+        yield from self.targets
+        yield self.patrol_end
+        yield self.split
+        if self.refuel is not None:
+            yield self.refuel
+        yield from self.nav_from
+        yield self.arrival
+        if self.divert is not None:
+            yield self.divert
+        yield self.bullseye
+
+
+class SeadFlightPlan(FormationAttackFlightPlan, PatrollingFlightPlan[SeadLayout]):
+    def __init__(self, flight: Flight, layout: SeadLayout) -> None:
         super().__init__(flight, layout)
 
     @staticmethod
@@ -24,7 +52,99 @@ class SeadFlightPlan(FormationAttackFlightPlan):
     def lead_time(self) -> timedelta:
         return timedelta(minutes=1)
 
+    @property
+    def patrol_duration(self) -> timedelta:
+        # Keep the SEAD Flight searching for 3mins
+        return timedelta(minutes=3)
+
+    @property
+    def patrol_speed(self) -> Speed:
+        # TODO Correct speed as they are in alert
+        if self.flight.unit_type.patrol_speed is not None:
+            return self.flight.unit_type.patrol_speed
+        # ~280 knots IAS at 21000.
+        return knots(400)
+
+    @property
+    def combat_speed_waypoints(self) -> set[FlightWaypoint]:
+        return {self.layout.patrol_start, self.layout.patrol_end}
+
+    @property
+    def engagement_distance(self) -> Distance:
+        if isinstance(self.package.target, TheaterGroundObject):
+            return self.package.target.max_threat_range()
+        return meters(0)
+
+    def request_escort_at(self) -> FlightWaypoint | None:
+        return self.layout.ingress
+
+    def dismiss_escort_at(self) -> FlightWaypoint | None:
+        return self.layout.split
+
 
 class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
-        return self._build(FlightWaypointType.INGRESS_SEAD)
+    def build(self) -> SeadLayout:
+        location = self.package.target
+        assert self.package.waypoints is not None
+        assert isinstance(location, TheaterGroundObject)
+        targets = [
+            StrikeTarget(f"{group.group_name} at {location.name}", group)
+            for group in location.groups
+            if group.units
+        ]
+        builder = WaypointBuilder(self.flight, self.coalition, targets)
+        target_waypoints = [
+            self.target_waypoint(self.flight, builder, target) for target in targets
+        ]
+
+        heading_from_target = location.position.heading_between_point(
+            self.package.waypoints.ingress
+        )
+        distance = location.max_threat_range().meters / 3 * 2
+        # 2/3 the range circle along the line from target to ingress
+        search_start = location.position.point_from_heading(
+            heading_from_target, distance
+        )
+        # 2/3 the range circle with a 45-90 angle
+        search_end = location.position.point_from_heading(
+            heading_from_target + 90, distance
+        )
+        sead_search = builder.race_track(
+            search_start, search_end, self.doctrine.ingress_altitude
+        )
+        sead_search[0].name = "SEAD SEARCH START"
+        sead_search[1].name = "SEAD SEARCH END"
+
+        hold = builder.hold(self._hold_point())
+        join = builder.join(self.package.waypoints.join)
+        split = builder.split(self.package.waypoints.split)
+        refuel = None
+        if self.package.waypoints.refuel is not None:
+            refuel = builder.refuel(self.package.waypoints.refuel)
+
+        return SeadLayout(
+            departure=builder.takeoff(self.flight.departure),
+            hold=hold,
+            nav_to=builder.nav_path(
+                hold.position, join.position, self.doctrine.ingress_altitude
+            ),
+            join=join,
+            ingress=builder.ingress(
+                FlightWaypointType.INGRESS_SEAD,
+                self.package.waypoints.ingress,
+                self.package.target,
+            ),
+            patrol_start=sead_search[0],
+            targets=target_waypoints,
+            patrol_end=sead_search[1],
+            split=split,
+            refuel=refuel,
+            nav_from=builder.nav_path(
+                split.position,
+                self.flight.arrival.position,
+                self.doctrine.ingress_altitude,
+            ),
+            arrival=builder.land(self.flight.arrival),
+            divert=builder.divert(self.flight.divert),
+            bullseye=builder.bullseye(),
+        )

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -19,7 +19,9 @@ from dcs.task import (
     Refueling,
     RunwayAttack,
     Transport,
+    SEAD,
 )
+from dcs.planes import F_14A, F_14A_135_GR, F_14B
 from dcs.unitgroup import FlyingGroup
 
 from game.ato import Flight, FlightType
@@ -163,7 +165,10 @@ class AircraftBehavior:
         # CAS is able to perform all the same tasks as SEAD using a superset of the
         # available aircraft, and F-14s are not able to be SEAD despite having TALDs.
         # https://forums.eagle.ru/topic/272112-cannot-assign-f-14-to-sead/
-        group.task = CAS.name
+        if flight.unit_type in [F_14A, F_14B, F_14A_135_GR]:
+            group.task = CAS.name
+        else:
+            group.task = SEAD.name
         self.configure_behavior(
             flight,
             group,
@@ -271,7 +276,10 @@ class AircraftBehavior:
         # CAS is able to perform all the same tasks as SEAD using a superset of the
         # available aircraft, and F-14s are not able to be SEAD despite having TALDs.
         # https://forums.eagle.ru/topic/272112-cannot-assign-f-14-to-sead/
-        group.task = CAS.name
+        if flight.unit_type in [F_14A, F_14B, F_14A_135_GR]:
+            group.task = CAS.name
+        else:
+            group.task = SEAD.name
         self.configure_behavior(
             flight,
             group,

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -1,7 +1,7 @@
 import logging
 
 from dcs.point import MovingPoint
-from dcs.task import AttackGroup, OptECMUsing, WeaponType
+from dcs.task import EngageGroup, OptECMUsing, WeaponType
 
 from game.theater import TheaterGroundObject
 from .pydcswaypointbuilder import PydcsWaypointBuilder
@@ -27,12 +27,8 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
                 )
                 continue
 
-            task = AttackGroup(miz_group.id, weapon_type=WeaponType.Guided)
-            task.params["expend"] = "All"
-            task.params["attackQtyLimit"] = False
-            task.params["directionEnabled"] = False
-            task.params["altitudeEnabled"] = False
-            task.params["groupAttack"] = True
+            task = EngageGroup(miz_group.id)
+            task.params["weaponType"] = WeaponType.Guided.value
             waypoint.tasks.append(task)
 
         # Preemptively use ECM to better avoid getting swatted.


### PR DESCRIPTION
I tried to solve the issue that AI is to dumb to do the SEAD missions well when using the skynet plugin. I believe i found the issue of the AI not able to fire harms and just suicide diving to kill the Radar with guns: Change the Waypoint task from AttackGroup to Search and Engage Group as mentioned over here: https://forum.dcs.world/topic/270766-sead-ai-task-problem/?do=findComment&comment=4655599

In addition to make the AI really "search" and hunt the Radar even if skynet is going offline and online again (or maybe doing some other fancy magic stuff) i also added a Racetrack search inside the Threat Range of the targeted SAM. This will ensure that the SAM group will search 3 mins before leaving and going home again. I set it to 3 mins because this will alert barcap flights in the air and the SEAD group should get out of the AO real quick.

![grafik](https://user-images.githubusercontent.com/6678803/160464193-f63c6775-1001-480d-ac5d-02e9eae23ff1.png)

![grafik](https://user-images.githubusercontent.com/6678803/160462537-69cc86ba-8de0-44b6-8f47-47f3cf381a44.png)

I tested with and without Skynet and had really really good effects. Tried a lot with Late Activation and triggered stuff to stress the SEAD package but it works perfectly.

Changed:
- change AttackGroup task to Search and Engage Group
- Add SEAD Search as racetrack with 3 min duration so that late radar activation (skynet for example) will be recognized correctly
- Changed the Flighttype to SEAD if not using F-14. (THis is just for the visuals.. it does not have any affect based on my testing)

Draft PR as this is mainly for discussion :)
