### PR TITLE
Add Setting to hide enemy units in ME

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Added performance option to not cull IADS when culling would effect how mission is played at target area.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system
 * **[Mission Generation]** Added information about the modulation (AM/FM) of the assigned frequencies to the kneeboard and assign AM modulation instead of FM for JTAC.
+* **[Mission Generation]** Added setting to hide enemy units in the Mission Editor which will be enabled by default. They can be shown by enabling the "Show Hidden Units" setting in the Mission Editor.
 * **[Factions]** Updated the Faction file structure. Older custom faction files will not work correctly and have to be updated to the new structure.
 * **[Flight Planning]**  Added preset formations for different flight types at hold, join, ingress, and split waypoints.  Air to Air flights will tend toward line-abreast and spread-four formations.  Air to ground flights will tend towards trail formation.
 * **[Flight Planning]** Added the ability to plan tankers for recovery on package flights.  AI does not plan.

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Added performance option to not cull IADS when culling would effect how mission is played at target area.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system
 * **[Mission Generation]** Added information about the modulation (AM/FM) of the assigned frequencies to the kneeboard and assign AM modulation instead of FM for JTAC.
-* **[Mission Generation]** Added setting to hide enemy units in the Mission Editor which will be enabled by default. They can be shown by enabling the "Show Hidden Units" setting in the Mission Editor.
+* **[Mission Generation]** Added setting to hide enemy units in the Mission Editor. This will be set to hide flights and front line units by default. They can be shown by enabling the "Show Hidden Units" setting in the Mission Editor.
 * **[Factions]** Updated the Faction file structure. Older custom faction files will not work correctly and have to be updated to the new structure.
 * **[Flight Planning]**  Added preset formations for different flight types at hold, join, ingress, and split waypoints.  Air to Air flights will tend toward line-abreast and spread-four formations.  Air to ground flights will tend towards trail formation.
 * **[Flight Planning]** Added the ability to plan tankers for recovery on package flights.  AI does not plan.

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -126,7 +126,7 @@ class AircraftGenerator:
                 hidden = False
             else:
                 country = enemy_country
-                hidden = self.game.settings.hide_opfor_units
+                hidden = self.game.settings.hide_opfor_units is not None
 
             for squadron in control_point.squadrons:
                 try:

--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -43,11 +43,13 @@ class FlightGroupSpawner:
         country: Country,
         mission: Mission,
         helipads: dict[ControlPoint, StaticGroup],
+        hidden: bool,
     ) -> None:
         self.flight = flight
         self.country = country
         self.mission = mission
         self.helipads = helipads
