### PR TITLE
Change DEAD and SEAD AttackGroup task to expend=auto

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed SA-13 incorrectly created as SA-8 Loading Unit which will not be spawned in the generated mission.
 * **[Mission Generation]** Fixed an issue which generated the helipads at FARPs incorrectly and placed the helicopters within each other.
 * **[Mission Generation]** Fixed an issue with SEAD missions flown by the AI when using the Skynet Plugin and anti-radiation missiles (ARM). The AI now correctly engages the SAM when it comes alive instead of diving into it.
+* **[Mission Generation]** Fixed an issue where SEAD and DEAD flights fired all missiles / bombs against a single unit in a group instead of targeting the whole group
 
 # 5.2.0
 

--- a/game/missiongenerator/aircraft/waypoints/deadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/deadingress.py
@@ -28,7 +28,7 @@ class DeadIngressBuilder(PydcsWaypointBuilder):
                 continue
 
             task = AttackGroup(miz_group.id, weapon_type=WeaponType.Auto)
-            task.params["expend"] = "All"
+            task.params["expend"] = "Auto"
             task.params["attackQtyLimit"] = False
             task.params["directionEnabled"] = False
             task.params["altitudeEnabled"] = False

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -42,7 +42,7 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
                 attack_task = AttackGroup(
                     miz_group.id, weapon_type=DcsWeaponType.Guided
                 )
-                attack_task.params["expend"] = "All"
+                attack_task.params["expend"] = "Auto"
                 attack_task.params["attackQtyLimit"] = False
                 attack_task.params["directionEnabled"] = False
                 attack_task.params["altitudeEnabled"] = False


### PR DESCRIPTION
With All the AI fires all available missiles / bombs and so on against one single target instead of attacking the whole group. If we want to use all ammunition against a single target we should use the AttackUnit instead.

solves #2152 