### PR TITLE
Move FlightPlan creation into Flight.

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -194,9 +194,7 @@ class Flight(SidcDescribable):
     def abort(self) -> None:
         from .flightplans.rtb import RtbFlightPlan
 
-        self.flight_plan = RtbFlightPlan.builder_type()(
-            self, self.coalition.game.theater
-        ).build()
+        self.flight_plan = RtbFlightPlan.builder_type()(self).build()
 
         self.set_state(
             Navigating(

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -7,10 +7,12 @@ from typing import Any, List, Optional, TYPE_CHECKING
 from dcs import Point
 from dcs.planes import C_101CC, C_101EB, Su_33
 
+from .flightplans.planningerror import PlanningError
 from .flightroster import FlightRoster
 from .flightstate import FlightState, Navigating, Uninitialized
 from .flightstate.killed import Killed
 from .loadouts import Loadout
+from .packagewaypoints import PackageWaypoints
 from ..sidc import (
     Entity,
     SidcDescribable,
@@ -81,9 +83,9 @@ class Flight(SidcDescribable):
         # Used for simulating the travel to first contact.
         self.state: FlightState = Uninitialized(self, squadron.settings)
 
-        # Will be replaced with a more appropriate FlightPlan by
-        # FlightPlanBuilder, but an empty flight plan the flight begins with an
-        # empty flight plan.
+        # Will be replaced with a more appropriate FlightPlan later, but start with a
+        # cheaply constructed one since adding more flights to the package may affect
+        # the optimal layout.
         from .flightplans.custom import CustomFlightPlan, CustomLayout
 
         self.flight_plan: FlightPlan[Any] = CustomFlightPlan(
@@ -243,3 +245,24 @@ class Flight(SidcDescribable):
         for pilot in self.roster.pilots:
             if pilot is not None:
                 results.kill_pilot(self, pilot)
+
+    def recreate_flight_plan(self) -> None:
+        self.flight_plan = self._make_flight_plan()
+
+    def _make_flight_plan(self) -> FlightPlan[Any]:
+        from game.navmesh import NavMeshError
+        from .flightplans.flightplanbuildertypes import FlightPlanBuilderTypes
+
+        try:
+            if self.package.waypoints is None:
+                self.package.waypoints = PackageWaypoints.create(
+                    self.package, self.coalition
+                )
+            builder = FlightPlanBuilderTypes.for_flight(self)(self)
+            return builder.build()
+        except NavMeshError as ex:
+            color = "blue" if self.squadron.player else "red"
+            raise PlanningError(
+                f"Could not plan {color} {self.flight_type.value} from "
+                f"{self.departure} to {self.package.target}"
+            ) from ex

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -194,8 +194,9 @@ class Flight(SidcDescribable):
     def abort(self) -> None:
         from .flightplans.rtb import RtbFlightPlan
 
-        layout = RtbFlightPlan.builder_type()(self, self.coalition.game.theater).build()
-        self.flight_plan = RtbFlightPlan(self, layout)
+        self.flight_plan = RtbFlightPlan.builder_type()(
+            self, self.coalition.game.theater
+        ).build()
 
         self.set_state(
             Navigating(

--- a/game/ato/flightplans/antiship.py
+++ b/game/ato/flightplans/antiship.py
@@ -20,8 +20,8 @@ class AntiShipFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[AntiShipFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
         from game.transfers import CargoShip
@@ -40,3 +40,6 @@ class Builder(FormationAttackBuilder):
     @staticmethod
     def anti_ship_targets_for_tgo(tgo: NavalGroundObject) -> list[StrikeTarget]:
         return [StrikeTarget(f"{g.group_name} at {tgo.name}", g) for g in tgo.groups]
+
+    def build(self) -> AntiShipFlightPlan:
+        return AntiShipFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/bai.py
+++ b/game/ato/flightplans/bai.py
@@ -19,8 +19,8 @@ class BaiFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[BaiFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
         from game.transfers import Convoy
@@ -38,3 +38,6 @@ class Builder(FormationAttackBuilder):
             raise InvalidObjectiveLocation(self.flight.flight_type, location)
 
         return self._build(FlightWaypointType.INGRESS_BAI, targets)
+
+    def build(self) -> BaiFlightPlan:
+        return BaiFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/barcap.py
+++ b/game/ato/flightplans/barcap.py
@@ -12,8 +12,28 @@ from .patrolling import PatrollingFlightPlan, PatrollingLayout
 from .waypointbuilder import WaypointBuilder
 
 
-class Builder(CapBuilder):
-    def build(self) -> PatrollingLayout:
+class BarCapFlightPlan(PatrollingFlightPlan[PatrollingLayout]):
+    @staticmethod
+    def builder_type() -> Type[Builder]:
+        return Builder
+
+    @property
+    def patrol_duration(self) -> timedelta:
+        return self.flight.coalition.doctrine.cap_duration
+
+    @property
+    def patrol_speed(self) -> Speed:
+        return self.flight.unit_type.preferred_patrol_speed(
+            self.layout.patrol_start.alt
+        )
+
+    @property
+    def engagement_distance(self) -> Distance:
+        return self.flight.coalition.doctrine.cap_engagement_range
+
+
+class Builder(CapBuilder[BarCapFlightPlan, PatrollingLayout]):
+    def layout(self) -> PatrollingLayout:
         location = self.package.target
 
         if isinstance(location, FrontLine):
@@ -46,22 +66,5 @@ class Builder(CapBuilder):
             bullseye=builder.bullseye(),
         )
 
-
-class BarCapFlightPlan(PatrollingFlightPlan[PatrollingLayout]):
-    @staticmethod
-    def builder_type() -> Type[Builder]:
-        return Builder
-
-    @property
-    def patrol_duration(self) -> timedelta:
-        return self.flight.coalition.doctrine.cap_duration
-
-    @property
-    def patrol_speed(self) -> Speed:
-        return self.flight.unit_type.preferred_patrol_speed(
-            self.layout.patrol_start.alt
-        )
-
-    @property
-    def engagement_distance(self) -> Distance:
-        return self.flight.coalition.doctrine.cap_engagement_range
+    def build(self) -> BarCapFlightPlan:
+        return BarCapFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/capbuilder.py
+++ b/game/ato/flightplans/capbuilder.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import random
 from abc import ABC
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, TypeVar
 
 from dcs import Point
 from shapely.geometry import Point as ShapelyPoint
 
 from game.utils import Heading, meters, nautical_miles
+from .flightplan import FlightPlan
+from .patrolling import PatrollingLayout
 from ..closestairfields import ObjectiveDistanceCache
 from ..flightplans.ibuilder import IBuilder
 from ..flightplans.planningerror import PlanningError
@@ -15,8 +17,11 @@ from ..flightplans.planningerror import PlanningError
 if TYPE_CHECKING:
     from game.theater import MissionTarget
 
+FlightPlanT = TypeVar("FlightPlanT", bound=FlightPlan[Any])
+LayoutT = TypeVar("LayoutT", bound=PatrollingLayout)
 
-class CapBuilder(IBuilder, ABC):
+
+class CapBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
     def cap_racetrack_for_objective(
         self, location: MissionTarget, barcap: bool
     ) -> tuple[Point, Point]:

--- a/game/ato/flightplans/custom.py
+++ b/game/ato/flightplans/custom.py
@@ -13,11 +13,6 @@ if TYPE_CHECKING:
     from ..flightwaypoint import FlightWaypoint
 
 
-class Builder(IBuilder):
-    def build(self) -> CustomLayout:
-        return CustomLayout([])
-
-
 @dataclass(frozen=True)
 class CustomLayout(Layout):
     custom_waypoints: list[FlightWaypoint]
@@ -55,3 +50,11 @@ class CustomFlightPlan(FlightPlan[CustomLayout]):
     @property
     def mission_departure_time(self) -> timedelta:
         return self.package.time_over_target
+
+
+class Builder(IBuilder[CustomFlightPlan, CustomLayout]):
+    def layout(self) -> CustomLayout:
+        return CustomLayout([])
+
+    def build(self) -> CustomFlightPlan:
+        return CustomFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/dead.py
+++ b/game/ato/flightplans/dead.py
@@ -22,8 +22,8 @@ class DeadFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[DeadFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
         is_ewr = isinstance(location, EwrGroundObject)
@@ -36,3 +36,6 @@ class Builder(FormationAttackBuilder):
             raise InvalidObjectiveLocation(self.flight.flight_type, location)
 
         return self._build(FlightWaypointType.INGRESS_DEAD)
+
+    def build(self) -> DeadFlightPlan:
+        return DeadFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/escort.py
+++ b/game/ato/flightplans/escort.py
@@ -16,8 +16,8 @@ class EscortFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[EscortFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         assert self.package.waypoints is not None
 
         builder = WaypointBuilder(self.flight, self.coalition)
@@ -51,3 +51,6 @@ class Builder(FormationAttackBuilder):
             divert=builder.divert(self.flight.divert),
             bullseye=builder.bullseye(),
         )
+
+    def build(self) -> EscortFlightPlan:
+        return EscortFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/flightplan.py
+++ b/game/ato/flightplans/flightplan.py
@@ -8,15 +8,14 @@ generating the waypoints for the mission.
 from __future__ import annotations
 
 import math
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Iterator
 from datetime import timedelta
 from functools import cached_property
-from typing import Any, Generic, TYPE_CHECKING, Type, TypeGuard, TypeVar
+from typing import Any, Generic, TYPE_CHECKING, TypeGuard, TypeVar
 
 from game.typeguard import self_type_guard
 from game.utils import Distance, Speed, meters
-from .ibuilder import IBuilder
 from .planningerror import PlanningError
 from ..flightwaypointtype import FlightWaypointType
 from ..starttype import StartType
@@ -63,11 +62,6 @@ class FlightPlan(ABC, Generic[LayoutT]):
     @property
     def package(self) -> Package:
         return self.flight.package
-
-    @staticmethod
-    @abstractmethod
-    def builder_type() -> Type[IBuilder]:
-        ...
 
     @property
     def waypoints(self) -> list[FlightWaypoint]:

--- a/game/ato/flightplans/flightplanbuilder.py
+++ b/game/ato/flightplans/flightplanbuilder.py
@@ -108,4 +108,4 @@ class FlightPlanBuilder:
             ) from ex
 
     def generate_flight_plan(self, flight: Flight) -> FlightPlan[Any]:
-        return self.builder_type(flight)(flight, self.theater).build()
+        return self.builder_type(flight)(flight).build()

--- a/game/ato/flightplans/flightplanbuilder.py
+++ b/game/ato/flightplans/flightplanbuilder.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Type
 
 from game.ato import FlightType
-from game.ato.closestairfields import ObjectiveDistanceCache
-from game.data.doctrine import Doctrine
-from game.flightplan import IpZoneGeometry, JoinZoneGeometry
-from game.flightplan.refuelzonegeometry import RefuelZoneGeometry
 from .aewc import AewcFlightPlan
 from .airassault import AirAssaultFlightPlan
 from .airlift import AirliftFlightPlan
@@ -27,13 +23,12 @@ from .strike import StrikeFlightPlan
 from .sweep import SweepFlightPlan
 from .tarcap import TarCapFlightPlan
 from .theaterrefueling import TheaterRefuelingFlightPlan
-from .waypointbuilder import WaypointBuilder
+from ..packagewaypoints import PackageWaypoints
 
 if TYPE_CHECKING:
-    from game.ato import Flight, FlightWaypoint, Package
+    from game.ato import Flight, Package
     from game.coalition import Coalition
-    from game.theater import ConflictTheater, ControlPoint, FrontLine
-    from game.threatzones import ThreatZones
+    from game.theater import ConflictTheater, FrontLine
 
 
 class FlightPlanBuilder:
@@ -57,14 +52,6 @@ class FlightPlanBuilder:
     def is_player(self) -> bool:
         return self.coalition.player
 
-    @property
-    def doctrine(self) -> Doctrine:
-        return self.coalition.doctrine
-
-    @property
-    def threat_zones(self) -> ThreatZones:
-        return self.coalition.opponent.threat_zone
-
     def populate_flight_plan(self, flight: Flight) -> None:
         """Creates a default flight plan for the given mission."""
         if flight not in self.package.flights:
@@ -74,7 +61,9 @@ class FlightPlanBuilder:
 
         try:
             if self.package.waypoints is None:
-                self.regenerate_package_waypoints()
+                self.package.waypoints = PackageWaypoints.create(
+                    self.package, self.coalition
+                )
             flight.flight_plan = self.generate_flight_plan(flight)
         except NavMeshError as ex:
             color = "blue" if self.is_player else "red"
@@ -121,76 +110,3 @@ class FlightPlanBuilder:
             )
         layout = plan_type.builder_type()(flight, self.theater).build()
         return plan_type(flight, layout)
-
-    def regenerate_flight_plans(self) -> None:
-        new_flights: list[Flight] = []
-        for old_flight in self.package.flights:
-            old_flight.flight_plan = self.generate_flight_plan(old_flight)
-            new_flights.append(old_flight)
-        self.package.flights = new_flights
-
-    def regenerate_package_waypoints(self) -> None:
-        from game.ato.packagewaypoints import PackageWaypoints
-
-        package_airfield = self.package_airfield()
-
-        # Start by picking the best IP for the attack.
-        ingress_point = IpZoneGeometry(
-            self.package.target.position,
-            package_airfield.position,
-            self.coalition,
-        ).find_best_ip()
-
-        join_point = JoinZoneGeometry(
-            self.package.target.position,
-            package_airfield.position,
-            ingress_point,
-            self.coalition,
-        ).find_best_join_point()
-
-        refuel_point = RefuelZoneGeometry(
-            package_airfield.position,
-            join_point,
-            self.coalition,
-        ).find_best_refuel_point()
-
-        # And the split point based on the best route from the IP. Since that's no
-        # different than the best route *to* the IP, this is the same as the join point.
-        # TODO: Estimate attack completion point based on the IP and split from there?
-        self.package.waypoints = PackageWaypoints(
-            WaypointBuilder.perturb(join_point),
-            ingress_point,
-            WaypointBuilder.perturb(join_point),
-            refuel_point,
-        )
-
-    # TODO: Make a model for the waypoint builder and use that in the UI.
-    def generate_rtb_waypoint(
-        self, flight: Flight, arrival: ControlPoint
-    ) -> FlightWaypoint:
-        """Generate RTB landing point.
-
-        Args:
-            flight: The flight to generate the landing waypoint for.
-            arrival: Arrival airfield or carrier.
-        """
-        builder = WaypointBuilder(flight, self.coalition)
-        return builder.land(arrival)
-
-    def package_airfield(self) -> ControlPoint:
-        # We'll always have a package, but if this is being planned via the UI
-        # it could be the first flight in the package.
-        if not self.package.flights:
-            raise PlanningError(
-                "Cannot determine source airfield for package with no flights"
-            )
-
-        # The package airfield is either the flight's airfield (when there is no
-        # package) or the closest airfield to the objective that is the
-        # departure airfield for some flight in the package.
-        cache = ObjectiveDistanceCache.get_closest_airfields(self.package.target)
-        for airfield in cache.operational_airfields:
-            for flight in self.package.flights:
-                if flight.departure == airfield:
-                    return airfield
-        raise PlanningError("Could not find any airfield assigned to this package")

--- a/game/ato/flightplans/flightplanbuilder.py
+++ b/game/ato/flightplans/flightplanbuilder.py
@@ -14,6 +14,7 @@ from .dead import DeadFlightPlan
 from .escort import EscortFlightPlan
 from .ferry import FerryFlightPlan
 from .flightplan import FlightPlan
+from .ibuilder import IBuilder
 from .ocaaircraft import OcaAircraftFlightPlan
 from .ocarunway import OcaRunwayFlightPlan
 from .packagerefueling import PackageRefuelingFlightPlan
@@ -72,42 +73,39 @@ class FlightPlanBuilder:
                 f"{flight.departure} to {flight.package.target}"
             ) from ex
 
-    def plan_type(self, flight: Flight) -> Type[FlightPlan[Any]]:
-        plan_type: Type[FlightPlan[Any]]
+    def builder_type(self, flight: Flight) -> Type[IBuilder[Any, Any]]:
         if flight.flight_type is FlightType.REFUELING:
             if self.package.target.is_friendly(self.is_player) or isinstance(
                 self.package.target, FrontLine
             ):
-                return TheaterRefuelingFlightPlan
-            return PackageRefuelingFlightPlan
+                return TheaterRefuelingFlightPlan.builder_type()
+            return PackageRefuelingFlightPlan.builder_type()
 
-        plan_dict: dict[FlightType, Type[FlightPlan[Any]]] = {
-            FlightType.ANTISHIP: AntiShipFlightPlan,
-            FlightType.BAI: BaiFlightPlan,
-            FlightType.BARCAP: BarCapFlightPlan,
-            FlightType.CAS: CasFlightPlan,
-            FlightType.DEAD: DeadFlightPlan,
-            FlightType.ESCORT: EscortFlightPlan,
-            FlightType.OCA_AIRCRAFT: OcaAircraftFlightPlan,
-            FlightType.OCA_RUNWAY: OcaRunwayFlightPlan,
-            FlightType.SEAD: SeadFlightPlan,
-            FlightType.SEAD_ESCORT: EscortFlightPlan,
-            FlightType.STRIKE: StrikeFlightPlan,
-            FlightType.SWEEP: SweepFlightPlan,
-            FlightType.TARCAP: TarCapFlightPlan,
-            FlightType.AEWC: AewcFlightPlan,
-            FlightType.TRANSPORT: AirliftFlightPlan,
-            FlightType.FERRY: FerryFlightPlan,
-            FlightType.AIR_ASSAULT: AirAssaultFlightPlan,
+        builder_dict: dict[FlightType, Type[IBuilder[Any, Any]]] = {
+            FlightType.ANTISHIP: AntiShipFlightPlan.builder_type(),
+            FlightType.BAI: BaiFlightPlan.builder_type(),
+            FlightType.BARCAP: BarCapFlightPlan.builder_type(),
+            FlightType.CAS: CasFlightPlan.builder_type(),
+            FlightType.DEAD: DeadFlightPlan.builder_type(),
+            FlightType.ESCORT: EscortFlightPlan.builder_type(),
+            FlightType.OCA_AIRCRAFT: OcaAircraftFlightPlan.builder_type(),
+            FlightType.OCA_RUNWAY: OcaRunwayFlightPlan.builder_type(),
+            FlightType.SEAD: SeadFlightPlan.builder_type(),
+            FlightType.SEAD_ESCORT: EscortFlightPlan.builder_type(),
+            FlightType.STRIKE: StrikeFlightPlan.builder_type(),
+            FlightType.SWEEP: SweepFlightPlan.builder_type(),
+            FlightType.TARCAP: TarCapFlightPlan.builder_type(),
+            FlightType.AEWC: AewcFlightPlan.builder_type(),
+            FlightType.TRANSPORT: AirliftFlightPlan.builder_type(),
+            FlightType.FERRY: FerryFlightPlan.builder_type(),
+            FlightType.AIR_ASSAULT: AirAssaultFlightPlan.builder_type(),
         }
         try:
-            return plan_dict[flight.flight_type]
+            return builder_dict[flight.flight_type]
         except KeyError as ex:
             raise PlanningError(
                 f"{flight.flight_type} flight plan generation not implemented"
             ) from ex
 
     def generate_flight_plan(self, flight: Flight) -> FlightPlan[Any]:
-        plan_type = self.plan_type(flight)
-        layout = plan_type.builder_type()(flight, self.theater).build()
-        return plan_type(flight, layout)
+        return self.builder_type(flight)(flight, self.theater).build()

--- a/game/ato/flightplans/formationattack.py
+++ b/game/ato/flightplans/formationattack.py
@@ -11,6 +11,7 @@ from dcs import Point
 from game.flightplan import HoldZoneGeometry
 from game.theater import MissionTarget
 from game.utils import Speed, meters
+from .flightplan import FlightPlan
 from .formation import FormationFlightPlan, FormationLayout
 from .ibuilder import IBuilder
 from .planningerror import PlanningError
@@ -151,10 +152,11 @@ class FormationAttackLayout(FormationLayout):
         yield self.bullseye
 
 
+FlightPlanT = TypeVar("FlightPlanT", bound=FlightPlan[FormationAttackLayout])
 LayoutT = TypeVar("LayoutT", bound=FormationAttackLayout)
 
 
-class FormationAttackBuilder(IBuilder, ABC):
+class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
     def _build(
         self,
         ingress_type: FlightWaypointType,

--- a/game/ato/flightplans/ibuilder.py
+++ b/game/ato/flightplans/ibuilder.py
@@ -19,9 +19,12 @@ LayoutT = TypeVar("LayoutT", bound=Layout)
 
 
 class IBuilder(ABC, Generic[FlightPlanT, LayoutT]):
-    def __init__(self, flight: Flight, theater: ConflictTheater) -> None:
+    def __init__(self, flight: Flight) -> None:
         self.flight = flight
-        self.theater = theater
+
+    @property
+    def theater(self) -> ConflictTheater:
+        return self.flight.departure.theater
 
     @abstractmethod
     def layout(self) -> LayoutT:

--- a/game/ato/flightplans/ibuilder.py
+++ b/game/ato/flightplans/ibuilder.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import Any, Generic, TYPE_CHECKING, TypeVar
+
+from .flightplan import FlightPlan, Layout
 
 if TYPE_CHECKING:
     from game.coalition import Coalition
@@ -10,16 +12,23 @@ if TYPE_CHECKING:
     from game.threatzones import ThreatZones
     from ..flight import Flight
     from ..package import Package
-    from .flightplan import Layout
 
 
-class IBuilder(ABC):
+FlightPlanT = TypeVar("FlightPlanT", bound=FlightPlan[Any])
+LayoutT = TypeVar("LayoutT", bound=Layout)
+
+
+class IBuilder(ABC, Generic[FlightPlanT, LayoutT]):
     def __init__(self, flight: Flight, theater: ConflictTheater) -> None:
         self.flight = flight
         self.theater = theater
 
     @abstractmethod
-    def build(self) -> Layout:
+    def layout(self) -> LayoutT:
+        ...
+
+    @abstractmethod
+    def build(self) -> FlightPlanT:
         ...
 
     @property

--- a/game/ato/flightplans/ocaaircraft.py
+++ b/game/ato/flightplans/ocaaircraft.py
@@ -19,8 +19,8 @@ class OcaAircraftFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[OcaAircraftFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
         if not isinstance(location, Airfield):
@@ -31,3 +31,6 @@ class Builder(FormationAttackBuilder):
             raise InvalidObjectiveLocation(self.flight.flight_type, location)
 
         return self._build(FlightWaypointType.INGRESS_OCA_AIRCRAFT)
+
+    def build(self) -> OcaAircraftFlightPlan:
+        return OcaAircraftFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/ocarunway.py
+++ b/game/ato/flightplans/ocarunway.py
@@ -19,8 +19,8 @@ class OcaRunwayFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[OcaRunwayFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
         if not isinstance(location, Airfield):
@@ -31,3 +31,6 @@ class Builder(FormationAttackBuilder):
             raise InvalidObjectiveLocation(self.flight.flight_type, location)
 
         return self._build(FlightWaypointType.INGRESS_OCA_RUNWAY)
+
+    def build(self) -> OcaRunwayFlightPlan:
+        return OcaRunwayFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/refuelingflightplan.py
+++ b/game/ato/flightplans/refuelingflightplan.py
@@ -1,0 +1,20 @@
+from abc import ABC
+
+from game.utils import Distance, Speed, knots, meters
+from .patrolling import PatrollingFlightPlan, PatrollingLayout
+
+
+class RefuelingFlightPlan(PatrollingFlightPlan[PatrollingLayout], ABC):
+    @property
+    def patrol_speed(self) -> Speed:
+        # TODO: Could use self.flight.unit_type.preferred_patrol_speed(altitude).
+        if self.flight.unit_type.patrol_speed is not None:
+            return self.flight.unit_type.patrol_speed
+        # ~280 knots IAS at 21000.
+        return knots(400)
+
+    @property
+    def engagement_distance(self) -> Distance:
+        # TODO: Factor out a common base of the combat and non-combat race-tracks.
+        # No harm in setting this, but we ought to clean up a bit.
+        return meters(0)

--- a/game/ato/flightplans/rtb.py
+++ b/game/ato/flightplans/rtb.py
@@ -15,42 +15,6 @@ if TYPE_CHECKING:
     from ..flightwaypoint import FlightWaypoint
 
 
-class Builder(IBuilder):
-    def build(self) -> RtbLayout:
-        if not isinstance(self.flight.state, InFlight):
-            raise RuntimeError(f"Cannot abort {self} because it is not in flight")
-
-        current_position = self.flight.state.estimate_position()
-        current_altitude, altitude_reference = self.flight.state.estimate_altitude()
-
-        altitude_is_agl = self.flight.unit_type.dcs_unit_type.helicopter
-        altitude = (
-            feet(1500)
-            if altitude_is_agl
-            else self.flight.unit_type.preferred_patrol_altitude
-        )
-        builder = WaypointBuilder(self.flight, self.flight.coalition)
-        abort_point = builder.nav(
-            current_position, current_altitude, altitude_reference == "RADIO"
-        )
-        abort_point.name = "ABORT AND RTB"
-        abort_point.pretty_name = "Abort and RTB"
-        abort_point.description = "Abort mission and return to base"
-        return RtbLayout(
-            departure=builder.takeoff(self.flight.departure),
-            abort_location=abort_point,
-            nav_to_destination=builder.nav_path(
-                current_position,
-                self.flight.arrival.position,
-                altitude,
-                altitude_is_agl,
-            ),
-            arrival=builder.land(self.flight.arrival),
-            divert=builder.divert(self.flight.divert),
-            bullseye=builder.bullseye(),
-        )
-
-
 @dataclass(frozen=True)
 class RtbLayout(StandardLayout):
     abort_location: FlightWaypoint
@@ -88,3 +52,42 @@ class RtbFlightPlan(StandardFlightPlan[RtbLayout]):
     @property
     def mission_departure_time(self) -> timedelta:
         return timedelta()
+
+
+class Builder(IBuilder[RtbFlightPlan, RtbLayout]):
+    def layout(self) -> RtbLayout:
+        if not isinstance(self.flight.state, InFlight):
+            raise RuntimeError(f"Cannot abort {self} because it is not in flight")
+
+        current_position = self.flight.state.estimate_position()
+        current_altitude, altitude_reference = self.flight.state.estimate_altitude()
+
+        altitude_is_agl = self.flight.unit_type.dcs_unit_type.helicopter
+        altitude = (
+            feet(1500)
+            if altitude_is_agl
+            else self.flight.unit_type.preferred_patrol_altitude
+        )
+        builder = WaypointBuilder(self.flight, self.flight.coalition)
+        abort_point = builder.nav(
+            current_position, current_altitude, altitude_reference == "RADIO"
+        )
+        abort_point.name = "ABORT AND RTB"
+        abort_point.pretty_name = "Abort and RTB"
+        abort_point.description = "Abort mission and return to base"
+        return RtbLayout(
+            departure=builder.takeoff(self.flight.departure),
+            abort_location=abort_point,
+            nav_to_destination=builder.nav_path(
+                current_position,
+                self.flight.arrival.position,
+                altitude,
+                altitude_is_agl,
+            ),
+            arrival=builder.land(self.flight.arrival),
+            divert=builder.divert(self.flight.divert),
+            bullseye=builder.bullseye(),
+        )
+
+    def build(self) -> RtbFlightPlan:
+        return RtbFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/sead.py
+++ b/game/ato/flightplans/sead.py
@@ -25,6 +25,9 @@ class SeadFlightPlan(FormationAttackFlightPlan):
         return timedelta(minutes=1)
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[SeadFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         return self._build(FlightWaypointType.INGRESS_SEAD)
+
+    def build(self) -> SeadFlightPlan:
+        return SeadFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/strike.py
+++ b/game/ato/flightplans/strike.py
@@ -19,8 +19,8 @@ class StrikeFlightPlan(FormationAttackFlightPlan):
         return Builder
 
 
-class Builder(FormationAttackBuilder):
-    def build(self) -> FormationAttackLayout:
+class Builder(FormationAttackBuilder[StrikeFlightPlan, FormationAttackLayout]):
+    def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
         if not isinstance(location, TheaterGroundObject):
@@ -31,3 +31,6 @@ class Builder(FormationAttackBuilder):
             targets.append(StrikeTarget(f"{unit.type.id} #{idx}", unit))
 
         return self._build(FlightWaypointType.INGRESS_STRIKE, targets)
+
+    def build(self) -> StrikeFlightPlan:
+        return StrikeFlightPlan(self.flight, self.layout())

--- a/game/ato/packagewaypoints.py
+++ b/game/ato/packagewaypoints.py
@@ -1,7 +1,17 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from dcs import Point
+
+from game.ato.flightplans.waypointbuilder import WaypointBuilder
+from game.flightplan import IpZoneGeometry, JoinZoneGeometry
+from game.flightplan.refuelzonegeometry import RefuelZoneGeometry
+
+if TYPE_CHECKING:
+    from game.ato import Package
+    from game.coalition import Coalition
 
 
 @dataclass(frozen=True)
@@ -10,3 +20,37 @@ class PackageWaypoints:
     ingress: Point
     split: Point
     refuel: Point
+
+    @staticmethod
+    def create(package: Package, coalition: Coalition) -> PackageWaypoints:
+        origin = package.departure_closest_to_target()
+
+        # Start by picking the best IP for the attack.
+        ingress_point = IpZoneGeometry(
+            package.target.position,
+            origin.position,
+            coalition,
+        ).find_best_ip()
+
+        join_point = JoinZoneGeometry(
+            package.target.position,
+            origin.position,
+            ingress_point,
+            coalition,
+        ).find_best_join_point()
+
+        refuel_point = RefuelZoneGeometry(
+            origin.position,
+            join_point,
+            coalition,
+        ).find_best_refuel_point()
+
+        # And the split point based on the best route from the IP. Since that's no
+        # different than the best route *to* the IP, this is the same as the join point.
+        # TODO: Estimate attack completion point based on the IP and split from there?
+        return PackageWaypoints(
+            WaypointBuilder.perturb(join_point),
+            ingress_point,
+            WaypointBuilder.perturb(join_point),
+            refuel_point,
+        )

--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -108,9 +108,8 @@ class MizCampaignLoader:
         if self.mission.country(self.RED_COUNTRY.name) is None:
             self.mission.coalition["red"].add_country(self.RED_COUNTRY)
 
-    @staticmethod
-    def control_point_from_airport(airport: Airport) -> ControlPoint:
-        cp = Airfield(airport, starts_blue=airport.is_blue())
+    def control_point_from_airport(self, airport: Airport) -> ControlPoint:
+        cp = Airfield(airport, self.theater, starts_blue=airport.is_blue())
 
         # Use the unlimited aircraft option to determine if an airfield should
         # be owned by the player when the campaign is "inverted".
@@ -257,20 +256,26 @@ class MizCampaignLoader:
         for blue in (False, True):
             for group in self.off_map_spawns(blue):
                 control_point = OffMapSpawn(
-                    str(group.name), group.position, starts_blue=blue
+                    str(group.name), group.position, self.theater, starts_blue=blue
                 )
                 control_point.captured_invert = group.late_activation
                 control_points[control_point.id] = control_point
             for ship in self.carriers(blue):
-                control_point = Carrier(ship.name, ship.position, starts_blue=blue)
+                control_point = Carrier(
+                    ship.name, ship.position, self.theater, starts_blue=blue
+                )
                 control_point.captured_invert = ship.late_activation
                 control_points[control_point.id] = control_point
             for ship in self.lhas(blue):
-                control_point = Lha(ship.name, ship.position, starts_blue=blue)
+                control_point = Lha(
+                    ship.name, ship.position, self.theater, starts_blue=blue
+                )
                 control_point.captured_invert = ship.late_activation
                 control_points[control_point.id] = control_point
             for fob in self.fobs(blue):
-                control_point = Fob(str(fob.name), fob.position, starts_blue=blue)
+                control_point = Fob(
+                    str(fob.name), fob.position, self.theater, starts_blue=blue
+                )
                 control_point.captured_invert = fob.late_activation
                 control_points[control_point.id] = control_point
 

--- a/game/commander/packagefulfiller.py
+++ b/game/commander/packagefulfiller.py
@@ -6,7 +6,6 @@ from typing import Dict, Iterable, Optional, Set, TYPE_CHECKING
 
 from game.ato.airtaaskingorder import AirTaskingOrder
 from game.ato.closestairfields import ObjectiveDistanceCache
-from game.ato.flightplans.flightplanbuilder import FlightPlanBuilder
 from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.commander.missionproposals import EscortType, ProposedFlight, ProposedMission
@@ -190,12 +189,9 @@ class PackageFulfiller:
         # flights that will rendezvous with their package will be affected by
         # the other flights in the package. Escorts will not be able to
         # contribute to this.
-        flight_plan_builder = FlightPlanBuilder(
-            builder.package, self.coalition, self.theater
-        )
         for flight in builder.package.flights:
             with tracer.trace("Flight plan population"):
-                flight_plan_builder.populate_flight_plan(flight)
+                flight.recreate_flight_plan()
 
         needed_escorts = self.check_needed_escorts(builder)
         for escort in escorts:
@@ -221,7 +217,7 @@ class PackageFulfiller:
         for flight in package.flights:
             if not flight.flight_plan.waypoints:
                 with tracer.trace("Flight plan population"):
-                    flight_plan_builder.populate_flight_plan(flight)
+                    flight.recreate_flight_plan()
 
         if package.has_players and self.player_missions_asap:
             package.auto_asap = True

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -26,21 +26,21 @@ from typing import (
 from uuid import UUID
 
 from dcs.mapping import Point
-from dcs.terrain.terrain import Airport, ParkingSlot
-from dcs.unitgroup import ShipGroup, StaticGroup
-from dcs.unittype import ShipType
 from dcs.ships import (
     CVN_71,
     CVN_72,
     CVN_73,
     CVN_75,
     CV_1143_5,
-    KUZNECOW,
-    Stennis,
     Forrestal,
+    KUZNECOW,
     LHA_Tarawa,
+    Stennis,
     Type_071,
 )
+from dcs.terrain.terrain import Airport, ParkingSlot
+from dcs.unitgroup import ShipGroup, StaticGroup
+from dcs.unittype import ShipType
 
 from game.ato.closestairfields import ObjectiveDistanceCache
 from game.ground_forces.combat_stance import CombatStance
@@ -56,8 +56,8 @@ from game.sidc import (
     Status,
     SymbolSet,
 )
-from game.utils import Distance, Heading, meters
 from game.theater.presetlocation import PresetLocation
+from game.utils import Distance, Heading, meters
 from .base import Base
 from .frontline import FrontLine
 from .missiontarget import MissionTarget
@@ -320,6 +320,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         name: str,
         position: Point,
         at: StartingPosition,
+        theater: ConflictTheater,
         starts_blue: bool,
         cptype: ControlPointType = ControlPointType.AIRBASE,
     ) -> None:
@@ -327,6 +328,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self.id = uuid.uuid4()
         self.full_name = name
         self.at = at
+        self.theater = theater
         self.starts_blue = starts_blue
         self.connected_objectives: List[TheaterGroundObject] = []
         self.preset_locations = PresetLocations()
@@ -1040,11 +1042,14 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
 
 
 class Airfield(ControlPoint):
-    def __init__(self, airport: Airport, starts_blue: bool) -> None:
+    def __init__(
+        self, airport: Airport, theater: ConflictTheater, starts_blue: bool
+    ) -> None:
         super().__init__(
             airport.name,
             airport.position,
             airport,
+            theater,
             starts_blue,
             cptype=ControlPointType.AIRBASE,
         )
@@ -1237,9 +1242,16 @@ class NavalControlPoint(ControlPoint, ABC):
 
 
 class Carrier(NavalControlPoint):
-    def __init__(self, name: str, at: Point, starts_blue: bool):
+    def __init__(
+        self, name: str, at: Point, theater: ConflictTheater, starts_blue: bool
+    ):
         super().__init__(
-            name, at, at, starts_blue, cptype=ControlPointType.AIRCRAFT_CARRIER_GROUP
+            name,
+            at,
+            at,
+            theater,
+            starts_blue,
+            cptype=ControlPointType.AIRCRAFT_CARRIER_GROUP,
         )
 
     @property
@@ -1276,8 +1288,12 @@ class Carrier(NavalControlPoint):
 
 
 class Lha(NavalControlPoint):
-    def __init__(self, name: str, at: Point, starts_blue: bool):
-        super().__init__(name, at, at, starts_blue, cptype=ControlPointType.LHA_GROUP)
+    def __init__(
+        self, name: str, at: Point, theater: ConflictTheater, starts_blue: bool
+    ):
+        super().__init__(
+            name, at, at, theater, starts_blue, cptype=ControlPointType.LHA_GROUP
+        )
 
     @property
     def symbol_set_and_entity(self) -> tuple[SymbolSet, Entity]:
@@ -1306,9 +1322,16 @@ class OffMapSpawn(ControlPoint):
     def runway_is_operational(self) -> bool:
         return True
 
-    def __init__(self, name: str, position: Point, starts_blue: bool):
+    def __init__(
+        self, name: str, position: Point, theater: ConflictTheater, starts_blue: bool
+    ):
         super().__init__(
-            name, position, position, starts_blue, cptype=ControlPointType.OFF_MAP
+            name,
+            position,
+            position,
+            theater,
+            starts_blue,
+            cptype=ControlPointType.OFF_MAP,
         )
 
     @property
@@ -1365,8 +1388,12 @@ class OffMapSpawn(ControlPoint):
 
 
 class Fob(ControlPoint):
-    def __init__(self, name: str, at: Point, starts_blue: bool):
-        super().__init__(name, at, at, starts_blue, cptype=ControlPointType.FOB)
+    def __init__(
+        self, name: str, at: Point, theater: ConflictTheater, starts_blue: bool
+    ):
+        super().__init__(
+            name, at, at, theater, starts_blue, cptype=ControlPointType.FOB
+        )
         self.name = name
 
     @property

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -43,7 +43,6 @@ from dcs.mapping import Point
 from game.ato.ai_flight_planner_db import aircraft_for_task
 from game.ato.closestairfields import ObjectiveDistanceCache
 from game.ato.flight import Flight
-from game.ato.flightplans.flightplanbuilder import FlightPlanBuilder
 from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.dcs.aircrafttype import AircraftType
@@ -364,10 +363,7 @@ class AirliftPlanner:
         transfer.transport = transport
 
         self.package.add_flight(flight)
-        planner = FlightPlanBuilder(
-            self.package, self.game.coalition_for(self.for_player), self.game.theater
-        )
-        planner.populate_flight_plan(flight)
+        flight.recreate_flight_plan()
         return flight_size
 
 

--- a/qt_ui/windows/SquadronDialog.py
+++ b/qt_ui/windows/SquadronDialog.py
@@ -1,30 +1,25 @@
 import logging
 from typing import Callable, Iterator, Optional
 
-from PySide2.QtCore import (
-    QItemSelectionModel,
-    QModelIndex,
-    Qt,
-    QItemSelection,
-)
+from PySide2.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, Qt
 from PySide2.QtWidgets import (
     QAbstractItemView,
-    QDialog,
-    QListView,
-    QVBoxLayout,
-    QPushButton,
-    QHBoxLayout,
-    QLabel,
     QCheckBox,
     QComboBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListView,
+    QPushButton,
+    QVBoxLayout,
 )
 
-from game.squadrons import Pilot, Squadron
-from game.theater import ControlPoint, ConflictTheater
 from game.ato.flighttype import FlightType
+from game.squadrons import Pilot, Squadron
+from game.theater import ConflictTheater, ControlPoint
 from qt_ui.delegates import TwoColumnRowDelegate
 from qt_ui.errorreporter import report_errors
-from qt_ui.models import SquadronModel, AtoModel
+from qt_ui.models import AtoModel, SquadronModel
 
 
 class PilotDelegate(TwoColumnRowDelegate):
@@ -144,7 +139,6 @@ class SquadronDialog(QDialog):
         super().__init__(parent)
         self.ato_model = ato_model
         self.squadron_model = squadron_model
-        self.theater = theater
 
         self.setMinimumSize(1000, 440)
         self.setWindowTitle(str(squadron_model.squadron))
@@ -200,7 +194,7 @@ class SquadronDialog(QDialog):
             if destination is None:
                 self.squadron.cancel_relocation()
             else:
-                self.squadron.plan_relocation(destination, self.theater)
+                self.squadron.plan_relocation(destination)
             self.ato_model.replace_from_game(player=True)
 
     def check_disabled_button_states(

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -16,7 +16,6 @@ from PySide2.QtWidgets import (
 )
 
 from game.ato.flight import Flight
-from game.ato.flightplans.flightplanbuilder import FlightPlanBuilder
 from game.ato.flightplans.planningerror import PlanningError
 from game.ato.package import Package
 from game.game import Game
@@ -181,11 +180,8 @@ class QPackageDialog(QDialog):
     def add_flight(self, flight: Flight) -> None:
         """Adds the new flight to the package."""
         self.package_model.add_flight(flight)
-        planner = FlightPlanBuilder(
-            self.package_model.package, self.game.blue, self.game.theater
-        )
         try:
-            planner.populate_flight_plan(flight)
+            flight.recreate_flight_plan()
             self.package_model.update_tot()
             EventStream.put_nowait(GameUpdateEvents().new_flight(flight))
         except PlanningError as ex:

--- a/qt_ui/windows/mission/flight/settings/FlightAirfieldDisplay.py
+++ b/qt_ui/windows/mission/flight/settings/FlightAirfieldDisplay.py
@@ -4,7 +4,6 @@ from PySide2.QtWidgets import QGroupBox, QLabel, QMessageBox, QVBoxLayout
 
 from game import Game
 from game.ato.flight import Flight
-from game.ato.flightplans.flightplanbuilder import FlightPlanBuilder
 from game.ato.flightplans.planningerror import PlanningError
 from game.ato.traveltime import TotEstimator
 from qt_ui.models import PackageModel
@@ -71,16 +70,10 @@ class FlightAirfieldDisplay(QGroupBox):
 
         self.flight.divert = divert
         try:
-            self.update_flight_plan()
+            self.flight.recreate_flight_plan()
         except PlanningError as ex:
             self.flight.divert = old_divert
             logging.exception("Could not change divert airfield")
             QMessageBox.critical(
                 self, "Could not update flight plan", str(ex), QMessageBox.Ok
             )
-
-    def update_flight_plan(self) -> None:
-        planner = FlightPlanBuilder(
-            self.package_model.package, self.game.blue, self.game.theater
-        )
-        planner.populate_flight_plan(self.flight)

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
@@ -14,7 +14,6 @@ from PySide2.QtWidgets import (
 from game import Game
 from game.ato.flight import Flight
 from game.ato.flightplans.custom import CustomFlightPlan, CustomLayout
-from game.ato.flightplans.flightplanbuilder import FlightPlanBuilder
 from game.ato.flightplans.formationattack import FormationAttackFlightPlan
 from game.ato.flightplans.planningerror import PlanningError
 from game.ato.flightplans.waypointbuilder import WaypointBuilder
@@ -38,7 +37,6 @@ class QFlightWaypointTab(QFrame):
         self.game = game
         self.package = package
         self.flight = flight
-        self.planner = FlightPlanBuilder(package, game.blue, game.theater)
 
         self.flight_waypoint_list: Optional[QFlightWaypointList] = None
         self.rtb_waypoint: Optional[QPushButton] = None
@@ -168,7 +166,7 @@ class QFlightWaypointTab(QFrame):
         if result == QMessageBox.Yes:
             self.flight.flight_type = task
             try:
-                self.planner.populate_flight_plan(self.flight)
+                self.flight.recreate_flight_plan()
             except PlanningError as ex:
                 self.flight.flight_type = original_task
                 logging.exception("Could not recreate flight")

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, List, Optional, Any
+from typing import Iterable, List, Optional
 
 from PySide2.QtCore import Signal
 from PySide2.QtWidgets import (
@@ -14,10 +14,10 @@ from PySide2.QtWidgets import (
 from game import Game
 from game.ato.flight import Flight
 from game.ato.flightplans.custom import CustomFlightPlan, CustomLayout
-from game.ato.flightplans.flightplan import FlightPlan
 from game.ato.flightplans.flightplanbuilder import FlightPlanBuilder
 from game.ato.flightplans.formationattack import FormationAttackFlightPlan
 from game.ato.flightplans.planningerror import PlanningError
+from game.ato.flightplans.waypointbuilder import WaypointBuilder
 from game.ato.flighttype import FlightType
 from game.ato.flightwaypoint import FlightWaypoint
 from game.ato.loadouts import Loadout
@@ -139,7 +139,7 @@ class QFlightWaypointTab(QFrame):
         self.on_change()
 
     def on_rtb_waypoint(self):
-        rtb = self.planner.generate_rtb_waypoint(self.flight, self.flight.from_cp)
+        rtb = WaypointBuilder(self.flight, self.coalition).land(self.flight.arrival)
         self.degrade_to_custom_flight_plan()
         assert isinstance(self.flight.flight_plan, CustomFlightPlan)
         self.flight.flight_plan.layout.custom_waypoints.append(rtb)


### PR DESCRIPTION
Several preparatory commits (will merge with rebase), and the meat is in the fourth and sixth:

* Each `FlightPlan` is now instantiated directly by its builder. This makes it so flights can recreate their own flight plans from a cached layout (not cached yet) without breaking type safety.
* `Flight` now creates the `FlightPlan` itself. `FlightPlanBuilder` is no longer needed (it was definitely redundant with `IBuilder`). 