### PR TITLE
Pilot leveling flag behaves the opposite

### DIFF
--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -201,7 +201,7 @@ class FlightGroupConfigurator:
         missions_for_skill_increase = 4
         increase = pilot.record.missions_flown // missions_for_skill_increase
         capped_increase = min(current_level + increase, len(levels) - 1)
-        new_level = (capped_increase, current_level)[
+        new_level = (current_level, capped_increase)[
             self.game.settings.ai_pilot_levelling
         ]
         return levels[new_level]


### PR DESCRIPTION
I ran into an issue with pilot leveling. 

The checkbox under Settings -> Campaign Management -> Allow AI Pilot Leveling sets the flag true if checked.

When the flag is evaluated in the below changed snippet, the expression behaves exactly the opposite and increases the levels if not checked and vice versa. Swapping should fix.

