### PR TITLE
Focus on the exception window

### DIFF
--- a/qt_ui/uncaughtexceptionhandler.py
+++ b/qt_ui/uncaughtexceptionhandler.py
@@ -33,7 +33,7 @@ class UncaughtExceptionHandler(QObject):
     def show_exception_box(self, message: str, exception: str) -> None:
         if QApplication.instance() is not None:
             QMessageBox().critical(
-                self.parent(),
+                QApplication.focusWidget(),
                 "An unexpected error occurred",
                 "\n".join([message, "", exception]),
                 QMessageBox.Ok,


### PR DESCRIPTION
Solves the problem where an exception window might get hidden under some other window or dialog, which sort of freezes the entire program cause you need to dismiss the exception window first. You can normally unfreeze by pressing enter, but that closes the exception window before you read the message.