### PR TITLE
Fix suicide SEAD flights

### DIFF
--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -287,7 +287,15 @@ class WaypointBuilder:
         return self._target_area(f"STRIKE {target.name}", target)
 
     def sead_area(self, target: MissionTarget) -> FlightWaypoint:
-        return self._target_area(f"SEAD on {target.name}", target, flyover=True)
+        # Set flyover with ingress altitude to allow the flight to search and engage
+        # the target group at the ingress alt without suicide dive
+        return self._target_area(
+            f"SEAD on {target.name}",
+            target,
+            flyover=True,
+            altitude=self.doctrine.ingress_altitude,
+            alt_type="BARO",
+        )
 
     def dead_area(self, target: MissionTarget) -> FlightWaypoint:
         return self._target_area(f"DEAD on {target.name}", target)
@@ -297,14 +305,18 @@ class WaypointBuilder:
 
     @staticmethod
     def _target_area(
-        name: str, location: MissionTarget, flyover: bool = False
+        name: str,
+        location: MissionTarget,
+        flyover: bool = False,
+        altitude: Distance = meters(0),
+        alt_type: AltitudeReference = "RADIO",
     ) -> FlightWaypoint:
         waypoint = FlightWaypoint(
             name,
             FlightWaypointType.TARGET_GROUP_LOC,
             location.position,
-            meters(0),
-            "RADIO",
+            altitude,
+            alt_type,
             description=name,
             pretty_name=name,
         )

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -50,6 +50,10 @@ class PydcsWaypointBuilder:
             # It seems we need to leave waypoint.type exactly as it is even
             # though it's set to "Turning Point". If I set this to "Fly Over
             # Point" and then save the mission in the ME DCS resets it.
+            if self.flight.client_count > 0:
+                # Set Altitute to 0 AGL for player flights so that they can slave target pods or weapons to the waypoint
+                waypoint.alt = 0
+                waypoint.alt_type = "RADIO"
 
         waypoint.alt_type = self.waypoint.alt_type
         tot = self.flight.flight_plan.tot_for_waypoint(self.waypoint)

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -42,7 +42,7 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
                 # into the SAM instead of waiting for it to come alive
                 engage_task = EngageGroup(miz_group.id)
                 engage_task.params["weaponType"] = DcsWeaponType.Guided.value
-                # Ensure that they fire all ammunition in one attack pass
+                engage_task.params["groupAttack"] = True
                 engage_task.params["expend"] = Expend.All.value
                 waypoint.tasks.append(engage_task)
             else:


### PR DESCRIPTION
additional fix for #2152. 

This sets the Target Waypoint ALT to the Ingress ALT for non player flights. Player flights will have the target waypoint set to 0 AGL so that they can slave weapons or TGP to it.

This is required as the radar may not be alive when reaching the ingress waypoint (skynet script) and therefore the AI just moves on to the next waypoint which was set to 0AGL before. On the way to this wp the radar may start emitting but then the AI is already near to 0 AGL and they can not do much more. Therefore the WP will be set to the Ingress altitude for AI to represent the correct behaviour of "Search and Engage".