### PR TITLE
PBO: Unculled zones

### DIFF
--- a/client/src/api/eventstream.tsx
+++ b/client/src/api/eventstream.tsx
@@ -23,7 +23,9 @@ import {
   ControlPoint,
   Flight,
   FrontLine,
+  IadsConnection,
   Tgo,
+  UnculledZone,
 } from "./liberationApi";
 import { navMeshUpdated } from "./navMeshSlice";
 import { updateTgo } from "./tgosSlice";
@@ -31,7 +33,6 @@ import { threatZonesUpdated } from "./threatZonesSlice";
 import { unculledZonesUpdated } from "./unculledZonesSlice";
 import { LatLng } from "leaflet";
 import { updateIadsConnection } from "./iadsNetworkSlice";
-import { IadsConnection } from "./_liberationApi";
 
 interface GameUpdateEvents {
   updated_flight_positions: { [id: string]: LatLng };
@@ -39,7 +40,7 @@ interface GameUpdateEvents {
   updated_combats: Combat[];
   ended_combats: string[];
   navmesh_updates: boolean[];
-  unculled_zones_updated: boolean;
+  updated_unculled_zones: UnculledZone[];
   threat_zones_updated: boolean;
   new_flights: Flight[];
   updated_flights: string[];
@@ -88,15 +89,7 @@ export const handleStreamedEvents = (
     });
   }
 
-  if (events.unculled_zones_updated) {
-    backend.get(`/map-zones/unculled`).then(
-      (result) => {
-        if (result.data) {
-          dispatch(unculledZonesUpdated(result.data));
-        }
-      }
-    );
-  }
+  dispatch(unculledZonesUpdated(events.updated_unculled_zones));
 
   if (events.threat_zones_updated) {
     dispatch(liberationApi.endpoints.getThreatZones.initiate()).then(

--- a/client/src/api/eventstream.tsx
+++ b/client/src/api/eventstream.tsx
@@ -89,7 +89,9 @@ export const handleStreamedEvents = (
     });
   }
 
-  dispatch(unculledZonesUpdated(events.updated_unculled_zones));
+  if (events.updated_unculled_zones.length > 0) {
+    dispatch(unculledZonesUpdated(events.updated_unculled_zones));
+  }
 
   if (events.threat_zones_updated) {
     dispatch(liberationApi.endpoints.getThreatZones.initiate()).then(

--- a/game/game.py
+++ b/game/game.py
@@ -514,7 +514,7 @@ class Game:
             zones.append(package.target.position)
 
         self.__culling_zones = zones
-        events.update_unculled_zones()
+        events.update_unculled_zones(zones)
 
     def add_destroyed_units(self, data: dict[str, Union[float, str]]) -> None:
         pos = Point(

--- a/game/server/eventstream/models.py
+++ b/game/server/eventstream/models.py
@@ -9,6 +9,7 @@ from game.server.combat.models import FrozenCombatJs
 from game.server.flights.models import FlightJs
 from game.server.frontlines.models import FrontLineJs
 from game.server.leaflet import LeafletPoint
+from game.server.mapzones.models import UnculledZoneJs
 
 if TYPE_CHECKING:
     from game import Game
@@ -21,7 +22,7 @@ class GameUpdateEventsJs(BaseModel):
     updated_combats: list[FrozenCombatJs]
     ended_combats: list[UUID]
     navmesh_updates: set[bool]
-    unculled_zones_updated: bool
+    updated_unculled_zones: list[UnculledZoneJs]
     threat_zones_updated: bool
     new_flights: list[FlightJs]
     updated_flights: set[UUID]
@@ -46,6 +47,7 @@ class GameUpdateEventsJs(BaseModel):
         # because we need to send the unload event.
         new_combats = []
         updated_combats = []
+        updated_unculled_zones = []
         if game is not None:
             new_combats = [
                 FrozenCombatJs.for_combat(c, game.theater) for c in events.new_combats
@@ -54,6 +56,7 @@ class GameUpdateEventsJs(BaseModel):
                 FrozenCombatJs.for_combat(c, game.theater)
                 for c in events.updated_combats
             ]
+            updated_unculled_zones = UnculledZoneJs.from_game(game)
 
         return GameUpdateEventsJs(
             updated_flight_positions={
@@ -63,7 +66,7 @@ class GameUpdateEventsJs(BaseModel):
             updated_combats=updated_combats,
             ended_combats=[c.id for c in events.ended_combats],
             navmesh_updates=events.navmesh_updates,
-            unculled_zones_updated=events.unculled_zones_updated,
+            updated_unculled_zones=updated_unculled_zones,
             threat_zones_updated=events.threat_zones_updated,
             new_flights=[
                 FlightJs.for_flight(f, with_waypoints=True) for f in events.new_flights

--- a/game/sim/gameupdateevents.py
+++ b/game/sim/gameupdateevents.py
@@ -22,7 +22,7 @@ class GameUpdateEvents:
     ended_combats: list[FrozenCombat] = field(default_factory=list)
     updated_flight_positions: list[tuple[Flight, Point]] = field(default_factory=list)
     navmesh_updates: set[bool] = field(default_factory=set)
-    unculled_zones_updated: bool = False
+    unculled_zones_updated: list[Point] = field(default_factory=list)
     threat_zones_updated: bool = False
     new_flights: set[Flight] = field(default_factory=set)
     updated_flights: set[UUID] = field(default_factory=set)
@@ -68,8 +68,8 @@ class GameUpdateEvents:
         self.navmesh_updates.add(player)
         return self
 
-    def update_unculled_zones(self) -> GameUpdateEvents:
-        self.unculled_zones_updated = True
+    def update_unculled_zones(self, zones: list[Point]) -> GameUpdateEvents:
+        self.unculled_zones_updated = zones
         return self
 
     def update_threat_zones(self) -> GameUpdateEvents:


### PR DESCRIPTION
Push-Based Overhaul (phase 1) for unculled zones. Unless unculled zones stop getting recomputed all at once, I don't think there's any further need to improve efficiency here. The only thing that would still make sense to do is already put the logic in place so we can update single zone, but that relates to the same problem we're having with supply routes...

Partial fix #2263 