### PR TITLE
Disable player options for non-flyable aircraft

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,8 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed adding additional mission types for a squadron causing error messages when the mission type is not supported by the aircraft type by default
 * **[Mission Generation]** AAA ground units now spawn correctly at the frontline
 * **[UI]** Fixed and issue where the liberation main exe was still running after application close.
+* **[UI]** Disable player slots for non-flyable aircraft.
+
 
 # 5.2.0
 

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Iterator
+from typing import Iterable, Iterator, Optional
 
 from PySide2.QtCore import (
     QItemSelection,
@@ -9,25 +9,26 @@ from PySide2.QtCore import (
 )
 from PySide2.QtGui import QIcon, QStandardItem, QStandardItemModel
 from PySide2.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QDialog,
+    QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
     QListView,
+    QMessageBox,
+    QPushButton,
     QScrollArea,
     QStackedLayout,
     QTabWidget,
     QTextEdit,
+    QToolButton,
     QVBoxLayout,
     QWidget,
-    QCheckBox,
-    QPushButton,
-    QGridLayout,
-    QToolButton,
-    QMessageBox,
 )
+
 from game import Game
 from game.ato.flighttype import FlightType
 from game.coalition import Coalition
@@ -177,12 +178,14 @@ class SquadronConfigurationBox(QGroupBox):
         )
         left_column.addWidget(self.base_selector)
 
-        if squadron.player:
+        if not squadron.player and squadron.aircraft.flyable:
+            player_label = QLabel("Player slots not available for opfor")
+        elif not squadron.aircraft.flyable:
+            player_label = QLabel("Player slots not available for non-flyable aircraft")
+        else:
             player_label = QLabel(
                 "Players (one per line, leave empty for an AI-only squadron):"
             )
-        else:
-            player_label = QLabel("Player slots not available for opfor")
         left_column.addWidget(player_label)
 
         players = [p for p in squadron.pilot_pool if p.player]
@@ -192,7 +195,7 @@ class SquadronConfigurationBox(QGroupBox):
             players = []
         self.player_list = QTextEdit("<br />".join(p.name for p in players))
         self.player_list.setAcceptRichText(False)
-        self.player_list.setEnabled(squadron.player)
+        self.player_list.setEnabled(squadron.player and squadron.aircraft.flyable)
         left_column.addWidget(self.player_list)
         delete_button = QPushButton("Remove Squadron")
         delete_button.setMaximumWidth(140)

--- a/qt_ui/windows/mission/flight/settings/QFlightSlotEditor.py
+++ b/qt_ui/windows/mission/flight/settings/QFlightSlotEditor.py
@@ -94,6 +94,10 @@ class PilotControls(QHBoxLayout):
         self.player_checkbox = QCheckBox(text="Player")
         self.player_checkbox.setToolTip("Checked if this pilot is a player.")
         self.on_pilot_changed(self.selector.currentIndex())
+        enabled = False
+        if self.roster is not None and self.roster.squadron is not None:
+            enabled = self.roster.squadron.aircraft.flyable
+        self.player_checkbox.setEnabled(enabled)
         self.addWidget(self.player_checkbox)
 
         self.player_checkbox.toggled.connect(self.on_player_toggled)


### PR DESCRIPTION
3 items handled:

- Enable/Disable player checkbox if (not) flyable
- Disable player list in air wing config dialog for non-flyable aircraft
- Update changelog

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2339.

(cherry picked from commit 18057af9ad9212e750b2338add1bc01bf50b868e)