### PR TITLE
Update pydcs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Saves from 5.x are not compatible with 6.0.
 
 ## Features/Improvements
 
-* **[Engine]** Support for DCS 2.7.12.23362 with the new units (technicals & EWR) and the ACLS & Link4
+* **[Engine]** Support for DCS 2.7.16.27869 with the new units (technicals & EWR) and the ACLS & Link4
 * **[Mission Generation]** Added an option to fast-forward mission generation until the point of first contact (WIP).
 * **[Mission Generation]** Added performance option to not cull IADS when culling would effect how mission is played at target area.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pluggy==1.0.0
 pre-commit==2.19.0
 py==1.11.0
 pydantic==1.9.1
--e git+https://github.com/pydcs/dcs@f95006776f65e14c1fa06de1dd14f8aab670bb97#egg=pydcs
+-e git+https://github.com/pydcs/dcs@ca682e883449164d39401750cdc1c974bc902064#egg=pydcs
 pyinstaller==5.2
 pyinstaller-hooks-contrib==2022.8
 pyparsing==3.0.9


### PR DESCRIPTION
Last version of pydcs was missing flyable aircraft, specifically the following:
- Mi-24P
- I-16
- Christen Eagle II
- Mirage-F1CE

It also removed the flyable option for the F/A-18C, i.e. the AI variant.
Note that the flyable F-18's ID is "FA-18C_hornet".
