### PR TITLE
save mission description and then show it on take off window

### DIFF
--- a/gen/briefinggen.py
+++ b/gen/briefinggen.py
@@ -169,6 +169,8 @@ class BriefingGenerator(MissionInfoGenerator):
         self._generate_frontline_info()
         self.generate_allied_flights_by_departure()
         self.mission.set_description_text(self.template.render(vars(self)))
+        with open("./mission_description_text.txt", "w") as f:
+            f.write(self.mission.description_text())
         self.mission.add_picture_blue(
             os.path.abspath("./resources/ui/splash_screen.png")
         )

--- a/qt_ui/windows/QWaitingForMissionResultWindow.py
+++ b/qt_ui/windows/QWaitingForMissionResultWindow.py
@@ -104,6 +104,11 @@ class QWaitingForMissionResultWindow(QDialog):
         self.instructions_text.setOpenExternalLinks(True)
         self.gridLayout.addWidget(self.instructions_text, 1, 0)
 
+        self.briefing_text = QTextBrowser()
+        with open("./mission_description_text.txt", "r") as briefing_file:
+            self.briefing_text.setText(briefing_file.read())
+        self.gridLayout.addWidget(self.briefing_text, 1, 1)
+
         progress = QLabel("")
         progress.setAlignment(QtCore.Qt.AlignCenter)
         progress_bar = QMovie("./resources/ui/loader.gif")
@@ -119,7 +124,7 @@ class QWaitingForMissionResultWindow(QDialog):
         self.cancel = QPushButton("Abort mission")
         self.cancel.clicked.connect(self.close)
         self.actions_layout.addWidget(self.cancel)
-        self.gridLayout.addWidget(self.actions, 2, 0)
+        self.gridLayout.addWidget(self.actions, 2, 0, 1, 3)
 
         self.actions2 = QGroupBox("Actions :")
         self.actions2_layout = QHBoxLayout()


### PR DESCRIPTION
really just a proof of concept can try to make it prettier if this actually wants to be merged, prob ideally make it a bit wider and taller, but then the splash picture thing gets all messed up, guess the OG size of window was based on that picture 🤷‍♂️ 

Also, not 100% sure if this is the 'right' way to go about it, it was suggested to save or convert as HTML, but simply saving the description text as HTML removed all the line breaks, so instead, now saving as .txt and then just setText for the QTextBrowser

also considered instead of side by side thing, maybe making the separate QTextBrowser's tabbed - so view instructions or briefing but not both at the same time, idk how hard that is tho

![image](https://user-images.githubusercontent.com/47610393/160529302-e4bf7f27-1240-44bb-88aa-6a8cfef0ef14.png)
