### PR TITLE
Fix incomplete reset

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Modding]** Updated the High Digit SAMs implementation and added the HQ-2 as well as the upgraded SA-2 and SA-3 Launchers from the mod. Threat range circles will now also be displayed correctly.
 * **[UI]** Added options to the loadout editor for setting properties such as HMD choice.
 * **[UI]** Added separate images for the different carrier types.
-* **[UI]** Add Accept button to Air Wing Configurator screen.
+* **[UI]** Add Accept/Reset buttons to Air Wing Configurator screen.
 * **[Campaign]** Allow campaign designers to define default values for the economy settings (starting budget and multiplier).
 * **[Plugins]** Allow full support of the SkynetIADS plugin with all advanced features (connection nodes, power sources, command centers) if campaign supports it.
 * **[Plugins]** Added support for the CTLD script by ciribob with many possible customization options and updated the JTAC Autolase to the CTLD included script.

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -143,7 +143,6 @@ class SquadronConfigurationBox(QGroupBox):
     def __init__(self, squadron: Squadron, theater: ConflictTheater) -> None:
         super().__init__()
         self.squadron = squadron
-        self.reset_title()
 
         columns = QHBoxLayout()
         self.setLayout(columns)
@@ -153,15 +152,16 @@ class SquadronConfigurationBox(QGroupBox):
 
         left_column.addWidget(QLabel("Name:"))
         self.name_edit = QLineEdit(squadron.name)
-        self.name_edit.textChanged.connect(self.on_name_changed)
+        self.name_edit.textChanged.connect(lambda x: self.reset_title())
         left_column.addWidget(self.name_edit)
+
+        self.reset_title()
 
         nickname_edit_layout = QGridLayout()
         left_column.addLayout(nickname_edit_layout)
 
         nickname_edit_layout.addWidget(QLabel("Nickname:"), 0, 0, 1, 2)
         self.nickname_edit = QLineEdit(squadron.nickname)
-        self.nickname_edit.textChanged.connect(self.on_nickname_changed)
         nickname_edit_layout.addWidget(self.nickname_edit, 1, 0, Qt.AlignTop)
         reroll_nickname_button = QToolButton()
         reroll_nickname_button.setIcon(QIcon(ICONS["Reload"]))
@@ -175,7 +175,6 @@ class SquadronConfigurationBox(QGroupBox):
             squadron.location,
             squadron.aircraft,
         )
-        self.base_selector.currentIndexChanged.connect(self.on_base_changed)
         left_column.addWidget(self.base_selector)
 
         if squadron.player:
@@ -210,21 +209,8 @@ class SquadronConfigurationBox(QGroupBox):
     def remove_from_squadron_config(self) -> None:
         self.remove_squadron_signal.emit(self.squadron)
 
-    def on_name_changed(self, text: str) -> None:
-        self.squadron.name = text
-        self.reset_title()
-
-    def on_nickname_changed(self, text: str) -> None:
-        self.squadron.nickname = text
-
-    def on_base_changed(self, index: int) -> None:
-        base = self.base_selector.itemData(index)
-        if base is None:
-            raise RuntimeError("Base cannot be none")
-        self.squadron.assign_to_base(base)
-
     def reset_title(self) -> None:
-        self.setTitle(f"{self.squadron.name} - {self.squadron.aircraft}")
+        self.setTitle(f"{self.name_edit.text()} - {self.squadron.aircraft}")
 
     def reroll_nickname(self) -> None:
         self.nickname_edit.setText(
@@ -232,6 +218,13 @@ class SquadronConfigurationBox(QGroupBox):
         )
 
     def apply(self) -> Squadron:
+        self.squadron.name = self.name_edit.text()
+        self.squadron.nickname = self.nickname_edit.text()
+        base = self.base_selector.currentData()
+        if base is None:
+            raise RuntimeError("Base cannot be none")
+        self.squadron.assign_to_base(base)
+
         player_names = self.player_list.toPlainText().splitlines()
         # Prepend player pilots so they get set active first.
         self.squadron.pilot_pool = [

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -309,7 +309,6 @@ class AircraftSquadronsPage(QWidget):
 
 class AircraftSquadronsPanel(QStackedLayout):
     page_removed = Signal(AircraftType)
-    squadrons_changed = Signal()
 
     def __init__(self, air_wing: AirWing, theater: ConflictTheater) -> None:
         super().__init__()
@@ -326,7 +325,6 @@ class AircraftSquadronsPanel(QStackedLayout):
         self.squadrons_pages.pop(aircraft_type)
         self.page_removed.emit(aircraft_type)
         self.update()
-        self.squadrons_changed.emit()
 
     def new_page_for_type(
         self, aircraft_type: AircraftType, squadrons: list[Squadron]
@@ -345,7 +343,6 @@ class AircraftSquadronsPanel(QStackedLayout):
             self.new_page_for_type(squadron.aircraft, [squadron])
 
         self.update()
-        self.squadrons_changed.emit()
 
     def apply(self) -> None:
         self.air_wing.squadrons = {}
@@ -528,7 +525,6 @@ class AirWingConfigurationDialog(QDialog):
             name = "Blue" if coalition.player else "Red"
             self.tab_widget.addTab(coalition_tab, name)
             self.tabs.append(coalition_tab)
-            coalition_tab.squadrons_panel.squadrons_changed.connect(self.changed)
 
         buttons_layout = QHBoxLayout()
         apply_button = QPushButton("Accept Changes && Start Campaign")
@@ -541,15 +537,9 @@ class AirWingConfigurationDialog(QDialog):
         buttons_layout.addWidget(apply_button)
         layout.addLayout(buttons_layout)
 
-        self.has_changed = False
-
-    def changed(self) -> None:
-        self.has_changed = True
-
     def revert(self) -> None:
         for tab in self.tabs:
             tab.revert()
-        self.has_changed = False
 
     def accept(self) -> None:
         for tab in self.tabs:
@@ -557,16 +547,15 @@ class AirWingConfigurationDialog(QDialog):
         super().accept()
 
     def reject(self) -> None:
-        if self.has_changed:
-            result = QMessageBox.information(
-                None,
-                "Discard changes?",
-                "Are you sure you want to discard your changes and start the campaign?",
-                QMessageBox.Yes,
-                QMessageBox.No,
-            )
-            if result == QMessageBox.No:
-                return
+        result = QMessageBox.information(
+            None,
+            "Discard changes?",
+            "Are you sure you want to discard your changes and start the campaign?",
+            QMessageBox.Yes,
+            QMessageBox.No,
+        )
+        if result == QMessageBox.No:
+            return
         super().reject()
 
 


### PR DESCRIPTION
I missed something in #2318 where the squadron boxes wouldn't revert. This PR fixes that problem and also removes the "changed check" upon closing the window. Thus closing with [X] is always going to present a confirmation pop-up. The idea is to force people to use the 'Accept' button instead, even if they didn't make any changes.