### PR TITLE
Fix invalid squadron liveries

### DIFF
--- a/resources/squadrons/A-10C Warthog I/25th FS.yaml
+++ b/resources/squadrons/A-10C Warthog I/25th FS.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 0
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 3)
-livery: 25th FS Osab AB, Korea (OS)
+livery: 25th FS Osan AB, Korea (OS)
 mission_types:
   - BAI
   - CAS

--- a/resources/squadrons/A-10C Warthog II/25th FS.yaml
+++ b/resources/squadrons/A-10C Warthog II/25th FS.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 6
 country: USA
 role: Close Air Support
 aircraft: A-10C Thunderbolt II (Suite 7)
-livery: 25th FS Osab AB, Korea (OS)
+livery: 25th FS Osan AB, Korea (OS)
 mission_types:
   - BAI
   - CAS

--- a/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-33.yaml
+++ b/resources/squadrons/F-14A 135-GR Tomcat (Late)/VF-33.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 0
 country: USA
 role: Strike Fighter
 aircraft: F-14A Tomcat (Block 135-GR Late)
-livery: VF-33 Starfighters 201
+livery: VF-33 Starfighters AB201 (1988)
 mission_types:
   - BAI
   - BARCAP

--- a/resources/squadrons/F-14B Tomcat/VF-102.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-102.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat
-livery: VF-102 Diamondbacks 102 (2000)
+livery: VF-102 Diamondbacks 102
 mission_types:
   - BAI
   - BARCAP

--- a/resources/squadrons/Mi-8/SAAF 253th Sqn.yaml
+++ b/resources/squadrons/Mi-8/SAAF 253th Sqn.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 0
 country: Syria
 role: Transport Helicopter
 aircraft: Mi-8MTV2 Hip
-livery: "BP_RS01"
+livery: Standard
 mission_types:
   - Transport
   - CAS

--- a/resources/squadrons/Mi-8/SAAF 255th Sqn.yaml
+++ b/resources/squadrons/Mi-8/SAAF 255th Sqn.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 0
 country: Syria
 role: Transport Helicopter
 aircraft: Mi-8MTV2 Hip
-livery: "BP_RS01"
+livery: Standard
 mission_types:
   - Transport
   - CAS

--- a/resources/squadrons/Mig-29/SAAF 697th Sqn.yaml
+++ b/resources/squadrons/Mig-29/SAAF 697th Sqn.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C
-livery: "ERAF"
+livery: Algerian AF FC-16
 mission_types:
   - BARCAP
   - TARCAP

--- a/resources/squadrons/Mig-29/SAAF 699th Sqn.yaml
+++ b/resources/squadrons/Mig-29/SAAF 699th Sqn.yaml
@@ -5,7 +5,7 @@ female_pilot_percentage: 0
 country: Syria
 role: Air Superiority Fighter
 aircraft: MiG-29S Fulcrum-C
-livery: "ERAF"
+livery: Algerian AF FC-16
 mission_types:
   - BARCAP
   - TARCAP

--- a/resources/squadrons/S-3B/VS-35F.yaml
+++ b/resources/squadrons/S-3B/VS-35F.yaml
@@ -5,6 +5,6 @@ female_pilot_percentage: 0
 country: USA
 role: Tanker
 aircraft: S-3B Tanker
-livery: NAVY Standard
+livery: usaf standard
 mission_types:
   - Refueling


### PR DESCRIPTION
While messing with the livery scanner that I'm working on, I noticed a little typo for the 25th FS (A-10C II)