### PR TITLE
Fine-tune 'Accept' button in AirWingConfigurationDiaglog

### DIFF
--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -26,6 +26,7 @@ from PySide2.QtWidgets import (
     QPushButton,
     QGridLayout,
     QToolButton,
+    QMessageBox,
 )
 from game import Game
 from game.ato.flighttype import FlightType
@@ -512,13 +513,33 @@ class AirWingConfigurationDialog(QDialog):
             tab_widget.addTab(coalition_tab, name)
             self.tabs.append(coalition_tab)
 
-        apply_button = QPushButton("Accept")
+        buttons_layout = QHBoxLayout()
+        apply_button = QPushButton("Accept Changes && Start Campaign")
+        apply_button.setProperty("style", "btn-accept")
         apply_button.clicked.connect(lambda state: self.accept())
-        layout.addWidget(apply_button)
+        discard_button = QPushButton("Discard Changes && Start Campaign")
+        discard_button.setProperty("style", "btn-danger")
+        super_reject = super(AirWingConfigurationDialog, self).reject
+        discard_button.clicked.connect(lambda state: super_reject())
+        buttons_layout.addWidget(apply_button)
+        buttons_layout.addWidget(discard_button)
+        layout.addLayout(buttons_layout)
 
-    def reject(self) -> None:
+    def accept(self) -> None:
         for tab in self.tabs:
             tab.apply()
+        super().accept()
+
+    def reject(self) -> None:
+        result = QMessageBox.information(
+            None,
+            "Discard changes?",
+            "Are you sure you want to discard your changes?",
+            QMessageBox.Yes,
+            QMessageBox.No
+        )
+        if result == QMessageBox.No:
+            return
         super().reject()
 
 

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -534,7 +534,7 @@ class AirWingConfigurationDialog(QDialog):
         result = QMessageBox.information(
             None,
             "Discard changes?",
-            "Are you sure you want to discard your changes?",
+            "Are you sure you want to discard your changes and start the campaign?",
             QMessageBox.Yes,
             QMessageBox.No,
         )

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -554,15 +554,8 @@ class AirWingConfigurationDialog(QDialog):
         self.has_changed = True
 
     def revert(self) -> None:
-        # self.tab_widget.clear()
         for tab in self.tabs:
             tab.revert()
-            # game = tab.game
-            # coalition = tab.coalition
-            # new_tab = AirWingConfigurationTab(coalition, game)
-            # new_tab.squadrons_panel.squadrons_changed.connect(self.changed)
-            # name = "Blue" if coalition.player else "Red"
-            # self.tab_widget.addTab(new_tab, name)
         self.has_changed = False
 
     def accept(self) -> None:

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -521,8 +521,8 @@ class AirWingConfigurationDialog(QDialog):
         discard_button.setProperty("style", "btn-danger")
         super_reject = super(AirWingConfigurationDialog, self).reject
         discard_button.clicked.connect(lambda state: super_reject())
-        buttons_layout.addWidget(apply_button)
         buttons_layout.addWidget(discard_button)
+        buttons_layout.addWidget(apply_button)
         layout.addLayout(buttons_layout)
 
     def accept(self) -> None:

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -536,7 +536,7 @@ class AirWingConfigurationDialog(QDialog):
             "Discard changes?",
             "Are you sure you want to discard your changes?",
             QMessageBox.Yes,
-            QMessageBox.No
+            QMessageBox.No,
         )
         if result == QMessageBox.No:
             return

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -316,6 +316,7 @@ class AircraftSquadronsPage(QWidget):
 
 class AircraftSquadronsPanel(QStackedLayout):
     page_removed = Signal(AircraftType)
+    squadrons_changed = Signal()
 
     def __init__(self, air_wing: AirWing, theater: ConflictTheater) -> None:
         super().__init__()
@@ -332,6 +333,7 @@ class AircraftSquadronsPanel(QStackedLayout):
         self.squadrons_pages.pop(aircraft_type)
         self.page_removed.emit(aircraft_type)
         self.update()
