### PR TITLE
Appending 'Missions' to the lfs.writedir() path for failover save loc…

### DIFF
--- a/resources/plugins/base/dcs_liberation.lua
+++ b/resources/plugins/base/dcs_liberation.lua
@@ -112,7 +112,7 @@ local function discoverDebriefingFilePath()
 
     -- nothing worked, let's try the last resort folder : current directory.
     if lfs then
-        return testDebriefingFilePath(lfs.writedir(), "the working directory", useCurrentStamping)
+        return testDebriefingFilePath(lfs.writedir().."Missions\\", "the working directory", useCurrentStamping)
     end
     
     return nil


### PR DESCRIPTION
…ation of state.json


Related to Issue opened on behalf of Fox3ms.com - https://github.com/dcs-liberation/dcs_liberation/issues/2381 

This change would remove the need for automation and symlinks to provide access to state.json with dedicated DCS servers. 

PR was opened on advice from "Lion" in the DCS: Liberation Discord  to start further discussion. 