### PR TITLE
Allow campaign designer to set default economy values

### DIFF
--- a/game/campaignloader/campaign.py
+++ b/game/campaignloader/campaign.py
@@ -31,6 +31,7 @@ PERF_FRIENDLY = 0
 PERF_MEDIUM = 1
 PERF_HARD = 2
 PERF_NASA = 3
+DEFAULT_BUDGET = 2000
 
 
 @dataclass(frozen=True)
@@ -48,6 +49,12 @@ class Campaign:
     recommended_player_faction: str
     recommended_enemy_faction: str
     recommended_start_date: Optional[datetime.date]
+
+    recommended_player_money: int
+    recommended_enemy_money: int
+    recommended_player_income_multiplier: float
+    recommended_enemy_income_multiplier: float
+
     performance: int
     data: Dict[str, Any]
     path: Path
@@ -95,6 +102,10 @@ class Campaign:
             data.get("recommended_player_faction", "USA 2005"),
             data.get("recommended_enemy_faction", "Russia 1990"),
             start_date,
+            data.get("recommended_player_money", DEFAULT_BUDGET),
+            data.get("recommended_enemy_money", DEFAULT_BUDGET),
+            data.get("recommended_player_income_multiplier", 1.0),
+            data.get("recommended_enemy_income_multiplier", 1.0),
             data.get("performance", 0),
             data,
             path,

--- a/game/version.py
+++ b/game/version.py
@@ -135,4 +135,11 @@ VERSION = _build_version_string()
 #:   This removes the randomization of the orientation from the generation.
 #:   Most campaigns will not need any updates and will work out of the box.
 #:
-CAMPAIGN_FORMAT_VERSION = (10, 0)
+#: Version 10.1
+#: * Campaign designers can now define the recommended economy settings:
+#:   `recommended_player_money: 2000`.
+#:   `recommended_enemy_money: 2000`.
+#:   `recommended_player_income_multiplier: 1.0`.
+#:   `recommended_enemy_income_multiplier: 1.0`.
+#:
+CAMPAIGN_FORMAT_VERSION = (10, 1)

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -14,7 +14,7 @@ from PySide2.QtWidgets import QApplication, QCheckBox, QSplashScreen
 from dcs.payloads import PayloadDirectories
 
 from game import Game, VERSION, persistency
-from game.campaignloader.campaign import Campaign
+from game.campaignloader.campaign import Campaign, DEFAULT_BUDGET
 from game.data.weapons import Pylon, Weapon, WeaponGroup
 from game.dcs.aircrafttype import AircraftType
 from game.factions import FACTIONS
@@ -32,7 +32,6 @@ from qt_ui import (
 )
 from qt_ui.windows.GameUpdateSignal import GameUpdateSignal
 from qt_ui.windows.QLiberationWindow import QLiberationWindow
-from qt_ui.windows.newgame.QNewGameWizard import DEFAULT_BUDGET
 from qt_ui.windows.preferences.QLiberationFirstStartWindow import (
     QLiberationFirstStartWindow,
 )

--- a/qt_ui/widgets/spinsliders.py
+++ b/qt_ui/widgets/spinsliders.py
@@ -17,7 +17,7 @@ class FloatSpinSlider(QHBoxLayout):
         slider = QSlider(Qt.Horizontal)
         slider.setMinimum(int(minimum * divisor))
         slider.setMaximum(int(maximum * divisor))
-        slider.setValue(initial)
+        slider.setValue(int(initial * divisor))
         self.spinner = FloatSpinner(divisor, minimum, maximum, initial)
         slider.valueChanged.connect(lambda x: self.spinner.setValue(x))
         self.spinner.valueChanged.connect(lambda x: slider.setValue(x))


### PR DESCRIPTION
default starting money and income multiplier can be set in campaign.yaml

bumps campaign Version to 10.1

solves #2155 