+        self.squadrons_changed.emit()
 
     def new_page_for_type(
         self, aircraft_type: AircraftType, squadrons: list[Squadron]
@@ -350,11 +352,20 @@ class AircraftSquadronsPanel(QStackedLayout):
             self.new_page_for_type(squadron.aircraft, [squadron])
 
         self.update()
+        self.squadrons_changed.emit()
 
     def apply(self) -> None:
         self.air_wing.squadrons = {}
         for aircraft, page in self.squadrons_pages.items():
             self.air_wing.squadrons[aircraft] = page.apply()
+
+    def revert(self) -> None:
+        for _, page in self.squadrons_pages.items():
+            self.removeWidget(page)
+        self.squadrons_pages: dict[AircraftType, AircraftSquadronsPage] = {}
+        for aircraft, squadrons in self.air_wing.squadrons.items():
+            self.new_page_for_type(aircraft, squadrons)
+        self.update()
 
 
 class AircraftTypeList(QListView):
@@ -362,6 +373,7 @@ class AircraftTypeList(QListView):
 
     def __init__(self, air_wing: AirWing) -> None:
         super().__init__()
+        self.air_wing = air_wing
         self.setIconSize(QSize(91, 24))
         self.setMinimumWidth(300)
 
@@ -405,6 +417,12 @@ class AircraftTypeList(QListView):
         if name in AIRCRAFT_ICONS:
             return QIcon(AIRCRAFT_ICONS[name])
         return None
+
+    def revert(self) -> None:
+        self.item_model.clear()
+        for aircraft in self.air_wing.squadrons:
+            self.add_aircraft_type(aircraft)
+        self.update()
 
 
 class AirWingConfigurationTab(QWidget):
@@ -481,6 +499,11 @@ class AirWingConfigurationTab(QWidget):
     def apply(self) -> None:
         self.squadrons_panel.apply()
 
+    def revert(self) -> None:
+        self.type_list.revert()
+        self.squadrons_panel.revert()
+        self.update()
+
 
 class AirWingConfigurationDialog(QDialog):
     """Dialog window for air wing configuration."""
@@ -503,27 +526,44 @@ class AirWingConfigurationDialog(QDialog):
 
         layout.addWidget(doc_label)
 
-        tab_widget = QTabWidget()
-        layout.addWidget(tab_widget)
+        self.tab_widget = QTabWidget()
+        layout.addWidget(self.tab_widget)
 
         self.tabs = []
         for coalition in game.coalitions:
             coalition_tab = AirWingConfigurationTab(coalition, game)
             name = "Blue" if coalition.player else "Red"
-            tab_widget.addTab(coalition_tab, name)
+            self.tab_widget.addTab(coalition_tab, name)
             self.tabs.append(coalition_tab)
+            coalition_tab.squadrons_panel.squadrons_changed.connect(self.changed)
 
         buttons_layout = QHBoxLayout()
         apply_button = QPushButton("Accept Changes && Start Campaign")
         apply_button.setProperty("style", "btn-accept")
         apply_button.clicked.connect(lambda state: self.accept())
-        discard_button = QPushButton("Discard Changes && Start Campaign")
+        discard_button = QPushButton("Reset Changes")
         discard_button.setProperty("style", "btn-danger")
-        super_reject = super(AirWingConfigurationDialog, self).reject
-        discard_button.clicked.connect(lambda state: super_reject())
+        discard_button.clicked.connect(lambda state: self.revert())
         buttons_layout.addWidget(discard_button)
         buttons_layout.addWidget(apply_button)
         layout.addLayout(buttons_layout)
+
+        self.has_changed = False
+
+    def changed(self) -> None:
+        self.has_changed = True
+
+    def revert(self) -> None:
+        # self.tab_widget.clear()
+        for tab in self.tabs:
+            tab.revert()
+            # game = tab.game
+            # coalition = tab.coalition
+            # new_tab = AirWingConfigurationTab(coalition, game)
+            # new_tab.squadrons_panel.squadrons_changed.connect(self.changed)
+            # name = "Blue" if coalition.player else "Red"
+            # self.tab_widget.addTab(new_tab, name)
+        self.has_changed = False
 
     def accept(self) -> None:
         for tab in self.tabs:
@@ -531,15 +571,16 @@ class AirWingConfigurationDialog(QDialog):
         super().accept()
 
     def reject(self) -> None:
-        result = QMessageBox.information(
-            None,
-            "Discard changes?",
-            "Are you sure you want to discard your changes and start the campaign?",
-            QMessageBox.Yes,
-            QMessageBox.No,
-        )
-        if result == QMessageBox.No:
-            return
+        if self.has_changed:
+            result = QMessageBox.information(
+                None,
+                "Discard changes?",
+                "Are you sure you want to discard your changes and start the campaign?",
+                QMessageBox.Yes,
+                QMessageBox.No,
+            )
+            if result == QMessageBox.No:
+                return
         super().reject()
 
 

--- a/resources/stylesheets/style-dcs.css
+++ b/resources/stylesheets/style-dcs.css
@@ -208,6 +208,19 @@ QPushButton[style="btn-danger"]:hover{
     background-color:#D84545;
 }
 
+
+QPushButton[style="btn-accept"] {
+    background-color:#82A466;
+    color: white;
+    padding: 6px;
+    border-radius:2px;
+    border: 1px solid #82A466;
+}
+
+QPushButton[style="btn-accept"]:hover {
+    background-color:#5C863F;
+}
+
 QPushButton:disabled{
 
     background:#d6d6d6;


### PR DESCRIPTION
- Fixes 'Accept' not saving changes
- Adds confirmation pop-up when pressing [X] when a change was made, asking if you're sure you want to discard the changes and start the campaign
- Adds 'Reset' button reverting all changes made so far

