### PR TITLE
Correction to identifying convoys

### DIFF
--- a/game/commander/objectivefinder.py
+++ b/game/commander/objectivefinder.py
@@ -174,7 +174,7 @@ class ObjectiveFinder:
             yield from self.game.coalition_for(
                 self.is_player
             ).transfers.convoys.travelling_to(
-                front_line.control_point_hostile_to(self.is_player)
+                front_line.control_point_hostile_to(not self.is_player)
             )
 
     def cargo_ships(self) -> Iterator[CargoShip]:
@@ -182,7 +182,7 @@ class ObjectiveFinder:
             yield from self.game.coalition_for(
                 self.is_player
             ).transfers.cargo_ships.travelling_to(
-                front_line.control_point_hostile_to(self.is_player)
+                front_line.control_point_hostile_to(not self.is_player)
             )
 
     def friendly_control_points(self) -> Iterator[ControlPoint]:


### PR DESCRIPTION
as it was, when it was looping front lines, it was checking if there was any convoys going to the other side's front line which was never true. Like a RedFor never transports to a BlueFor, I think this fixes it... you'd want to find the front line that _is_ friendly to the is_player.

I think...

Pull requests should be made against the `develop` branch. Any backports
necessary will be handled by the development team.

New features and bug fixes are usually worth mentioning in the changelog.
Exceptions are fixes for bugs that never shipped (were only present in a canary
build), and changes with no intended user observable behavior, such as a
refactor. If you're comfortable writing the note yourself, add it to
`changelog.md` in the root of the project in the section for the upcoming
release.
