### PR TITLE
Fix #2011

### DIFF
--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -158,12 +158,11 @@ class DefaultSquadronAssigner:
         if squadron_def is None:
             return None
 
-        overrides: Dict[str, Union[str, int]] = {}
         if config.name is not None:
-            overrides["name"] = config.name
+            squadron_def.name = config.name
         if config.nickname is not None:
-            overrides["nickname"] = config.nickname
+            squadron_def.nickname = config.nickname
         if config.female_pilot_percentage is not None:
-            overrides["female_pilot_percentage"] = config.female_pilot_percentage
+            squadron_def.female_pilot_percentage = config.female_pilot_percentage
 
-        return dataclasses.replace(squadron_def, **overrides)
+        return squadron_def


### PR DESCRIPTION
Fix #2011 

@Khopa I wonder why you didn't overwrite the attributes of the `squadron_def` straight away, because I concluded that 'dataclass.replace' returns a new object which causes a problem, since the "claiming" of squadrons is still linked to the original 'squadron_def' object, and thus the claim that happens in 'Squadron.create_from' (game/squadrons/squadron.py) doesn't have any effect.

What are your thoughts? Does this approach seem reasonable or was there a specific reason you chose to work with `dataclass.replace`?