### PR TITLE
Adopt SEAD tasking for Skynet (AttackGroup to Search and Engage Group)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Saves from 5.x are not compatible with 6.0.
 
 * **[Mission Generation]** Fixed SA-13 incorrectly created as SA-8 Loading Unit which will not be spawned in the generated mission.
 * **[Mission Generation]** Fixed an issue which generated the helipads at FARPs incorrectly and placed the helicopters within each other.
+* **[Mission Generation]** Fixed an issue with SEAD missions flown by the AI when using the Skynet Plugin and anti-radiation missiles (ARM). The AI now correctly engages the SAM when it comes alive instead of diving into it.
 
 # 5.2.0
 

--- a/game/ato/package.py
+++ b/game/ato/package.py
@@ -168,6 +168,7 @@ class Package:
             FlightType.FERRY,
             FlightType.REFUELING,
             FlightType.SWEEP,
+            FlightType.SEAD_ESCORT,
             FlightType.ESCORT,
         ]
         for task in tasks_by_priority:

--- a/game/data/weapons.py
+++ b/game/data/weapons.py
@@ -94,6 +94,7 @@ class Weapon:
 
 @unique
 class WeaponType(Enum):
+    ARM = "ARM"
     LGB = "LGB"
     TGP = "TGP"
     UNKNOWN = "unknown"

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -1,7 +1,8 @@
 import logging
 
 from dcs.point import MovingPoint
-from dcs.task import AttackGroup, OptECMUsing, WeaponType
+from dcs.task import AttackGroup, EngageGroup, OptECMUsing, WeaponType as DcsWeaponType
+from game.data.weapons import WeaponType
 
 from game.theater import TheaterGroundObject
 from .pydcswaypointbuilder import PydcsWaypointBuilder
@@ -27,13 +28,26 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
                 )
                 continue
 
-            task = AttackGroup(miz_group.id, weapon_type=WeaponType.Guided)
-            task.params["expend"] = "All"
-            task.params["attackQtyLimit"] = False
-            task.params["directionEnabled"] = False
-            task.params["altitudeEnabled"] = False
-            task.params["groupAttack"] = True
-            waypoint.tasks.append(task)
+            if self.flight.loadout.has_weapon_of_type(WeaponType.ARM):
+                # Special handling for ARM Weapon types:
+                # The SEAD flight will Search for the targeted group and then engage it
+                # if it is found only. This will prevent AI from having huge problems
+                # when skynet is enabled and the Radar is not emitting. They dive
+                # into the SAM instead of waiting for it to come alive
+                engage_task = EngageGroup(miz_group.id)
+                engage_task.params["weaponType"] = DcsWeaponType.Guided.value
+                waypoint.tasks.append(engage_task)
+            else:
+                # All non ARM types like Decoys will use the normal AttackGroup Task
+                attack_task = AttackGroup(
+                    miz_group.id, weapon_type=DcsWeaponType.Guided
+                )
+                attack_task.params["expend"] = "All"
+                attack_task.params["attackQtyLimit"] = False
+                attack_task.params["directionEnabled"] = False
+                attack_task.params["altitudeEnabled"] = False
+                attack_task.params["groupAttack"] = True
+                waypoint.tasks.append(attack_task)
 
         # Preemptively use ECM to better avoid getting swatted.
         ecm_option = OptECMUsing(value=OptECMUsing.Values.UseIfDetectedLockByRadar)

--- a/resources/weapons/standoff/AGM-45A.yaml
+++ b/resources/weapons/standoff/AGM-45A.yaml
@@ -1,0 +1,4 @@
+name: AGM-45A Shrike ARM
+type: ARM
+clsids:
+  - "{AGM_45A}"

--- a/resources/weapons/standoff/AGM-45B.yaml
+++ b/resources/weapons/standoff/AGM-45B.yaml
@@ -1,0 +1,4 @@
+name: AGM-45B Shrike ARM (Imp)
+type: ARM
+clsids:
+  - "{3E6B632D-65EB-44D2-9501-1C2D04515404}"

