### PR TITLE
Grey out advanced IADS in new game wizard if needed

### DIFF
--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -391,8 +391,12 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
         mapSettingsLayout.addWidget(QtWidgets.QLabel("Invert Map"), 0, 0)
         mapSettingsLayout.addWidget(invertMap, 0, 1)
         self.advanced_iads = QtWidgets.QCheckBox()
+        disabled_grey_out = "QCheckBox::indicator:disabled{ background-color: rgba(255, 255, 255, 5%); }"
+        self.advanced_iads.setStyleSheet(disabled_grey_out)
         self.registerField("advanced_iads", self.advanced_iads)
-        mapSettingsLayout.addWidget(QtWidgets.QLabel("Advanced IADS (WIP)"), 1, 0)
+        self.iads_label = QtWidgets.QLabel("Advanced IADS (WIP)")
+        self.iads_label.setStyleSheet("QLabel:disabled{color: #888888}")
+        mapSettingsLayout.addWidget(self.iads_label, 1, 0)
         mapSettingsLayout.addWidget(self.advanced_iads, 1, 1)
         mapSettingsGroup.setLayout(mapSettingsLayout)
 
@@ -457,6 +461,7 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
             else:
                 timePeriodPreset.setChecked(True)
             self.advanced_iads.setEnabled(campaign.advanced_iads)
+            self.iads_label.setEnabled(campaign.advanced_iads)
             self.advanced_iads.setChecked(campaign.advanced_iads)
             if not campaign.advanced_iads:
                 self.advanced_iads.setToolTip(


### PR DESCRIPTION
After comparing different possibilities on how to grey out the advanced IADS option in the new game wizard, I find these changes to be best:

Disabled, greyed out
![image](https://user-images.githubusercontent.com/10977187/177212408-a646626e-23d1-42d4-aa1b-54b2df6dc2a1.png)

Enabled, checked
![image](https://user-images.githubusercontent.com/10977187/177212474-de9c5a7e-1104-4f77-8dd3-4a4daa9c635d.png)

Enabled, unchecked
![image](https://user-images.githubusercontent.com/10977187/177212569-ecd340b0-82c4-49a5-bf89-75fede7ccb36.png)

Imo it's no longer confusing in the sense that the greyed out checkbox looks checked. I tried turning down the 'alpha' to 2-3% but then the difference becomes too subtle.