### PR TITLE
Add modulation to RadioFrequency

### DIFF
--- a/game/airfields.py
+++ b/game/airfields.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar, Dict, Optional, TYPE_CHECKING, Tuple
 
 import yaml
 from dcs.terrain import Airport
+from dcs.task import Modulation
 
 from game.radio.radios import RadioFrequency
 from game.radio.tacan import TacanChannel
@@ -33,10 +34,10 @@ class AtcData:
         if atc_data is None:
             return None
         return AtcData(
-            RadioFrequency.parse(atc_data["hf"]),
-            RadioFrequency.parse(atc_data["vhf_low"]),
-            RadioFrequency.parse(atc_data["vhf_high"]),
-            RadioFrequency.parse(atc_data["uhf"]),
+            RadioFrequency.parse(atc_data["hf"], Modulation.FM),
+            RadioFrequency.parse(atc_data["vhf_low"], Modulation.FM),
+            RadioFrequency.parse(atc_data["vhf_high"], Modulation.AM),
+            RadioFrequency.parse(atc_data["uhf"], Modulation.AM),
         )
 
 
@@ -108,7 +109,10 @@ class AirfieldData:
 
         vor = None
         if (vor_data := data.get("vor")) is not None:
-            vor = (vor_data["callsign"], RadioFrequency.parse(vor_data["frequency"]))
+            vor = (
+                vor_data["callsign"],
+                RadioFrequency.parse(vor_data["frequency"], Modulation.FM),
+            )
 
         rsbn = None
         if (rsbn_data := data.get("rsbn")) is not None:
@@ -122,7 +126,7 @@ class AirfieldData:
             if (ils_data := runway_data.get("ils")) is not None:
                 ils[name] = (
                     ils_data["callsign"],
-                    RadioFrequency.parse(ils_data["frequency"]),
+                    RadioFrequency.parse(ils_data["frequency"], Modulation.FM),
                 )
 
             if (prmg_data := runway_data.get("prmg")) is not None:
@@ -131,13 +135,13 @@ class AirfieldData:
             if (outer_ndb_data := runway_data.get("outer_ndb")) is not None:
                 outer_ndb[name] = (
                     outer_ndb_data["callsign"],
-                    RadioFrequency.parse(outer_ndb_data["frequency"]),
+                    RadioFrequency.parse(outer_ndb_data["frequency"], Modulation.AM),
                 )
 
             if (inner_ndb_data := runway_data.get("inner_ndb")) is not None:
                 inner_ndb[name] = (
                     inner_ndb_data["callsign"],
-                    RadioFrequency.parse(inner_ndb_data["frequency"]),
+                    RadioFrequency.parse(inner_ndb_data["frequency"], Modulation.AM),
                 )
 
         return AirfieldData(

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -165,7 +165,11 @@ class FlotGenerator:
                 maintask=AFAC,
             )
             jtac.points[0].tasks.append(
-                FAC(callsign=len(self.air_support.jtacs) + 1, frequency=int(freq.mhz))
+                FAC(
+                    callsign=len(self.air_support.jtacs) + 1,
+                    frequency=int(freq.mhz),
+                    modulation=freq.modulation,
+                )
             )
             jtac.points[0].tasks.append(SetInvisibleCommand(True))
             jtac.points[0].tasks.append(SetImmortalCommand(True))


### PR DESCRIPTION
To show the Players the Frequency modulation used i added the Modulation to the RadioFrequency and to RadioRange. This is more a preparation for future enhancements where we could use VHF FM for specific things like inter-flight or JTAC. But for now most of the communication is done in AM as it's the default also used by DCS.
We currently do not force the modulation in the code anywhere other than JTAC. Pydcs defaults to AM (modulation=0)

- This adds the information about the modulation of the RadioFrequency.
- Updated all Radios with the capabale modulation
- Show Modulation on Kneeboard
- Defaulting to AM Modulation as this is also the default used by pydcs.
- Force AM Modulation for JTAC tasking

also solves #1847 as AM Modulation is now used for the JTAC Task as we use alloc_uhf which defaults to the UHF Band with AM Modulation. We now give the freq.modulation as parameter for the FAC task


![page01](https://user-images.githubusercontent.com/6678803/162703774-93bb5056-bb1b-412e-bf39-e15c562116e6.png)
![page00](https://user-images.githubusercontent.com/6678803/162703777-ca77828e-5740-486e-b102-14dca60ccf7f.png)

