### PR TITLE
Fix eslint warning in CI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "eslintIgnore": ["leaflet-ruler.d.ts"],
   "prettier": {
     "endOfLine": "auto"
   },

--- a/client/src/components/ruler/leaflet-ruler.d.ts
+++ b/client/src/components/ruler/leaflet-ruler.d.ts
@@ -1,3 +1,5 @@
+// Ignoring eslint here because we know L.control.ruler is used in Ruler.tsx
+
 interface CircleMarker {
   color: string;
   radius: number;


### PR DESCRIPTION
Following up on the ruler, seems like the CI is complaining about an eslint warning. Decided to let eslint ignore `leaflet-ruler.d.ts` since we know the warning is incorrect...