### PR TITLE
Fix end-combat

### DIFF
--- a/game/sim/gameupdateevents.py
+++ b/game/sim/gameupdateevents.py
@@ -55,8 +55,9 @@ class GameUpdateEvents:
         self.updated_combats.append(combat)
         return self
 
-    def end_combat(self, combat: FrozenCombat) -> None:
+    def end_combat(self, combat: FrozenCombat) -> GameUpdateEvents:
         self.ended_combats.append(combat)
+        return self
 
     def update_flight_position(
         self, flight: Flight, new_position: Point


### PR DESCRIPTION
The main reason why combat lines stay drawn on the map. Though in my test I noticed 2 exceptions, not python errors just to be clear, i.e. 2 combat lines stayed active for units that were dead. The special case was the fact that they were both located right on top of the airbase icon. Not sure why this is happening and if I had to guess, it's a problem that's separate from this one.