### PR TITLE
Add Air wing config accept button

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python3

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Modding]** Updated the High Digit SAMs implementation and added the HQ-2 as well as the upgraded SA-2 and SA-3 Launchers from the mod. Threat range circles will now also be displayed correctly.
 * **[UI]** Added options to the loadout editor for setting properties such as HMD choice.
 * **[UI]** Added separate images for the different carrier types.
+* **[UI]** Add Accept button to Air Wing Configurator screen.
 * **[Campaign]** Allow campaign designers to define default values for the economy settings (starting budget and multiplier).
 * **[Plugins]** Allow full support of the SkynetIADS plugin with all advanced features (connection nodes, power sources, command centers) if campaign supports it.
 * **[Plugins]** Added support for the CTLD script by ciribob with many possible customization options and updated the JTAC Autolase to the CTLD included script.

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -512,6 +512,10 @@ class AirWingConfigurationDialog(QDialog):
             tab_widget.addTab(coalition_tab, name)
             self.tabs.append(coalition_tab)
 
+        apply_button = QPushButton("Accept")
+        apply_button.clicked.connect(lambda state: self.accept())
+        layout.addWidget(apply_button)
+
     def reject(self) -> None:
         for tab in self.tabs:
             tab.apply()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ anyio==3.5.0
 asgiref==3.5.0
 atomicwrites==1.4.0
 attrs==21.4.0
-black==22.1.0
+black==22.6.0
 certifi==2021.10.8
 cfgv==3.3.1
 click==8.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ attrs==21.4.0
 black==22.6.0
 certifi==2021.10.8
 cfgv==3.3.1
-click==8.0.3
+click==8.1.3
 colorama==0.4.4
 distlib==0.3.4
 Faker==12.3.0


### PR DESCRIPTION
This PR adds the Accept button found at the bottom of the Air Wing Configuration screen.  It spans the whole window as the AirWingConfigurator is a QVBoxLayout.  It doesn't add any functionality over just clicking the X in the corner.

Click and Black were updated in this PR as well as I could not commit without this error:  https://github.com/psf/black/issues/2964

@DanAlbert Let me know if you need me to redo this as two commits or separate PRs.  

![image](https://user-images.githubusercontent.com/74509817/178134652-5856733b-9501-421d-88bc-50ddf2bddba3.png)
