### PR TITLE
Fix default payloads for Mirage F1

### DIFF
--- a/resources/customized_payloads/Mirage-F1B.lua
+++ b/resources/customized_payloads/Mirage-F1B.lua
@@ -2,7 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1B",
 	["payloads"] = {
 		[1] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -38,8 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -75,7 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -103,8 +102,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -132,8 +130,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -169,8 +166,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -198,8 +194,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -235,8 +230,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -272,8 +266,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -301,8 +294,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",

--- a/resources/customized_payloads/Mirage-F1BE.lua
+++ b/resources/customized_payloads/Mirage-F1BE.lua
@@ -2,7 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1BE",
 	["payloads"] = {
 		[1] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -38,8 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -75,7 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -103,8 +102,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -132,8 +130,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -169,8 +166,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -198,8 +194,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -235,8 +230,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -272,8 +266,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -301,8 +294,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",

--- a/resources/customized_payloads/Mirage-F1C-200.lua
+++ b/resources/customized_payloads/Mirage-F1C-200.lua
@@ -2,7 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1C-200",
 	["payloads"] = {
 		[1] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -38,8 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -75,7 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -103,8 +102,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -132,8 +130,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -169,8 +166,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -198,8 +194,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -235,8 +230,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -272,8 +266,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",
@@ -301,8 +294,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{R550_Magic_1}",

--- a/resources/customized_payloads/Mirage-F1CE.lua
+++ b/resources/customized_payloads/Mirage-F1CE.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1CE",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -39,7 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -75,8 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -112,8 +110,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -141,8 +138,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -178,8 +174,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -207,8 +202,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -244,8 +238,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -281,7 +274,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -309,8 +302,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",

--- a/resources/customized_payloads/Mirage-F1CT.lua
+++ b/resources/customized_payloads/Mirage-F1CT.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1CT",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation BAI",
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -39,8 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -76,7 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -104,8 +102,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -133,8 +130,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -170,8 +166,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -199,8 +194,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -236,8 +230,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -273,8 +266,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -302,8 +294,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",

--- a/resources/customized_payloads/Mirage-F1EE.lua
+++ b/resources/customized_payloads/Mirage-F1EE.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1EE",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -39,7 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -75,8 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -112,8 +110,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -141,8 +138,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -178,8 +174,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -207,8 +202,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -244,8 +238,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -281,7 +274,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -309,8 +302,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",

--- a/resources/customized_payloads/Mirage-F1EQ.lua
+++ b/resources/customized_payloads/Mirage-F1EQ.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1EQ",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -39,7 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -75,8 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -112,8 +110,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -141,8 +138,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -178,8 +174,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -207,8 +202,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -244,8 +238,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -281,7 +274,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -309,8 +302,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",

--- a/resources/customized_payloads/Mirage-F1M-CE.lua
+++ b/resources/customized_payloads/Mirage-F1M-CE.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1M-CE",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -39,7 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -75,8 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -112,8 +110,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -141,8 +138,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -178,8 +174,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -207,8 +202,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -244,8 +238,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -281,7 +274,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -309,8 +302,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",

--- a/resources/customized_payloads/Mirage-F1M-EE.lua
+++ b/resources/customized_payloads/Mirage-F1M-EE.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "Mirage-F1M-EE",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["name"] = "Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -39,7 +38,7 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["name"] = "Liberation BAI",
+			["name"] = "BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -75,8 +74,7 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["name"] = "DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -112,8 +110,7 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
+			["name"] = "Fighter Sweep",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -141,8 +138,7 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -178,8 +174,7 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -207,8 +202,7 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
+			["name"] = "OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -244,8 +238,7 @@ local unitPayloads = {
 			},
 		},
 		[8] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["name"] = "OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -281,7 +274,7 @@ local unitPayloads = {
 			},
 		},
 		[9] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
@@ -309,8 +302,7 @@ local unitPayloads = {
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation Escort",
-			["name"] = "Liberation Escort",
+			["name"] = "Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",


### PR DESCRIPTION
Payloads are not showing up automatically, and thus the aircraft get generated without weapons. Apparently I missed the fact that the names of the payloads must exactly correspond with the mission type.