### PR TITLE
Initialize restore_start_type

### DIFF
--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -103,7 +103,7 @@ class QFlightCreator(QDialog):
         # When an off-map spawn overrides the start type to in-flight, we save
         # the selected type into this value. If a non-off-map spawn is selected
         # we restore the previous choice.
-        self.restore_start_type: Optional[str] = None
+        self.restore_start_type = self.game.settings.default_start_type
         self.start_type = QComboBox()
         for start_type in StartType:
             self.start_type.addItem(start_type.value, start_type)


### PR DESCRIPTION
Initializing `self.restore_start_type` fixes an issue where you try to create a flight, if it happens to select a squadron with an "OffMapSpawn" base as a first choice, then change to an "on map" squadron, it'll enable the combo-box but have "in-flight" selected. This fix makes sure it goes back to default start type for the specified scenario only.