### PR TITLE
Allow custom mission types for squadrons

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed an issue which generated the helipads at FARPs incorrectly and placed the helicopters within each other.
 * **[Mission Generation]** Fixed an issue with SEAD missions flown by the AI when using the Skynet Plugin and anti-radiation missiles (ARM). The AI now correctly engages the SAM when it comes alive instead of diving into it.
 * **[Mission Generation]** Fixed an issue where SEAD/DEAD/BAI flights fired all missiles / bombs against a single unit in a group instead of targeting the whole group.
+* **[Mission Generation]** Fixed adding additional mission types for a squadron causing error messages when the mission type is not supported by the aircraft type by default
 * **[UI]** Fixed and issue where the liberation main exe was still running after application close.
 
 # 5.2.0

--- a/game/ato/ai_flight_planner_db.py
+++ b/game/ato/ai_flight_planner_db.py
@@ -278,7 +278,7 @@ SEAD_CAPABLE = [
 
 
 # Aircraft used for DEAD tasks. Must be capable of the CAS DCS task.
-DEAD_CAPABLE = [
+DEAD_CAPABLE = SEAD_CAPABLE + [
     AJS37,
     F_14B,
     F_14A_135_GR,
@@ -303,7 +303,7 @@ DEAD_CAPABLE = [
     Bf_109K_4,
     FW_190D9,
     FW_190A8,
-] + SEAD_CAPABLE
+]
 
 
 # Aircraft used for Strike mission

--- a/game/squadrons/airwing.py
+++ b/game/squadrons/airwing.py
@@ -76,12 +76,22 @@ class AirWing:
             return squadron
         return None
 
-    def available_aircraft_for_task(self, task: FlightType) -> Iterator[AircraftType]:
+    def best_available_aircrafts_for(self, task: FlightType) -> list[AircraftType]:
+        """Returns an ordered list of available aircrafts for the given task"""
+        aircrafts = []
+        best_aircraft_for_task = aircraft_for_task(task)
         for aircraft, squadrons in self.squadrons.items():
             for squadron in squadrons:
                 if squadron.untasked_aircraft and task in squadron.mission_types:
-                    yield aircraft
+                    aircrafts.append(aircraft)
+                    if aircraft not in best_aircraft_for_task:
+                        best_aircraft_for_task.append(aircraft)
                     break
+        # Sort the list ordered by the best capability
+        return sorted(
+            aircrafts,
+            key=lambda ac: best_aircraft_for_task.index(ac),
+        )
 
     def auto_assignable_for_task(self, task: FlightType) -> Iterator[Squadron]:
         for squadron in self.iter_squadrons():

--- a/game/squadrons/airwing.py
+++ b/game/squadrons/airwing.py
@@ -57,6 +57,9 @@ class AirWing:
             for squadron in control_point.squadrons:
                 if squadron.can_auto_assign_mission(location, task, size, this_turn):
                     capable_at_base.append(squadron)
+                    if squadron.aircraft not in best_aircraft:
+                        # If it is not already in the list it should be the last one
+                        best_aircraft.append(squadron.aircraft)
 
             ordered.extend(
                 sorted(
@@ -73,11 +76,10 @@ class AirWing:
             return squadron
         return None
 
-    @property
-    def available_aircraft_types(self) -> Iterator[AircraftType]:
+    def available_aircraft_for_task(self, task: FlightType) -> Iterator[AircraftType]:
         for aircraft, squadrons in self.squadrons.items():
             for squadron in squadrons:
-                if squadron.untasked_aircraft:
+                if squadron.untasked_aircraft and task in squadron.mission_types:
                     yield aircraft
                     break
 

--- a/qt_ui/widgets/combos/QAircraftTypeSelector.py
+++ b/qt_ui/widgets/combos/QAircraftTypeSelector.py
@@ -1,5 +1,4 @@
 """Combo box for selecting aircraft types."""
-from typing import Iterable
 from PySide2.QtWidgets import QComboBox
 from game.dcs.aircrafttype import AircraftType
 
@@ -7,14 +6,14 @@ from game.dcs.aircrafttype import AircraftType
 class QAircraftTypeSelector(QComboBox):
     """Combo box for selecting among the given aircraft types."""
 
-    def __init__(self, aircraft_types: Iterable[AircraftType]) -> None:
+    def __init__(self, aircraft_types: list[AircraftType]) -> None:
         super().__init__()
 
         self.model().sort(0)
         self.setSizeAdjustPolicy(self.AdjustToContents)
         self.update_items(aircraft_types)
 
-    def update_items(self, aircraft_types: Iterable[AircraftType]):
+    def update_items(self, aircraft_types: list[AircraftType]):
         current_aircraft = self.currentData()
         self.clear()
         for aircraft in aircraft_types:

--- a/qt_ui/widgets/combos/QAircraftTypeSelector.py
+++ b/qt_ui/widgets/combos/QAircraftTypeSelector.py
@@ -1,31 +1,24 @@
 """Combo box for selecting aircraft types."""
-from typing import Iterable, Type
-
+from typing import Iterable
 from PySide2.QtWidgets import QComboBox
-from dcs.unittype import FlyingType
-
-from game.ato.ai_flight_planner_db import aircraft_for_task
-from game.ato.flighttype import FlightType
+from game.dcs.aircrafttype import AircraftType
 
 
 class QAircraftTypeSelector(QComboBox):
     """Combo box for selecting among the given aircraft types."""
 
-    def __init__(
-        self, aircraft_types: Iterable[Type[FlyingType]], mission_type: FlightType
-    ) -> None:
+    def __init__(self, aircraft_types: Iterable[AircraftType]) -> None:
         super().__init__()
 
         self.model().sort(0)
         self.setSizeAdjustPolicy(self.AdjustToContents)
-        self.update_items(mission_type, aircraft_types)
+        self.update_items(aircraft_types)
 
-    def update_items(self, mission_type: FlightType, aircraft_types):
+    def update_items(self, aircraft_types: Iterable[AircraftType]):
         current_aircraft = self.currentData()
         self.clear()
         for aircraft in aircraft_types:
-            if aircraft in aircraft_for_task(mission_type):
-                self.addItem(f"{aircraft}", userData=aircraft)
+            self.addItem(f"{aircraft}", userData=aircraft)
         current_aircraft_index = self.findData(current_aircraft)
         if current_aircraft_index != -1:
             self.setCurrentIndex(current_aircraft_index)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -56,8 +56,9 @@ class QFlightCreator(QDialog):
         layout.addLayout(QLabeledWidget("Task:", self.task_selector))
 
         self.aircraft_selector = QAircraftTypeSelector(
-            self.game.blue.air_wing.available_aircraft_types,
-            self.task_selector.currentData(),
+            self.game.blue.air_wing.available_aircraft_for_task(
+                self.task_selector.currentData()
+            )
         )
         self.aircraft_selector.setCurrentIndex(0)
         self.aircraft_selector.currentIndexChanged.connect(self.on_aircraft_changed)
@@ -216,7 +217,7 @@ class QFlightCreator(QDialog):
     def on_task_changed(self, index: int) -> None:
         task = self.task_selector.itemData(index)
         self.aircraft_selector.update_items(
-            task, self.game.blue.air_wing.available_aircraft_types
+            self.game.blue.air_wing.available_aircraft_for_task(task)
         )
         self.squadron_selector.update_items(task, self.aircraft_selector.currentData())
 

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -56,7 +56,7 @@ class QFlightCreator(QDialog):
         layout.addLayout(QLabeledWidget("Task:", self.task_selector))
 
         self.aircraft_selector = QAircraftTypeSelector(
-            self.game.blue.air_wing.available_aircraft_for_task(
+            self.game.blue.air_wing.best_available_aircrafts_for(
                 self.task_selector.currentData()
             )
         )
@@ -217,7 +217,7 @@ class QFlightCreator(QDialog):
     def on_task_changed(self, index: int) -> None:
         task = self.task_selector.itemData(index)
         self.aircraft_selector.update_items(
-            self.game.blue.air_wing.available_aircraft_for_task(task)
+            self.game.blue.air_wing.best_available_aircrafts_for(task)
         )
         self.squadron_selector.update_items(task, self.aircraft_selector.currentData())
 


### PR DESCRIPTION
Instead of giving an error when a mission type which was added to the squadron is not defined in the Ai autoplanner db for the aircraft the user should be able to task the aircraft accordingly.

- improve the Mission planner UI Dialog: Now fill the aircraft-type combo box with all available aircraft from the squadrons which can fulfill the task by checking the squadron mission types (`air_wing.available_aircraft_for_task(task)`). Previously it requested a list of all aircraft which can fulfill the task based on the definitions we had in the code not in the squadrons.
- Prevent the Error message by adding the aircraft-type to the list `best_aircraft` so that the AI Planner can correctly task the new aircraft-type. It will be added as last element as we can not guess how capabale the aircraft is in fullfilling the task. As we dont have it yet in the list it is either not the best in doing the task or a modded aircraft.

fixes #1995