### PR TITLE
Added Leopard 2A6M as a separate variant in Leopard-2.yaml

### DIFF
--- a/resources/units/ground_units/Leopard-2.yaml
+++ b/resources/units/ground_units/Leopard-2.yaml
@@ -16,3 +16,4 @@ price: 25
 role: Main Battle Tank
 variants:
   Leopard 2: {}
+  Leopard 2A6M: {}


### PR DESCRIPTION
Added Leopard 2A6M as a separate variant in Leopard-2.yaml in order to distinguish it from the other Leopard 2 models now available and to reduce confusion between the types. Kept the original Leopard 2 variant for backwards compatibility. Resolves #2295.
