### PR TITLE
Implemented GroundForcePainter for applying custom liveries to ground…

### DIFF
--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -112,6 +112,9 @@ class Faction:
     # List of default livery overrides
     liveries_overrides: Dict[AircraftType, List[str]] = field(default_factory=dict)
 
+    # List of default livery overrides for ground vehicles
+    liveries_overrides_ground_forces: Dict[str, List[str]] = field(default_factory=dict)
+
     #: Set to True if the faction should force the "Unrestricted satnav" option
     #: for the mission. This option enables GPS for capable aircraft regardless
     #: of the time period or operator. For example, the CJTF "countries" don't

--- a/game/game.py
+++ b/game/game.py
@@ -201,6 +201,11 @@ class Game:
             return self.blue
         return self.red
 
+    def coalition_for_country(self, country: str) -> Coalition:
+        if country == self.blue.country_name:
+            return self.blue
+        return self.red
+
     def adjust_budget(self, amount: float, player: bool) -> None:
         self.coalition_for(player).adjust_budget(amount)
 

--- a/game/missiongenerator/aircraft/aircraftpainter.py
+++ b/game/missiongenerator/aircraft/aircraftpainter.py
@@ -6,6 +6,8 @@ from typing import Any, Optional
 from dcs.unitgroup import FlyingGroup
 
 from game.ato import Flight
+from game.dcs.aircrafttype import AircraftType
+from game.factions import Faction
 
 
 class AircraftPainter:
@@ -42,3 +44,29 @@ class AircraftPainter:
             return
         for unit in self.group.units:
             unit.livery_id = livery
+
+
+class AircraftPainterJtac(AircraftPainter):
+    def __init__(
+        self, faction: Faction, unit_type: AircraftType, group: FlyingGroup[Any]
+    ) -> None:
+        self.faction = faction
+        self.unit_type = unit_type
+        self.group = group
+
+    def livery_from_unit_type(self) -> Optional[str]:
+        return self.unit_type.default_livery
+
+    def livery_from_faction(self) -> Optional[str]:
+        faction = self.faction
+
+        if (choices := faction.liveries_overrides.get(self.unit_type)) is not None:
+            return random.choice(choices)
+        return None
+
+    def determine_livery(self) -> Optional[str]:
+        if (livery := self.livery_from_faction()) is not None:
+            return livery
+        if (livery := self.livery_from_unit_type()) is not None:
+            return livery
+        return None

--- a/game/missiongenerator/convoygenerator.py
+++ b/game/missiongenerator/convoygenerator.py
@@ -10,6 +10,7 @@ from dcs.unit import Vehicle
 from dcs.unitgroup import VehicleGroup
 
 from game.dcs.groundunittype import GroundUnitType
+from game.missiongenerator.groundforcepainter import GroundForcePainter
 from game.transfers import Convoy
 from game.unitmap import UnitMap
 from game.utils import kph
@@ -71,6 +72,7 @@ class ConvoyGenerator:
         for_player: bool,
     ) -> VehicleGroup:
         country = self.mission.country(self.game.coalition_for(for_player).country_name)
+        faction = self.game.coalition_for(for_player).faction
 
         unit_types = list(units.items())
         main_unit_type, main_unit_count = unit_types[0]
@@ -96,6 +98,7 @@ class ConvoyGenerator:
                 v.position.x = position.x
                 v.position.y = next(y)
                 v.heading = 0
+                GroundForcePainter(faction, v).apply_livery()
                 group.add_unit(v)
 
         return group

--- a/game/missiongenerator/groundforcepainter.py
+++ b/game/missiongenerator/groundforcepainter.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, Optional
+
+from dcs.unitgroup import Vehicle
+
+from game.factions.faction import Faction
+
+
+class GroundForcePainter:
+    def __init__(self, faction: Faction, vehicle: Vehicle) -> None:
+        self.faction = faction
+        self.vehicle = vehicle
+
+    def livery_from_faction(self) -> Optional[str]:
+        faction = self.faction
+        try:
+            if (
+                choices := faction.liveries_overrides_ground_forces.get(
+                    self.vehicle.type
+                )
+            ) is not None:
+                return random.choice(choices)
+        except AttributeError:
+            logging.warning(
+                f"Faction {self.faction.name} is missing livery for ground unit {self.vehicle.type}"
+            )
+            return None
+        logging.warning(
+            f"Faction {self.faction.name} is missing livery for ground unit {self.vehicle.type}"
+        )
+        return None
+
+    def determine_livery(self) -> Optional[str]:
+        if (livery := self.livery_from_faction()) is not None:
+            return livery
+        return None
+
+    def apply_livery(self) -> None:
+        livery = self.determine_livery()
+        if livery is None:
+            return
+        self.vehicle.livery_id = livery

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -41,6 +41,8 @@ from dcs.unit import Unit, InvisibleFARP
 from dcs.unitgroup import MovingGroup, ShipGroup, StaticGroup, VehicleGroup
 from dcs.unittype import ShipType, VehicleType
 from dcs.vehicles import vehicle_map
+
+from game.missiongenerator.groundforcepainter import GroundForcePainter
 from game.missiongenerator.missiondata import CarrierInfo, MissionData
 
 from game.radio.radios import RadioFrequency, RadioRegistry
@@ -124,6 +126,7 @@ class GroundObjectGenerator:
         vehicle_group: Optional[VehicleGroup] = None
         for unit in units:
             assert issubclass(unit.type, VehicleType)
+            faction = self.game.coalition_for_country(self.country.name).faction
             if vehicle_group is None:
                 vehicle_group = self.m.vehicle_group(
                     self.country,
@@ -136,11 +139,13 @@ class GroundObjectGenerator:
                 self.enable_eplrs(vehicle_group, unit.type)
                 vehicle_group.units[0].name = unit.unit_name
                 self.set_alarm_state(vehicle_group)
+                GroundForcePainter(faction, vehicle_group.units[0]).apply_livery()
             else:
                 vehicle_unit = self.m.vehicle(unit.unit_name, unit.type)
                 vehicle_unit.player_can_drive = True
                 vehicle_unit.position = unit.position
                 vehicle_unit.heading = unit.position.heading.degrees
+                GroundForcePainter(faction, vehicle_unit).apply_livery()
                 vehicle_group.add_unit(vehicle_unit)
             self._register_theater_unit(unit, vehicle_group.units[-1])
         if vehicle_group is None:


### PR DESCRIPTION
… units. The liveries can be applied to front line objects (including infantry), convoys and TGOs.

Also implemented AircraftPainterJtac for applying a livery from the faction to generated JTAC air units.

This is only a draft for now, since it's getting the ground force liveries from the faction file. This has already been discussed on #dev and will not be the final way to find out the liveries.