### PR TITLE
Mark advanced IADS WIP.

### DIFF
--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -392,7 +392,7 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
         mapSettingsLayout.addWidget(invertMap, 0, 1)
         self.advanced_iads = QtWidgets.QCheckBox()
         self.registerField("advanced_iads", self.advanced_iads)
-        mapSettingsLayout.addWidget(QtWidgets.QLabel("Advanced IADS"), 1, 0)
+        mapSettingsLayout.addWidget(QtWidgets.QLabel("Advanced IADS (WIP)"), 1, 0)
         mapSettingsLayout.addWidget(self.advanced_iads, 1, 1)
         mapSettingsGroup.setLayout(mapSettingsLayout)
 


### PR DESCRIPTION
The advanced IADS currently only works during the initial game
generation. Any changes to the TGO (purchases/sales, captures, etc) will
disconnect the node from the network and return it to basic IADS
functionality.