### PR TITLE
Refactor 'grey-out' CSS

### DIFF
--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -391,11 +391,8 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
         mapSettingsLayout.addWidget(QtWidgets.QLabel("Invert Map"), 0, 0)
         mapSettingsLayout.addWidget(invertMap, 0, 1)
         self.advanced_iads = QtWidgets.QCheckBox()
-        disabled_grey_out = "QCheckBox::indicator:disabled{ background-color: rgba(255, 255, 255, 5%); }"
-        self.advanced_iads.setStyleSheet(disabled_grey_out)
         self.registerField("advanced_iads", self.advanced_iads)
         self.iads_label = QtWidgets.QLabel("Advanced IADS (WIP)")
-        self.iads_label.setStyleSheet("QLabel:disabled{color: #888888}")
         mapSettingsLayout.addWidget(self.iads_label, 1, 0)
         mapSettingsLayout.addWidget(self.advanced_iads, 1, 1)
         mapSettingsGroup.setLayout(mapSettingsLayout)

--- a/resources/stylesheets/style-dcs.css
+++ b/resources/stylesheets/style-dcs.css
@@ -231,6 +231,10 @@ QLabel{
     border: none;
 }
 
+QLabel:disabled {
+    color: #888888;
+}
+
 QLabel[style="base-title"]{
     font-size: 24px;
 }
@@ -381,6 +385,13 @@ QGroupBox::indicator:unchecked , QCheckBox::indicator:unchecked {
 
 QGroupBox::indicator:checked , QCheckBox::indicator:checked {
 image: url(resources/stylesheets/check.png);
+}
+
+QCheckBox:disabled {
+    color: #888888;
+}
+QCheckBox::indicator:disabled {
+    background-color: rgba(255, 255, 255, 5%);
 }
 
 

--- a/resources/stylesheets/style.css
+++ b/resources/stylesheets/style.css
@@ -192,3 +192,14 @@ QWidget[style="baseMenuHeader"]{
 QLabel[style="small"]{
     font-size: 8px;
 }
+
+QCheckBox:disabled {
+    color: #888888;
+}
+QCheckBox::indicator:disabled {
+    background-color: rgba(255, 255, 255, 5%);
+}
+
+QLabel:disabled {
+    color: #888888;
+}


### PR DESCRIPTION
The CSS used to grey out the checkbox and label for
advanced IADS should be refactored so it can be reused for
disabling player checkboxes in the flight edit/create dialogs.

The solution is applied to all checkboxes/labels, so that
there's a consistent way of showing users when a
checkbox/label is disabled.

(cherry picked from commit d9c6be0a9d232f73269da720bf7c0f4dfa1b9329)