### PR TITLE
Credits attribution (About... screen)

### DIFF
--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -391,6 +391,53 @@ class QLiberationWindow(QMainWindow):
             self.enable_game_actions(self.game is not None)
 
     def showAboutDialog(self):
+        contributors = [
+            "shdwp",
+            "Khopa",
+            "ColonelPanic",
+            "RndName",
+            "Roach",
+            "Malakhit",
+            "Wrycu",
+            "calvinmorrow",
+            "JohanAberg",
+            "Deus",
+            "SiKruger",
+            "Mustang-25",
+            "bgreman",
+            "magwo",
+            "SnappyComebacks",
+            "kavinsky",
+            "Schneefl0cke",
+            "pbzweihander",
+            "Raskil",
+            "nosv1",
+            "jake-lewis",
+            "teamMOYA",
+            "benedikt-wegmann",
+            "movq",
+            "bbirchnz",
+            "eddiwood",
+            "root0fall",
+            "calvinmorrow",
+            "UKayeF",
+            "Captain Cody",
+            "steveveepee",
+            "pedromagueija",
+            "parithon",
+            "TheCandianVendingMachine",
+            "bwRavencl",
+            "davidp57",
+            "Plob",
+            "Hawkmoon",
+            "alrik11es",
+            "Starfire13",
+            "Hornet2041/Lion",
+            "SgtFuzzle17",
+            "Doc_of_Mur",
+            "NickJZX",
+            "Sith1144",
+        ]
         text = (
             "<h3>DCS Liberation "
             + VERSION
@@ -399,7 +446,7 @@ class QLiberationWindow(QMainWindow):
             + "<h4>Authors</h4>"
             + "<p>DCS Liberation was originally developed by <b>shdwp</b>, DCS Liberation 2.0 is a partial rewrite based on this work by <b>Khopa</b>."
             "<h4>Contributors</h4>"
-            + "shdwp, Khopa, ColonelPanic, Roach, Malakhit, Wrycu, calvinmorrow, JohanAberg, Deus, SiKruger, Mustang-25, root0fall, Captain Cody, steveveepee, pedromagueija, parithon, bwRavencl, davidp57, Plob, Hawkmoon"
+            + ", ".join(contributors)
             + "<h4>Special Thanks  :</h4>"
             "<b>rp-</b> <i>for the pydcs framework</i><br/>"
             "<b>Grimes (mrSkortch)</b> & <b>Speed</b> <i>for the MIST framework</i><br/>"


### PR DESCRIPTION
Added some attribution to campaign designers, testers and other helpful members of the community in the Liberation credits. Also added some contributors from the GitHub commit history. Any omissions are not intentional. If I have missed anybody, feel free to add missing contributors (I haven't been part of the project long enough to know everybody and I might have otherwise missed someone by mistake).