### PR TITLE
Logical Strike Targeting

### DIFF
--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 from dcs.planes import B_17G, B_52H, Tu_22M3
 from dcs.point import MovingPoint
@@ -34,7 +35,47 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
         waypoint.tasks.append(bombing)
 
     def add_strike_tasks(self, waypoint: MovingPoint) -> None:
-        for target in self.waypoint.targets:
+
+        # logic to try and spread out the targets within a strike target
+        # for example, if there is one strike ahead of this flights strike, then shift it's bombing targets by two (arbitrary number, ideally it'd be based on number of planes/bombs per flight and knowing how many bombs per target the user wants)
+        strike_flights_ahead = 0
+        waypoint_index = [
+            i
+            for i, w in enumerate(self.flight.points)
+            if w.x == self.waypoint.x and w.y == self.waypoint.y
+        ][0]
+        logging.debug(f"waypoint index: {waypoint_index}")
+        for flight in self.package.flights:
+
+            # found a flight with the same target (aka ingress) waypoint
+            if (
+                flight.points[waypoint_index].x == self.waypoint.x
+                and flight.points[waypoint_index].y == self.waypoint.y
+            ):
+                strike_flights_ahead += 1
+
+            # found self's flight
+            if self.flight == flight:
+                strike_flights_ahead -= 1
+                break
+
+        logging.debug(f"strike_flights_ahead: {strike_flights_ahead}")
+        logging.debug(f"targets: {len(self.waypoint.targets)}")
+
+        if strike_flights_ahead > 0:
+            # ex. shifts [0, 1, 2] to [2, 0, 1]
+            start_index = strike_flights_ahead * 2
+            targets = [self.waypoint.targets[start_index]]
+            targets += self.waypoint.targets[start_index + 1 :]
+            targets += self.waypoint.targets[:start_index]
+            logging.info(
+                f"Shifting strike targets to {[self.waypoint.targets.index(t) + 1 for t in targets]}"
+            )
+        else:
+            # not shifting if no strike flights counted ahead of this flight
+            targets = [t for t in self.waypoint.targets]
+
+        for target in targets:
             bombing = Bombing(target.position, weapon_type=WeaponType.Auto)
             # If there is only one target, drop all ordnance in one pass.
             if len(self.waypoint.targets) == 1:

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -39,6 +39,7 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
         # logic to try and spread out the targets within a strike target
         # for example, if there is one strike ahead of this flights strike, then shift it's bombing targets by two (arbitrary number, ideally it'd be based on number of planes/bombs per flight and knowing how many bombs per target the user wants)
         strike_flights_ahead = 0
+        total_stike_flights = 0
         waypoint_index = [
             i
             for i, w in enumerate(self.flight.points)
@@ -52,19 +53,19 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
                 flight.points[waypoint_index].x == self.waypoint.x
                 and flight.points[waypoint_index].y == self.waypoint.y
             ):
-                strike_flights_ahead += 1
+                total_stike_flights += 1
 
             # found self's flight
             if self.flight == flight:
-                strike_flights_ahead -= 1
-                break
+                strike_flights_ahead = total_stike_flights - 1
 
         logging.debug(f"strike_flights_ahead: {strike_flights_ahead}")
         logging.debug(f"targets: {len(self.waypoint.targets)}")
 
+        shift_amount = int(len(self.waypoint.targets) / total_stike_flights)
         if strike_flights_ahead > 0:
             # ex. shifts [0, 1, 2] to [2, 0, 1]
-            start_index = strike_flights_ahead * 2
+            start_index = strike_flights_ahead * shift_amount
             targets = [self.waypoint.targets[start_index]]
             targets += self.waypoint.targets[start_index + 1 :]
             targets += self.waypoint.targets[:start_index]


### PR DESCRIPTION
This basically is trying to spread out the strike targets per package per strike flight - avoiding stacking all bombs onto the same targets. If we can say, Flight one, take out 1 and 2, then Flight 2, take out 3 and 4, that's ideal. Atm, given the lack of armament information/decoding of pylons and desired bombs per target, we simply figure out how many strike flights are in the package and shift the bombing targets accordingly 

Right now, it's just shifting 2 targets per flight, so the first strike flight would go for [1, 2, 3, 4], the second strike flight would go for [3, 4, 5, 1] if there were 5 total targets, in that order

If this gets submitted, I can submit a pull request for 5.2.0 too, if it's worth it - like if there's going to be another release before 6.0.0.

https://github.com/dcs-liberation/dcs_liberation/issues/2143#issue-1189333371


Pull requests should be made against the `develop` branch. Any backports
necessary will be handled by the development team.

New features and bug fixes are usually worth mentioning in the changelog.
Exceptions are fixes for bugs that never shipped (were only present in a canary
build), and changes with no intended user observable behavior, such as a
refactor. If you're comfortable writing the note yourself, add it to
`changelog.md` in the root of the project in the section for the upcoming
release.
