### PR TITLE
Improve Ingress Waypoint Attack tasking (SEAD, DEAD, BAI, Strike)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed SA-13 incorrectly created as SA-8 Loading Unit which will not be spawned in the generated mission.
 * **[Mission Generation]** Fixed an issue which generated the helipads at FARPs incorrectly and placed the helicopters within each other.
 * **[Mission Generation]** Fixed an issue with SEAD missions flown by the AI when using the Skynet Plugin and anti-radiation missiles (ARM). The AI now correctly engages the SAM when it comes alive instead of diving into it.
+* **[Mission Generation]** Fixed an issue where SEAD/DEAD/BAI flights fired all missiles / bombs against a single unit in a group instead of targeting the whole group
 
 # 5.2.0
 

--- a/game/missiongenerator/aircraft/waypoints/baiingress.py
+++ b/game/missiongenerator/aircraft/waypoints/baiingress.py
@@ -36,10 +36,6 @@ class BaiIngressBuilder(PydcsWaypointBuilder):
                 continue
 
             task = AttackGroup(miz_group.id, weapon_type=WeaponType.Auto)
-            task.params["attackQtyLimit"] = False
-            task.params["directionEnabled"] = False
-            task.params["altitudeEnabled"] = False
-            task.params["groupAttack"] = True
             waypoint.tasks.append(task)
 
         waypoint.tasks.append(OptFormation.trail_open())

--- a/game/missiongenerator/aircraft/waypoints/deadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/deadingress.py
@@ -27,12 +27,9 @@ class DeadIngressBuilder(PydcsWaypointBuilder):
                 )
                 continue
 
-            task = AttackGroup(miz_group.id, weapon_type=WeaponType.Auto)
-            task.params["expend"] = "All"
-            task.params["attackQtyLimit"] = False
-            task.params["directionEnabled"] = False
-            task.params["altitudeEnabled"] = False
-            task.params["groupAttack"] = True
+            task = AttackGroup(
+                miz_group.id, weapon_type=WeaponType.Auto, group_attack=True
+            )
             waypoint.tasks.append(task)
 
         # Preemptively use ECM to better avoid getting swatted.

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -40,13 +40,8 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
             else:
                 # All non ARM types like Decoys will use the normal AttackGroup Task
                 attack_task = AttackGroup(
-                    miz_group.id, weapon_type=DcsWeaponType.Guided
+                    miz_group.id, weapon_type=DcsWeaponType.Guided, group_attack=True
                 )
-                attack_task.params["expend"] = "All"
-                attack_task.params["attackQtyLimit"] = False
-                attack_task.params["directionEnabled"] = False
-                attack_task.params["altitudeEnabled"] = False
-                attack_task.params["groupAttack"] = True
                 waypoint.tasks.append(attack_task)
 
         # Preemptively use ECM to better avoid getting swatted.

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -1,7 +1,13 @@
 import logging
 
 from dcs.point import MovingPoint
-from dcs.task import AttackGroup, EngageGroup, OptECMUsing, WeaponType as DcsWeaponType
+from dcs.task import (
+    AttackGroup,
+    EngageGroup,
+    Expend,
+    OptECMUsing,
+    WeaponType as DcsWeaponType,
+)
 from game.data.weapons import WeaponType
 
 from game.theater import TheaterGroundObject
@@ -36,11 +42,16 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
                 # into the SAM instead of waiting for it to come alive
                 engage_task = EngageGroup(miz_group.id)
                 engage_task.params["weaponType"] = DcsWeaponType.Guided.value
+                # Ensure that they fire all ammunition in one attack pass
+                engage_task.params["expend"] = Expend.All.value
                 waypoint.tasks.append(engage_task)
             else:
                 # All non ARM types like Decoys will use the normal AttackGroup Task
                 attack_task = AttackGroup(
-                    miz_group.id, weapon_type=DcsWeaponType.Guided, group_attack=True
+                    miz_group.id,
+                    weapon_type=DcsWeaponType.Guided,
+                    group_attack=True,
+                    expend=Expend.All,
                 )
                 waypoint.tasks.append(attack_task)
 

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -2,7 +2,7 @@ import copy
 
 from dcs.planes import B_17G, B_52H, Tu_22M3
 from dcs.point import MovingPoint
-from dcs.task import Bombing, OptFormation, WeaponType
+from dcs.task import Bombing, OptFormation, WeaponType, Expend
 
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
@@ -25,21 +25,19 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
         for target in targets[1:]:
             center += target.position
         center /= len(targets)
-        bombing = Bombing(center, weapon_type=WeaponType.Bombs)
-        bombing.params["expend"] = "All"
-        bombing.params["attackQtyLimit"] = False
-        bombing.params["directionEnabled"] = False
-        bombing.params["altitudeEnabled"] = False
-        bombing.params["groupAttack"] = True
+        bombing = Bombing(
+            center, weapon_type=WeaponType.Bombs, expend=Expend.All, group_attack=True
+        )
         waypoint.tasks.append(bombing)
 
     def add_strike_tasks(self, waypoint: MovingPoint) -> None:
         for target in self.waypoint.targets:
-            bombing = Bombing(target.position, weapon_type=WeaponType.Auto)
+            bombing = Bombing(
+                target.position, weapon_type=WeaponType.Auto, group_attack=True
+            )
             # If there is only one target, drop all ordnance in one pass.
             if len(self.waypoint.targets) == 1:
-                bombing.params["expend"] = "All"
-            bombing.params["groupAttack"] = True
+                bombing.params["expend"] = Expend.All.value
             waypoint.tasks.append(bombing)
 
             # Register special waypoints

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pluggy==1.0.0
 pre-commit==2.17.0
 py==1.11.0
 pydantic==1.9.0
--e git+https://github.com/pydcs/dcs@fac1bd084f22150acfde3bff220f8e69487048d1#egg=pydcs
+-e git+https://github.com/pydcs/dcs@04248fa93573029ee76db6c30f62140dfa4a58c8#egg=pydcs
 pyinstaller==4.9
 pyinstaller-hooks-contrib==2022.1
 pyparsing==3.0.7


### PR DESCRIPTION
#2152 

 Improve Ingress WP attack tasking and update pydcs

- Updated the Attack Tasking of SEAD, DEAD, Strike and BAI to match the pydcs changes
- Changed DEAD, BAI and SEAD AttackGroup task to expend=auto. This solves an issue where the AI uses all Ammo on one single target as we defined the expend param to All instead of Auto which is used by default.