### PR TITLE
Fix issue 2339

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,8 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed adding additional mission types for a squadron causing error messages when the mission type is not supported by the aircraft type by default
 * **[Mission Generation]** AAA ground units now spawn correctly at the frontline
 * **[UI]** Fixed and issue where the liberation main exe was still running after application close.
+* **[UI]** Disable player slots for non-flyable aircraft.
+
 
 # 5.2.0
 

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -177,12 +177,15 @@ class SquadronConfigurationBox(QGroupBox):
         )
         left_column.addWidget(self.base_selector)
 
-        if squadron.player:
+        if squadron.player and squadron.aircraft.flyable:
             player_label = QLabel(
                 "Players (one per line, leave empty for an AI-only squadron):"
             )
         else:
-            player_label = QLabel("Player slots not available for opfor")
+            msg1 = "Player slots not available for opfor"
+            msg2 = "Player slots not available for non-flyable aircraft"
+            text = msg2 if squadron.player else msg1
+            player_label = QLabel(text)
         left_column.addWidget(player_label)
 
         players = [p for p in squadron.pilot_pool if p.player]
@@ -192,7 +195,7 @@ class SquadronConfigurationBox(QGroupBox):
             players = []
         self.player_list = QTextEdit("<br />".join(p.name for p in players))
         self.player_list.setAcceptRichText(False)
-        self.player_list.setEnabled(squadron.player)
+        self.player_list.setEnabled(squadron.player and squadron.aircraft.flyable)
         left_column.addWidget(self.player_list)
         delete_button = QPushButton("Remove Squadron")
         delete_button.setMaximumWidth(140)

--- a/qt_ui/windows/mission/flight/settings/QFlightSlotEditor.py
+++ b/qt_ui/windows/mission/flight/settings/QFlightSlotEditor.py
@@ -94,6 +94,10 @@ class PilotControls(QHBoxLayout):
         self.player_checkbox = QCheckBox(text="Player")
         self.player_checkbox.setToolTip("Checked if this pilot is a player.")
         self.on_pilot_changed(self.selector.currentIndex())
+        enabled = False
+        if self.roster is not None and self.roster.squadron is not None:
+            enabled = self.roster.squadron.aircraft.flyable
+        self.player_checkbox.setEnabled(enabled)
         self.addWidget(self.player_checkbox)
 
         self.player_checkbox.toggled.connect(self.on_player_toggled)


### PR DESCRIPTION
Resolves #2339 

For this 2 things needed to happen:

- QFlightSlotEditor needed to take the squadron's aircraft into account (check if flyable) to decide whether it should disable the "player checkbox"
- The AirWingConfigurationDialog (specifically in SquadronConfigurationBox) required disabling the "player list" so user can't add players. This would happen for opfor, but not for non-flyable aircraft on blue's side.

Merging #2340 should automatically grey out the "player checkboxes" in the flight edit/create dialog.