+        self.hidden = hidden
 
     def create_flight_group(self) -> FlyingGroup[Any]:
         """Creates the group for the flight and adds it to the mission.
@@ -153,6 +155,7 @@ class FlightGroupSpawner:
             maintask=None,
             group_size=self.flight.count,
         )
+        group.hidden = self.hidden
 
         group.points[0].alt_type = alt_type
         return group
@@ -165,7 +168,7 @@ class FlightGroupSpawner:
         # starts or (less likely) downgrade to warm starts to avoid the issue when the
         # player is generating the mission for multiplayer (which would need a new
         # option).
-        return self.mission.flight_group_from_airport(
+        group = self.mission.flight_group_from_airport(
             country=self.country,
             name=name,
             aircraft_type=self.flight.unit_type.dcs_unit_type,
@@ -175,6 +178,8 @@ class FlightGroupSpawner:
             group_size=self.flight.count,
             parking_slots=None,
         )
+        group.hidden = self.hidden
+        return group
 
     def _generate_over_departure(
         self, name: str, origin: ControlPoint
@@ -204,6 +209,7 @@ class FlightGroupSpawner:
             maintask=None,
             group_size=self.flight.count,
         )
+        group.hidden = self.hidden
 
         group.points[0].alt_type = alt_type
         return group
@@ -211,7 +217,7 @@ class FlightGroupSpawner:
     def _generate_at_group(
         self, name: str, at: Union[ShipGroup, StaticGroup]
     ) -> FlyingGroup[Any]:
-        return self.mission.flight_group_from_unit(
+        group = self.mission.flight_group_from_unit(
             country=self.country,
             name=name,
             aircraft_type=self.flight.unit_type.dcs_unit_type,
@@ -220,6 +226,8 @@ class FlightGroupSpawner:
             start_type=self._start_type_at_group(at),
             group_size=self.flight.count,
         )
+        group.hidden = self.hidden
+        return group
 
     def _generate_at_cp_helipad(self, name: str, cp: ControlPoint) -> FlyingGroup[Any]:
         try:

--- a/game/missiongenerator/airsupportgenerator.py
+++ b/game/missiongenerator/airsupportgenerator.py
@@ -75,7 +75,7 @@ class AirSupportGenerator:
         hidden = (
             False
             if self.conflict.blue_cp.captured
-            else self.game.settings.hide_opfor_units
+            else self.game.settings.hide_opfor_units is not None
         )
         country = self.mission.country(self.game.blue.country_name)
 

--- a/game/missiongenerator/airsupportgenerator.py
+++ b/game/missiongenerator/airsupportgenerator.py
@@ -72,7 +72,11 @@ class AirSupportGenerator:
             if self.conflict.blue_cp.captured
             else self.conflict.red_cp
         )
-
+        hidden = (
+            False
+            if self.conflict.blue_cp.captured
+            else self.game.settings.hide_opfor_units
+        )
         country = self.mission.country(self.game.blue.country_name)
 
         if not self.game.settings.disable_legacy_tanker:
@@ -114,6 +118,7 @@ class AirSupportGenerator:
                     speed=airspeed,
                     tacanchannel=str(tacan),
                 )
+                tanker_group.hidden = hidden
                 tanker_group.set_frequency(freq.mhz)
 
                 callsign = callsign_for_support_unit(tanker_group)
@@ -192,6 +197,7 @@ class AirSupportGenerator:
                 frequency=freq.mhz,
                 start_type=StartType.Warm,
             )
+            awacs_flight.hidden = hidden
             awacs_flight.set_frequency(freq.mhz)
 
             awacs_flight.points[0].tasks.append(SetInvisibleCommand(True))

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -201,7 +201,9 @@ class FlotGenerator:
         forward_heading: Heading,
     ) -> None:
 
-        hide_unit = False if is_player else self.game.settings.hide_opfor_units
+        hide_group = (
+            False if is_player else self.game.settings.hide_opfor_units is not None
+        )
         infantry_position = self.conflict.find_ground_position(
             group.points[0].position.random_point_within(250, 50),
             500,
@@ -237,7 +239,7 @@ class FlotGenerator:
                             heading=forward_heading.degrees,
                             move_formation=PointAction.OffRoad,
                         )
-                        vg.hidden = hide_unit
+                        vg.hidden = hide_group
             return
 
         possible_infantry_units = set(faction.infantry_with_class(UnitClass.INFANTRY))
@@ -263,7 +265,7 @@ class FlotGenerator:
             heading=forward_heading.degrees,
             move_formation=PointAction.OffRoad,
         )
-        vg.hidden = hide_unit
+        vg.hidden = hide_group
 
         for unit in units[1:]:
             position = infantry_position.random_point_within(55, 5)
@@ -276,7 +278,7 @@ class FlotGenerator:
                 heading=forward_heading.degrees,
                 move_formation=PointAction.OffRoad,
             )
-            infantry_group.hidden = hide_unit
+            infantry_group.hidden = hide_group
 
     def _set_reform_waypoint(
         self, dcs_group: VehicleGroup, forward_heading: Heading
@@ -730,7 +732,9 @@ class FlotGenerator:
         position, heading, combat_width = frontline_vector
         spawn_heading = heading.left if is_player else heading.right
         country = self.game.coalition_for(is_player).country_name
-        hide_unit = False if is_player else self.game.settings.hide_opfor_units
+        hide_group = (
+            False if is_player else self.game.settings.hide_opfor_units is not None
+        )
         for group in groups:
             if group.role == CombatGroupRole.ARTILLERY:
                 distance_from_frontline = (
@@ -753,7 +757,7 @@ class FlotGenerator:
                     group.size,
                     final_position,
                     heading=spawn_heading.opposite,
-                    hidden=hide_unit,
+                    hidden=hide_group,
                 )
                 if is_player:
                     g.set_skill(Skill(self.game.settings.player_skill))

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -264,7 +264,7 @@ class MissionGenerator:
             self.mission.country(self.game.red.country_name),
             self.game.red.ato,
             tgo_generator.runways,
-            self.game.settings.hide_opfor_units,
+            self.game.settings.hide_opfor_units is not None,
         )
         aircraft_generator.spawn_unused_aircraft(
             self.mission.country(self.game.blue.country_name),

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -258,11 +258,13 @@ class MissionGenerator:
             self.mission.country(self.game.blue.country_name),
             self.game.blue.ato,
             tgo_generator.runways,
+            hidden=False,
         )
         aircraft_generator.generate_flights(
             self.mission.country(self.game.red.country_name),
             self.game.red.ato,
             tgo_generator.runways,
+            self.game.settings.hide_opfor_units,
         )
         aircraft_generator.spawn_unused_aircraft(
             self.mission.country(self.game.blue.country_name),

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -88,8 +88,9 @@ class GroundObjectGenerator:
         if self.culled:
             return
         hide_group = (
-            self.game.settings.hide_opfor_units
+            True
             if self.ground_object.is_friendly(to_player=False)
+            and self.game.settings.hide_opfor_units == True
             else False
         )
         for group in self.ground_object.groups:

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -341,6 +341,12 @@ class Settings:
         GAMEPLAY_SECTION,
         default=False,
     )
+    hide_opfor_units: bool = boolean_option(
+        "Hide enemy units in Mission Editor",
+        MISSION_GENERATOR_PAGE,
+        GAMEPLAY_SECTION,
+        default=True,
+    )
     generate_marks: bool = boolean_option(
         "Put objective markers on the map",
         MISSION_GENERATOR_PAGE,

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -341,11 +341,16 @@ class Settings:
         GAMEPLAY_SECTION,
         default=False,
     )
-    hide_opfor_units: bool = boolean_option(
-        "Hide enemy units in Mission Editor",
+    hide_opfor_units: Optional[bool] = choices_option(
+        "Show enemy units in Mission Editor",
         MISSION_GENERATOR_PAGE,
         GAMEPLAY_SECTION,
-        default=True,
+        choices={
+            "Show all": None,
+            "Hide all enemy units": True,
+            "Hide flights and front line": False,
+        },
+        default=False,
     )
     generate_marks: bool = boolean_option(
         "Put objective markers on the map",


### PR DESCRIPTION
closes #1570

This adds a setting to hide all enemy units in the Mission Editor. Will be set to `Hide flights and front line` by default.

To show the enemy units in the Mission Editor, the User has to enable the "Show Hidden Units" Setting in the Mission Editor

![grafik](https://user-images.githubusercontent.com/6678803/166938134-b601a8ea-8b1b-4945-aa38-227f51fc5a9f.png)

