### PR TITLE
Corrected the naming of Ural-375 ZU-23 Insurgent / Ural-375 ZU-23 grou…

### DIFF
--- a/resources/factions/insurgents.json
+++ b/resources/factions/insurgents.json
@@ -32,8 +32,8 @@
   "missiles": [],
   "air_defense_units": [
     "SA-9 Strela",
-    "AAA ZU-23 Closed Emplacement",
-    "ZU-23 on Ural-375",
+    "AAA ZU-23 Insurgent Closed Emplacement",
+    "ZU-23 on Ural-375 Insurgent",
     "ZSU-23-4 Shilka"
   ],
   "preset_groups": [],

--- a/resources/factions/insurgents_hard.json
+++ b/resources/factions/insurgents_hard.json
@@ -37,8 +37,8 @@
   "air_defense_units": [
     "SA-9 Strela",
     "ZSU-57-2 'Sparka'",
-    "AAA ZU-23 Closed Emplacement",
-    "ZU-23 on Ural-375"
+    "AAA ZU-23 Insurgent Closed Emplacement",
+    "ZU-23 on Ural-375 Insurgent"
   ],
   "preset_groups": [],
   "naval_units": [],

--- a/resources/units/ground_units/Ural-375 ZU-23 Insurgent.yaml
+++ b/resources/units/ground_units/Ural-375 ZU-23 Insurgent.yaml
@@ -1,15 +1,12 @@
 class: AAA
-description: "The ZSU-57-2 Ob'yekt 500 is a Soviet self-propelled anti-aircraft gun\
-  \ (SPAAG), armed with two 57 mm autocannons. 'ZSU' stands for Zenitnaya Samokhodnaya\
-  \ Ustanovka (Russian: \u0417\u0435\u043D\u0438\u0442\u043D\u0430\u044F \u0421\u0430\
-  \u043C\u043E\u0445\u043E\u0434\u043D\u0430\u044F \u0423\u0441\u0442\u0430\u043D\u043E\
-  \u0432\u043A\u0430), meaning \"anti-aircraft self-propelled mount\", '57' stands\
-  \ for the bore of the armament in millimetres and '2' stands for the number of gun\
-  \ barrels. It was the first Soviet mass-produced tracked SPAAG."
+description:
+  The ZU-23-2 is a Soviet towed 23×152mm anti-aircraft twin-barreled
+  autocannon. ZU stands for Zenitnaya Ustanovka – anti-aircraft mount.
+  This variant is mounted on the bed of an Ural-375 6x6 truck.
 introduced: 1961
 manufacturer: KBP/Ural
 origin: USSR/Russia
 price: 7
 role: Self-Propelled Anti-Aircraft Gun
 variants:
-  ZU-23 on Ural-375: {}
+  ZU-23 on Ural-375 Insurgent: {}

--- a/resources/units/ground_units/Ural-375 ZU-23.yaml
+++ b/resources/units/ground_units/Ural-375 ZU-23.yaml
@@ -1,11 +1,8 @@
 class: AAA
-description: "The ZSU-57-2 Ob'yekt 500 is a Soviet self-propelled anti-aircraft gun\
-  \ (SPAAG), armed with two 57 mm autocannons. 'ZSU' stands for Zenitnaya Samokhodnaya\
-  \ Ustanovka (Russian: \u0417\u0435\u043D\u0438\u0442\u043D\u0430\u044F \u0421\u0430\
-  \u043C\u043E\u0445\u043E\u0434\u043D\u0430\u044F \u0423\u0441\u0442\u0430\u043D\u043E\
-  \u0432\u043A\u0430), meaning \"anti-aircraft self-propelled mount\", '57' stands\
-  \ for the bore of the armament in millimetres and '2' stands for the number of gun\
-  \ barrels. It was the first Soviet mass-produced tracked SPAAG."
+description:
+  The ZU-23-2 is a Soviet towed 23×152mm anti-aircraft twin-barreled
+  autocannon. ZU stands for Zenitnaya Ustanovka – anti-aircraft mount.
+  This variant is mounted on the bed of an Ural-375 6x6 truck.
 introduced: 1961
 manufacturer: KBP/Ural
 origin: USSR/Russia

--- a/resources/units/ground_units/ZU-23 Closed Insurgent.yaml
+++ b/resources/units/ground_units/ZU-23 Closed Insurgent.yaml
@@ -1,4 +1,8 @@
 class: AAA
+description:
+  The ZU-23-2 is a Soviet towed 23×152mm anti-aircraft twin-barreled
+  autocannon. ZU stands for Zenitnaya Ustanovka – anti-aircraft mount.
+  This variant is mounted on a closed emplacement.
 price: 6
 variants:
   AAA ZU-23 Insurgent Closed Emplacement: null

--- a/resources/units/ground_units/ZU-23 Emplacement Closed.yaml
+++ b/resources/units/ground_units/ZU-23 Emplacement Closed.yaml
@@ -1,4 +1,8 @@
 class: AAA
+description:
+  The ZU-23-2 is a Soviet towed 23×152mm anti-aircraft twin-barreled
+  autocannon. ZU stands for Zenitnaya Ustanovka – anti-aircraft mount.
+  This variant is mounted on a closed emplacement.
 price: 6
 variants:
   AAA ZU-23 Closed Emplacement: null

--- a/resources/units/ground_units/ZU-23 Emplacement.yaml
+++ b/resources/units/ground_units/ZU-23 Emplacement.yaml
@@ -1,4 +1,7 @@
 class: AAA
+description:
+  The ZU-23-2 is a Soviet towed 23×152mm anti-aircraft twin-barreled
+  autocannon. ZU stands for Zenitnaya Ustanovka – anti-aircraft mount.
 price: 6
 variants:
   AAA ZU-23 Emplacement: null

--- a/resources/units/ground_units/ZU-23 Insurgent.yaml
+++ b/resources/units/ground_units/ZU-23 Insurgent.yaml
@@ -1,4 +1,7 @@
 class: AAA
+description:
+  The ZU-23-2 is a Soviet towed 23×152mm anti-aircraft twin-barreled
+  autocannon. ZU stands for Zenitnaya Ustanovka – anti-aircraft mount.
 price: 6
 variants:
   AAA ZU-23 Insurgent Emplacement: null


### PR DESCRIPTION
…nd units. Previously, only the insurgent variant was used because the names were identical. Also added descriptions to all ZU-23 variants and specified that the insurgent variants are used with both Insurgent factions.