### PR TITLE
PBO: FrontLines

### DIFF
--- a/client/src/api/eventstream.tsx
+++ b/client/src/api/eventstream.tsx
@@ -13,7 +13,6 @@ import {
   updateFlightPositions,
 } from "./flightsSlice";
 import {
-  addFrontLine,
   deleteFrontLine,
   updateFrontLine,
 } from "./frontLinesSlice";
@@ -46,8 +45,7 @@ interface GameUpdateEvents {
   deleted_flights: string[];
   selected_flight: string | null;
   deselected_flight: boolean;
-  new_front_lines: FrontLine[];
-  updated_front_lines: string[];
+  updated_front_lines: FrontLine[];
   deleted_front_lines: string[];
   updated_tgos: string[];
   updated_control_points: number[];
@@ -131,19 +129,12 @@ export const handleStreamedEvents = (
     dispatch(selectFlight(events.selected_flight));
   }
 
-  for (const front of events.new_front_lines) {
-    dispatch(addFrontLine(front));
+  if (events.updated_front_lines.length > 0) {
+    dispatch(updateFrontLine(events.updated_front_lines));
   }
 
-  for (const id of events.updated_front_lines) {
-    backend.get(`/front-lines/${id}`).then((response) => {
-      const front = response.data as FrontLine;
-      dispatch(updateFrontLine(front));
-    });
-  }
-
-  for (const id of events.deleted_front_lines) {
-    dispatch(deleteFrontLine(id));
+  if (events.deleted_front_lines.length > 0) {
+    dispatch(deleteFrontLine(events.deleted_front_lines));
   }
 
   for (const id of events.updated_tgos) {

--- a/client/src/api/frontLinesSlice.ts
+++ b/client/src/api/frontLinesSlice.ts
@@ -15,16 +15,15 @@ export const frontLinesSlice = createSlice({
   name: "frontLines",
   initialState,
   reducers: {
-    addFrontLine: (state, action: PayloadAction<FrontLine>) => {
-      const front = action.payload;
-      state.fronts[front.id] = front;
+    updateFrontLine: (state, action: PayloadAction<FrontLine[]>) => {
+      for (const front of action.payload) {
+        state.fronts[front.id] = front;
+      }
     },
-    updateFrontLine: (state, action: PayloadAction<FrontLine>) => {
-      const front = action.payload;
-      state.fronts[front.id] = front;
-    },
-    deleteFrontLine: (state, action: PayloadAction<string>) => {
-      delete state.fronts[action.payload];
+    deleteFrontLine: (state, action: PayloadAction<string[]>) => {
+      for (const uid of action.payload) {
+        delete state.fronts[uid];
+      }
     },
   },
   extraReducers: (builder) => {
@@ -43,7 +42,7 @@ export const frontLinesSlice = createSlice({
   },
 });
 
-export const { addFrontLine, updateFrontLine, deleteFrontLine } =
+export const { updateFrontLine, deleteFrontLine } =
   frontLinesSlice.actions;
 
 export const selectFrontLines = (state: RootState) => state.frontLines;

--- a/game/server/eventstream/models.py
+++ b/game/server/eventstream/models.py
@@ -28,8 +28,7 @@ class GameUpdateEventsJs(BaseModel):
     deleted_flights: set[UUID]
     selected_flight: UUID | None
     deselected_flight: bool
-    new_front_lines: list[FrontLineJs]
-    updated_front_lines: set[UUID]
+    updated_front_lines: list[FrontLineJs]
     deleted_front_lines: set[UUID]
     updated_tgos: set[UUID]
     updated_control_points: set[UUID]
@@ -72,10 +71,9 @@ class GameUpdateEventsJs(BaseModel):
             deleted_flights=events.deleted_flights,
             selected_flight=events.selected_flight,
             deselected_flight=events.deselected_flight,
-            new_front_lines=[
-                FrontLineJs.for_front_line(f) for f in events.new_front_lines
+            updated_front_lines=[
+                FrontLineJs.for_front_line(f) for f in events.updated_front_lines
             ],
-            updated_front_lines=events.updated_front_lines,
             deleted_front_lines=events.deleted_front_lines,
             updated_tgos=events.updated_tgos,
             updated_control_points=events.updated_control_points,

--- a/game/sim/gameupdateevents.py
+++ b/game/sim/gameupdateevents.py
@@ -29,8 +29,7 @@ class GameUpdateEvents:
     deleted_flights: set[UUID] = field(default_factory=set)
     selected_flight: UUID | None = None
     deselected_flight: bool = False
-    new_front_lines: set[FrontLine] = field(default_factory=set)
-    updated_front_lines: set[UUID] = field(default_factory=set)
+    updated_front_lines: set[FrontLine] = field(default_factory=set)
     deleted_front_lines: set[UUID] = field(default_factory=set)
     updated_tgos: set[UUID] = field(default_factory=set)
     updated_control_points: set[UUID] = field(default_factory=set)
@@ -106,12 +105,8 @@ class GameUpdateEvents:
         self.selected_flight = None
         return self
 
-    def new_front_line(self, front_line: FrontLine) -> GameUpdateEvents:
-        self.new_front_lines.add(front_line)
-        return self
-
     def update_front_line(self, front_line: FrontLine) -> GameUpdateEvents:
-        self.updated_front_lines.add(front_line.id)
+        self.updated_front_lines.add(front_line)
         return self
 
     def delete_front_line(self, front_line: FrontLine) -> GameUpdateEvents:

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -398,7 +398,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self.front_lines[connection] = front
         connection.front_lines[self] = front
         self.front_line_db.add(front.id, front)
-        events.new_front_line(front)
+        events.update_front_line(front)
 
     def _remove_front_line_with(
         self, connection: ControlPoint, events: GameUpdateEvents


### PR DESCRIPTION
Partial fix #2263 

Removed `new_front_line` since it's redundant, it does exactly the same thing as `update_front_line` and readability isn't really deteriorating by removing it...