### PR TITLE
Refactoring for-loops for combat

### DIFF
--- a/client/src/api/combatSlice.ts
+++ b/client/src/api/combatSlice.ts
@@ -28,15 +28,7 @@ export const combatSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(gameLoaded, (state, action) => {
-      // still need to pass this from back-end, initialize empty...
       state.combat = {};
-      /* state.combat = action.payload.combat.reduce(
-        (acc: { [key: string]: Tgo }, curr) => {
-          acc[curr.id] = curr;
-          return acc;
-        },
-        {}
-      ); */
     });
     builder.addCase(gameUnloaded, (state) => {
       state.combat = {};

--- a/client/src/api/combatSlice.ts
+++ b/client/src/api/combatSlice.ts
@@ -1,3 +1,4 @@
+import { gameLoaded, gameUnloaded } from "./actions";
 import { RootState } from "../app/store";
 import Combat from "./combat";
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
@@ -14,28 +15,36 @@ export const combatSlice = createSlice({
   name: "combat",
   initialState,
   reducers: {
-    setCombat: (state, action: PayloadAction<Combat[]>) => {
-      state.combat = {};
+    updateCombats: (state, action: PayloadAction<Combat[]>) => {
       for (const combat of action.payload) {
         state.combat[combat.id] = combat;
       }
     },
-    newCombat: (state, action: PayloadAction<Combat>) => {
-      const combat = action.payload;
-      state.combat[combat.id] = combat;
+    endCombats: (state, action: PayloadAction<string[]>) => {
+      for (const cID of action.payload) {
+        delete state.combat[cID];
+      }
     },
-    updateCombat: (state, action: PayloadAction<Combat>) => {
-      const combat = action.payload;
-      state.combat[combat.id] = combat;
-    },
-    endCombat: (state, action: PayloadAction<string>) => {
-      delete state.combat[action.payload];
-    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(gameLoaded, (state, action) => {
+      // still need to pass this from back-end, initialize empty...
+      state.combat = {};
+      /* state.combat = action.payload.combat.reduce(
+        (acc: { [key: string]: Tgo }, curr) => {
+          acc[curr.id] = curr;
+          return acc;
+        },
+        {}
+      ); */
+    });
+    builder.addCase(gameUnloaded, (state) => {
+      state.combat = {};
+    });
   },
 });
 
-export const { setCombat, newCombat, updateCombat, endCombat } =
-  combatSlice.actions;
+export const { updateCombats, endCombats } = combatSlice.actions;
 
 export const selectCombat = (state: RootState) => state.combat;
 

--- a/client/src/api/eventstream.tsx
+++ b/client/src/api/eventstream.tsx
@@ -2,7 +2,7 @@ import { AppDispatch } from "../app/store";
 import { gameUnloaded } from "./actions";
 import backend from "./backend";
 import Combat from "./combat";
-import { endCombat, newCombat, updateCombat } from "./combatSlice";
+import { endCombats, updateCombats } from "./combatSlice";
 import { updateControlPoint } from "./controlPointsSlice";
 import {
   deselectFlight,
@@ -35,7 +35,6 @@ import { IadsConnection } from "./_liberationApi";
 
 interface GameUpdateEvents {
   updated_flight_positions: { [id: string]: LatLng };
-  new_combats: Combat[];
   updated_combats: Combat[];
   ended_combats: string[];
   navmesh_updates: boolean[];
@@ -66,16 +65,12 @@ export const handleStreamedEvents = (
     );
   }
 
-  for (const combat of events.new_combats) {
-    dispatch(newCombat(combat));
+  if (events.updated_combats.length > 0) {
+    dispatch(updateCombats(events.updated_combats));
   }
 
-  for (const combat of events.updated_combats) {
-    dispatch(updateCombat(combat));
-  }
-
-  for (const id of events.ended_combats) {
-    dispatch(endCombat(id));
+  if (events.ended_combats.length > 0) {
+    dispatch(endCombats(events.ended_combats));
   }
 
   for (const blue of events.navmesh_updates) {

--- a/game/server/eventstream/models.py
+++ b/game/server/eventstream/models.py
@@ -43,7 +43,6 @@ class GameUpdateEventsJs(BaseModel):
 
         # We still need to be able to send update events when there is no game loaded
         # because we need to send the unload event.
-        new_combats = []
         updated_combats = []
         if game is not None:
             updated_combats = [

--- a/game/server/eventstream/models.py
+++ b/game/server/eventstream/models.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 class GameUpdateEventsJs(BaseModel):
     updated_flight_positions: dict[UUID, LeafletPoint]
-    new_combats: list[FrozenCombatJs]
     updated_combats: list[FrozenCombatJs]
     ended_combats: list[UUID]
     navmesh_updates: set[bool]
@@ -47,9 +46,6 @@ class GameUpdateEventsJs(BaseModel):
         new_combats = []
         updated_combats = []
         if game is not None:
-            new_combats = [
-                FrozenCombatJs.for_combat(c, game.theater) for c in events.new_combats
-            ]
             updated_combats = [
                 FrozenCombatJs.for_combat(c, game.theater)
                 for c in events.updated_combats
@@ -59,7 +55,6 @@ class GameUpdateEventsJs(BaseModel):
             updated_flight_positions={
                 f[0].id: f[1].latlng() for f in events.updated_flight_positions
             },
-            new_combats=new_combats,
             updated_combats=updated_combats,
             ended_combats=[c.id for c in events.ended_combats],
             navmesh_updates=events.navmesh_updates,

--- a/game/sim/combat/combatinitiator.py
+++ b/game/sim/combat/combatinitiator.py
@@ -78,7 +78,7 @@ class CombatInitiator:
             a2a.update_for_combat(combat)
             own_a2a.update_for_combat(combat)
             self.combats.append(combat)
-            self.events.new_combat(combat)
+            self.events.update_combat(combat)
 
     def check_flight_for_joined_combat(
         self, flight: Flight

--- a/game/sim/gameupdateevents.py
+++ b/game/sim/gameupdateevents.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 @dataclass
 class GameUpdateEvents:
     simulation_complete = False
-    new_combats: list[FrozenCombat] = field(default_factory=list)
     updated_combats: list[FrozenCombat] = field(default_factory=list)
     ended_combats: list[FrozenCombat] = field(default_factory=list)
     updated_flight_positions: list[tuple[Flight, Point]] = field(default_factory=list)
@@ -45,10 +44,6 @@ class GameUpdateEvents:
 
     def complete_simulation(self) -> GameUpdateEvents:
         self.simulation_complete = True
-        return self
-
-    def new_combat(self, combat: FrozenCombat) -> GameUpdateEvents:
-        self.new_combats.append(combat)
         return self
 
     def update_combat(self, combat: FrozenCombat) -> GameUpdateEvents:


### PR DESCRIPTION
Partial fix #2263 

Removing redundancies and unused stuff, refactor for-loops to the slice...

Only 2 reducers that should be kept are `update_combat` & `end_combat`