--- a/resources/weapons/standoff/AGM-88C.yaml
+++ b/resources/weapons/standoff/AGM-88C.yaml
@@ -1,0 +1,8 @@
+name: AGM-88C HARM - High Speed Anti-Radiation Missile
+type: ARM
+# https://www.af.mil/About-Us/Fact-Sheets/Display/Article/104574/agm-88-harm/
+# 1984 is the date for the A variant but as we do not have that one we use it for C
+year: 1984
+clsids:
+  - "{B06DD79A-F21E-4EB9-BD9D-AB3844618C9C}"
+  - "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}"

--- a/resources/weapons/standoff/ALARM-2X.yaml
+++ b/resources/weapons/standoff/ALARM-2X.yaml
@@ -1,0 +1,4 @@
+name: 2 x ALARM
+type: ARM
+clsids:
+  - "{07BE2D19-0E48-4B0B-91DA-5F6C8F9E3C75}"

--- a/resources/weapons/standoff/ALARM.yaml
+++ b/resources/weapons/standoff/ALARM.yaml
@@ -1,0 +1,4 @@
+name: ALARM
+type: ARM
+clsids:
+  - "{E6747967-B1F0-4C77-977B-AB2E6EB0C102}"

--- a/resources/weapons/standoff/Kh-25MPU.yaml
+++ b/resources/weapons/standoff/Kh-25MPU.yaml
@@ -1,0 +1,6 @@
+name: Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr
+type: ARM
+clsids:
+  - "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}"
+  - "{752AF1D2-EBCC-4bd7-A1E7-2357F5601C70}"
+  - "{X-25MPU}"

--- a/resources/weapons/standoff/Kh-31P.yaml
+++ b/resources/weapons/standoff/Kh-31P.yaml
@@ -1,0 +1,6 @@
+name: Kh-31P (AS-17 Krypton) - 600kg, ARM, IN & Pas Rdr
+type: ARM
+clsids:
+  - "{D8F2C90B-887B-4B9E-9FE2-996BC9E9AF03}"
+  - "{D8F2C90B-887B-4B9E-9FE2-996BC9E9AF0A}"
+  - "{X-31P}"

--- a/resources/weapons/standoff/Kh-58U.yaml
+++ b/resources/weapons/standoff/Kh-58U.yaml
@@ -1,0 +1,5 @@
+name: Kh-58U (AS-11 Kilter) - 640kg, ARM, IN & Pas Rdr
+type: ARM
+clsids:
+  - "{FE382A68-8620-4AC0-BDF5-709BFE3977D7}"
+  - "{B5CA9846-776E-4230-B4FD-8BCC9BFB1676}"

--- a/resources/weapons/standoff/LD-10-2X.yaml
+++ b/resources/weapons/standoff/LD-10-2X.yaml
@@ -1,0 +1,5 @@
+name: LD-10 x 2
+type: ARM
+clsids:
+  - "DIS_LD-10_DUAL_L"
+  - "DIS_LD-10_DUAL_R"

--- a/resources/weapons/standoff/LD-10.yaml
+++ b/resources/weapons/standoff/LD-10.yaml
@@ -1,0 +1,4 @@
+name: LD-10
+type: ARM
+clsids:
+  - "DIS_LD-10"

--- a/resources/weapons/standoff/MAR-1.yaml
+++ b/resources/weapons/standoff/MAR-1.yaml
@@ -1,0 +1,4 @@
+name: MAR-1 High Speed Anti-Radiation Missile
+type: ARM
+clsids:
+  - "{JAS39_MAR-1}"


### PR DESCRIPTION
As discussed in the recent PR #2136 and on discord the AI is having huge problems with the SEAD tasking against SAM Sites when skynet is enabled. This is due to the fact that the radar does not emit until the flight is in actual range of the sam system.
AI can not handle this and starts just diving into the sam. It does not use the HARMs even if the radar comes alive - they will dive and just do nothing (except dying).

This Change adopts the Tasking so that Search and Engage Group is used instead AttackGroup with the one exception for F-14s. This Exception allows them to fire Decoys even if the radar is offline.

With the search and engage tasking the AI can fire the HARMs properly and do their task.

SEAD Escort flights have a similar tasking but they use Search and Engage along the route starting from the Join WP.

Tested with and without skynet with F-16s using HARMs and F-14B using ADM-141A

Also fixes a small issue which created some warnings in the logs