### PR TITLE
Add campaign property for campaign start time.

### DIFF
--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -4,7 +4,7 @@ import datetime
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, TYPE_CHECKING, Tuple
+from typing import Iterator, List, Optional, TYPE_CHECKING, Tuple
 from uuid import UUID
 
 from dcs.mapping import Point
@@ -20,6 +20,7 @@ from dcs.terrain import (
 from dcs.terrain.terrain import Terrain
 from shapely import geometry, ops
 
+from .daytimemap import DaytimeMap
 from .frontline import FrontLine
 from .iadsnetwork.iadsnetwork import IadsNetwork
 from .landmap import Landmap, load_landmap, poly_contains
@@ -42,19 +43,11 @@ class ConflictTheater:
 
     overview_image: str
     landmap: Optional[Landmap]
-    """
-    land_poly = None  # type: Polygon
-    """
-    daytime_map: Dict[str, Tuple[int, int]]
+    daytime_map: DaytimeMap
     iads_network: IadsNetwork
 
     def __init__(self) -> None:
         self.controlpoints: List[ControlPoint] = []
-        """
-        self.land_poly = geometry.Polygon(self.landmap[0][0])
-        for x in self.landmap[1]:
-            self.land_poly = self.land_poly.difference(geometry.Polygon(x))
-        """
 
     def add_controlpoint(self, point: ControlPoint) -> None:
         self.controlpoints.append(point)
@@ -266,12 +259,12 @@ class CaucasusTheater(ConflictTheater):
     overview_image = "caumap.gif"
 
     landmap = load_landmap(Path("resources/caulandmap.p"))
-    daytime_map = {
-        "dawn": (6, 9),
-        "day": (9, 18),
-        "dusk": (18, 20),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=6), datetime.time(hour=9)),
+        day=(datetime.time(hour=9), datetime.time(hour=18)),
+        dusk=(datetime.time(hour=18), datetime.time(hour=20)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:
@@ -288,12 +281,12 @@ class PersianGulfTheater(ConflictTheater):
     terrain = persiangulf.PersianGulf()
     overview_image = "persiangulf.gif"
     landmap = load_landmap(Path("resources/gulflandmap.p"))
-    daytime_map = {
-        "dawn": (6, 8),
-        "day": (8, 16),
-        "dusk": (16, 18),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=6), datetime.time(hour=8)),
+        day=(datetime.time(hour=8), datetime.time(hour=16)),
+        dusk=(datetime.time(hour=16), datetime.time(hour=18)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:
@@ -310,12 +303,12 @@ class NevadaTheater(ConflictTheater):
     terrain = nevada.Nevada()
     overview_image = "nevada.gif"
     landmap = load_landmap(Path("resources/nevlandmap.p"))
-    daytime_map = {
-        "dawn": (4, 6),
-        "day": (6, 17),
-        "dusk": (17, 18),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=4), datetime.time(hour=6)),
+        day=(datetime.time(hour=6), datetime.time(hour=17)),
+        dusk=(datetime.time(hour=17), datetime.time(hour=18)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:
@@ -332,12 +325,12 @@ class NormandyTheater(ConflictTheater):
     terrain = normandy.Normandy()
     overview_image = "normandy.gif"
     landmap = load_landmap(Path("resources/normandylandmap.p"))
-    daytime_map = {
-        "dawn": (6, 8),
-        "day": (10, 17),
-        "dusk": (17, 18),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=6), datetime.time(hour=8)),
+        day=(datetime.time(hour=10), datetime.time(hour=17)),
+        dusk=(datetime.time(hour=17), datetime.time(hour=18)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:
@@ -354,12 +347,12 @@ class TheChannelTheater(ConflictTheater):
     terrain = thechannel.TheChannel()
     overview_image = "thechannel.gif"
     landmap = load_landmap(Path("resources/channellandmap.p"))
-    daytime_map = {
-        "dawn": (6, 8),
-        "day": (10, 17),
-        "dusk": (17, 18),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=6), datetime.time(hour=8)),
+        day=(datetime.time(hour=10), datetime.time(hour=17)),
+        dusk=(datetime.time(hour=17), datetime.time(hour=18)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:
@@ -376,12 +369,12 @@ class SyriaTheater(ConflictTheater):
     terrain = syria.Syria()
     overview_image = "syria.gif"
     landmap = load_landmap(Path("resources/syrialandmap.p"))
-    daytime_map = {
-        "dawn": (6, 8),
-        "day": (8, 16),
-        "dusk": (16, 18),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=6), datetime.time(hour=8)),
+        day=(datetime.time(hour=8), datetime.time(hour=16)),
+        dusk=(datetime.time(hour=16), datetime.time(hour=18)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:
@@ -399,12 +392,12 @@ class MarianaIslandsTheater(ConflictTheater):
     overview_image = "marianaislands.gif"
 
     landmap = load_landmap(Path("resources/marianaislandslandmap.p"))
-    daytime_map = {
-        "dawn": (6, 8),
-        "day": (8, 16),
-        "dusk": (16, 18),
-        "night": (0, 5),
-    }
+    daytime_map = DaytimeMap(
+        dawn=(datetime.time(hour=6), datetime.time(hour=8)),
+        day=(datetime.time(hour=8), datetime.time(hour=16)),
+        dusk=(datetime.time(hour=16), datetime.time(hour=18)),
+        night=(datetime.time(hour=0), datetime.time(hour=5)),
+    )
 
     @property
     def timezone(self) -> datetime.timezone:

--- a/game/theater/daytimemap.py
+++ b/game/theater/daytimemap.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+from datetime import time
+from typing import TypeAlias
+
+from game.weather import TimeOfDay
+
+TimeRange: TypeAlias = tuple[time, time]
+
+
+@dataclass(frozen=True)
+class DaytimeMap:
+    dawn: TimeRange
+    day: TimeRange
+    dusk: TimeRange
+    night: TimeRange
+
+    def __post_init__(self) -> None:
+        # Checks that we only are even given whole-hour intervals. There's no reason to
+        # not support this eventually, but for now the fact that missions always start
+        # on the hour is a nice gameplay property. That'll have to go as a part of the
+        # mid-mission starts and removal of turns, but for now we can keep it to
+        # preserve the old behavior.
+        #
+        # Mission start time generation (currently in Conditions.generate_start_time)
+        # will need to be updated if and when this changes.
+        def check_time_is_hours(descr: str, t: time) -> None:
+            if t.minute:
+                raise ValueError(
+                    f"{descr} has non-zero minutes; only hour intervals are currently "
+                    "supported"
+                )
+            if t.second:
+                raise ValueError(
+                    f"{descr} has non-zero seconds; only hour intervals are currently "
+                    "supported"
+                )
+            if t.microsecond:
+                raise ValueError(
+                    f"{descr} has non-zero microseconds; only hour intervals are "
+                    "currently supported"
+                )
+
+        check_time_is_hours("dawn start", self.dawn[0])
+        check_time_is_hours("dawn end", self.dawn[1])
+        check_time_is_hours("day start", self.day[0])
+        check_time_is_hours("day end", self.day[1])
+        check_time_is_hours("dusk start", self.dusk[0])
+        check_time_is_hours("dusk end", self.dusk[1])
+        check_time_is_hours("night start", self.night[0])
+        check_time_is_hours("night end", self.night[1])
+
+    def range_of(self, item: TimeOfDay) -> TimeRange:
+        match item:
+            case TimeOfDay.Dawn:
+                return self.dawn
+            case TimeOfDay.Day:
+                return self.day
+            case TimeOfDay.Dusk:
+                return self.dusk
+            case TimeOfDay.Night:
+                return self.night
+            case _:
+                raise ValueError(f"Invalid value for TimeOfDay: {item}")
+
+    def best_guess_time_of_day_at(self, at: time) -> TimeOfDay:
+        """Returns an approximation of the time of day at the given time.
+
+        This is the best guess because time ranges need not cover the whole day. For the
+        Caucasus, for example, dusk ends at 20:00 but night does not begin until 24:00.
+        If a time between those hours is given, we call it dusk.
+        """
+        if self.night[0] < self.dawn[0] and at < self.night[0]:
+            # Night happens at or before midnight, so there's a time before dawn but
+            # after midnight where it can still be dusk.
+            return TimeOfDay.Dusk
+        if at < self.dawn[0]:
+            return TimeOfDay.Night
+        if at < self.day[0]:
+            return TimeOfDay.Dawn
+        if at < self.dusk[0]:
+            return TimeOfDay.Day
+        if self.night[0] > self.dusk[0] and at >= self.night[0]:
+            # Night happens before midnight, so it might still be dusk or night.
+            return TimeOfDay.Night
+        # If night starts at or before midnight, and it's at least dusk, it's definitely
+        # dusk.
+        return TimeOfDay.Dusk

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, time
 from typing import List
 
 import dcs.statics
@@ -17,7 +17,6 @@ from game.theater.theatergroundobject import (
     BuildingGroundObject,
     IadsBuildingGroundObject,
 )
-from .theatergroup import SceneryUnit, TheaterGroup, IadsGroundGroup, IadsRole
 from game.utils import Heading, escape_string_for_lua
 from game.version import VERSION
 from . import (
@@ -27,10 +26,7 @@ from . import (
     Fob,
     OffMapSpawn,
 )
-from ..campaignloader.campaignairwingconfig import CampaignAirWingConfig
-from ..data.building_data import IADS_BUILDINGS
-from ..data.groups import GroupTask
-from ..armedforces.forcegroup import ForceGroup
+from .theatergroup import IadsGroundGroup, IadsRole, SceneryUnit, TheaterGroup
 from ..armedforces.armedforces import ArmedForces
 from ..armedforces.forcegroup import ForceGroup
 from ..campaignloader.campaignairwingconfig import CampaignAirWingConfig
@@ -42,6 +38,7 @@ from ..settings import Settings
 @dataclass(frozen=True)
 class GeneratorSettings:
     start_date: datetime
+    start_time: time | None
     player_budget: int
     enemy_budget: int
     inverted: bool
@@ -96,6 +93,7 @@ class GameGenerator:
                 theater=self.theater,
                 air_wing_config=self.air_wing_config,
                 start_date=self.generator_settings.start_date,
+                start_time=self.generator_settings.start_time,
                 settings=self.settings,
                 player_budget=self.generator_settings.player_budget,
                 enemy_budget=self.generator_settings.enemy_budget,

--- a/game/version.py
+++ b/game/version.py
@@ -150,4 +150,9 @@ VERSION = _build_version_string()
 #: * Campaign files can optionally define the iads configuration
 #:   It is possible to define if the campaign supports advanced iads
 #:
-CAMPAIGN_FORMAT_VERSION = (10, 2)
+#: Version 10.3
+#: * Campaign files can optionally include a start time in their recommended_start_date
+#:   field. For example, `recommended_start_data: 2022-08-31 13:30:00` will have the
+#:   first turn start at 13:30. If omitted, or if only a date is given, the mission will
+#:   start at a random hour in the middle of the day as before.
+CAMPAIGN_FORMAT_VERSION = (10, 3)

--- a/game/weather.py
+++ b/game/weather.py
@@ -298,10 +298,16 @@ class Conditions:
         day: datetime.date,
         time_of_day: TimeOfDay,
         settings: Settings,
+        forced_time: datetime.time | None = None,
     ) -> Conditions:
-        _start_time = cls.generate_start_time(
-            theater, day, time_of_day, settings.night_disabled
-        )
+        # The time might be forced by the campaign for the first turn.
+        if forced_time is not None:
+            _start_time = datetime.datetime.combine(day, forced_time)
+        else:
+            _start_time = cls.generate_start_time(
+                theater, day, time_of_day, settings.night_disabled
+            )
+
         return cls(
             time_of_day=time_of_day,
             start_time=_start_time,

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -286,6 +286,7 @@ def create_game(
         ),
         GeneratorSettings(
             start_date=start_date,
+            start_time=campaign.recommended_start_time,
             player_budget=DEFAULT_BUDGET,
             enemy_budget=DEFAULT_BUDGET,
             inverted=inverted,

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -145,6 +145,7 @@ class NewGameWizard(QtWidgets.QWizard):
         )
         generator_settings = GeneratorSettings(
             start_date=start_date,
+            start_time=campaign.recommended_start_time,
             player_budget=int(self.field("starting_money")),
             enemy_budget=int(self.field("enemy_starting_money")),
             # QSlider forces integers, so we use 1 to 50 and divide by 10 to

--- a/tests/test_daytimemap.py
+++ b/tests/test_daytimemap.py
@@ -1,0 +1,107 @@
+from datetime import time
+
+import pytest
+
+from game.theater.daytimemap import DaytimeMap
+from game.weather import TimeOfDay
+
+
+def test_range_of() -> None:
+    m = DaytimeMap(
+        dawn=(time(hour=6), time(hour=9)),
+        day=(time(hour=9), time(hour=18)),
+        dusk=(time(hour=18), time(hour=20)),
+        night=(time(hour=0), time(hour=5)),
+    )
+
+    assert m.range_of(TimeOfDay.Dawn) == (time(hour=6), time(hour=9))
+    assert m.range_of(TimeOfDay.Day) == (time(hour=9), time(hour=18))
+    assert m.range_of(TimeOfDay.Dusk) == (time(hour=18), time(hour=20))
+    assert m.range_of(TimeOfDay.Night) == (time(hour=0), time(hour=5))
+
+
+def test_best_guess_time_of_day_at() -> None:
+    night_at_midnight = DaytimeMap(
+        dawn=(time(hour=6), time(hour=9)),
+        day=(time(hour=9), time(hour=18)),
+        dusk=(time(hour=18), time(hour=20)),
+        night=(time(hour=0), time(hour=5)),
+    )
+
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=0)) == TimeOfDay.Night
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=5)) == TimeOfDay.Night
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=6)) == TimeOfDay.Dawn
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=7)) == TimeOfDay.Dawn
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=9)) == TimeOfDay.Day
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=10)) == TimeOfDay.Day
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=18)) == TimeOfDay.Dusk
+    assert night_at_midnight.best_guess_time_of_day_at(time(hour=19)) == TimeOfDay.Dusk
+
+    night_before_midnight = DaytimeMap(
+        dawn=(time(hour=6), time(hour=9)),
+        day=(time(hour=9), time(hour=18)),
+        dusk=(time(hour=18), time(hour=20)),
+        night=(time(hour=22), time(hour=5)),
+    )
+
+    assert (
+        night_before_midnight.best_guess_time_of_day_at(time(hour=0)) == TimeOfDay.Night
+    )
+    assert (
+        night_before_midnight.best_guess_time_of_day_at(time(hour=1)) == TimeOfDay.Night
+    )
+    assert (
+        night_before_midnight.best_guess_time_of_day_at(time(hour=22))
+        == TimeOfDay.Night
+    )
+    assert (
+        night_before_midnight.best_guess_time_of_day_at(time(hour=23))
+        == TimeOfDay.Night
+    )
+    assert (
+        night_before_midnight.best_guess_time_of_day_at(time(hour=6)) == TimeOfDay.Dawn
+    )
+
+    night_after_midnight = DaytimeMap(
+        dawn=(time(hour=6), time(hour=9)),
+        day=(time(hour=9), time(hour=18)),
+        dusk=(time(hour=18), time(hour=20)),
+        night=(time(hour=2), time(hour=5)),
+    )
+
+    assert (
+        night_after_midnight.best_guess_time_of_day_at(time(hour=0)) == TimeOfDay.Dusk
+    )
+    assert (
+        night_after_midnight.best_guess_time_of_day_at(time(hour=23)) == TimeOfDay.Dusk
+    )
+    assert (
+        night_after_midnight.best_guess_time_of_day_at(time(hour=2)) == TimeOfDay.Night
+    )
+    assert (
+        night_after_midnight.best_guess_time_of_day_at(time(hour=6)) == TimeOfDay.Dawn
+    )
+
+
+def test_whole_hours_only() -> None:
+    with pytest.raises(ValueError):
+        DaytimeMap(
+            dawn=(time(minute=6), time(hour=9)),
+            day=(time(hour=9), time(hour=18)),
+            dusk=(time(hour=18), time(hour=20)),
+            night=(time(hour=2), time(hour=5)),
+        )
+    with pytest.raises(ValueError):
+        DaytimeMap(
+            dawn=(time(hour=6), time(hour=9)),
+            day=(time(second=9), time(hour=18)),
+            dusk=(time(hour=18), time(hour=20)),
+            night=(time(hour=2), time(hour=5)),
+        )
+    with pytest.raises(ValueError):
+        DaytimeMap(
+            dawn=(time(hour=6), time(hour=9)),
+            day=(time(hour=9), time(hour=18)),
+            dusk=(time(hour=18), time(microsecond=20)),
+            night=(time(hour=2), time(hour=5)),
+        )


### PR DESCRIPTION
This field is optional. Omitting the field (or using only a date instead
of a full timestamp) will use the old behavior of picking a random
daylight hour to start the campaign.

This doesn't include any UI in the new game wizard yet. This is only a
campaign yaml option.

https://github.com/dcs-liberation/dcs_liberation/issues/2400