### PR TITLE
Make TOT waypoints non-optional for flight plans.

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -8,6 +8,7 @@ from dcs import Point
 from dcs.planes import C_101CC, C_101EB, Su_33
 
 from .flightplans.planningerror import PlanningError
+from .flightplans.waypointbuilder import WaypointBuilder
 from .flightroster import FlightRoster
 from .flightstate import FlightState, Navigating, Uninitialized
 from .flightstate.killed import Killed
@@ -89,7 +90,11 @@ class Flight(SidcDescribable):
         from .flightplans.custom import CustomFlightPlan, CustomLayout
 
         self.flight_plan: FlightPlan[Any] = CustomFlightPlan(
-            self, CustomLayout(custom_waypoints=[])
+            self,
+            CustomLayout(
+                departure=WaypointBuilder(self, self.coalition).takeoff(self.departure),
+                custom_waypoints=[],
+            ),
         )
 
     def __getstate__(self) -> dict[str, Any]:

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from game.sim.gameupdateevents import GameUpdateEvents
     from game.sim.simulationresults import SimulationResults
     from game.squadrons import Squadron, Pilot
-    from game.theater import ControlPoint, MissionTarget
+    from game.theater import ControlPoint
     from game.transfers import TransferOrder
     from .flightplans.flightplan import FlightPlan
     from .flighttype import FlightType
@@ -62,8 +62,6 @@ class Flight(SidcDescribable):
             self.roster = roster
         self.divert = divert
         self.flight_type = flight_type
-        # TODO: Replace with FlightPlan.
-        self.targets: List[MissionTarget] = []
         self.loadout = Loadout.default_for(self)
         self.start_type = start_type
         self.use_custom_loadout = False

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -41,7 +41,7 @@ class AirAssaultFlightPlan(StandardFlightPlan[AirAssaultLayout]):
         return Builder
 
     @property
-    def tot_waypoint(self) -> FlightWaypoint | None:
+    def tot_waypoint(self) -> FlightWaypoint:
         return self.layout.drop_off
 
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:

--- a/game/ato/flightplans/airlift.py
+++ b/game/ato/flightplans/airlift.py
@@ -47,7 +47,7 @@ class AirliftFlightPlan(StandardFlightPlan[AirliftLayout]):
         return Builder
 
     @property
-    def tot_waypoint(self) -> FlightWaypoint | None:
+    def tot_waypoint(self) -> FlightWaypoint:
         return self.layout.drop_off
 
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:

--- a/game/ato/flightplans/ferry.py
+++ b/game/ato/flightplans/ferry.py
@@ -34,7 +34,7 @@ class FerryFlightPlan(StandardFlightPlan[FerryLayout]):
         return Builder
 
     @property
-    def tot_waypoint(self) -> FlightWaypoint | None:
+    def tot_waypoint(self) -> FlightWaypoint:
         return self.layout.arrival
 
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:

--- a/game/ato/flightplans/patrolling.py
+++ b/game/ato/flightplans/patrolling.py
@@ -85,7 +85,7 @@ class PatrollingFlightPlan(StandardFlightPlan[LayoutT], ABC):
         return {self.layout.patrol_start, self.layout.patrol_end}
 
     @property
-    def tot_waypoint(self) -> FlightWaypoint | None:
+    def tot_waypoint(self) -> FlightWaypoint:
         return self.layout.patrol_start
 
     @property

--- a/game/ato/flightplans/rtb.py
+++ b/game/ato/flightplans/rtb.py
@@ -40,8 +40,8 @@ class RtbFlightPlan(StandardFlightPlan[RtbLayout]):
         return 1
 
     @property
-    def tot_waypoint(self) -> FlightWaypoint | None:
-        return None
+    def tot_waypoint(self) -> FlightWaypoint:
+        return self.layout.abort_location
 
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:
         return None

--- a/game/ato/flightplans/standard.py
+++ b/game/ato/flightplans/standard.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class StandardLayout(Layout, ABC):
-    departure: FlightWaypoint
     arrival: FlightWaypoint
     divert: FlightWaypoint | None
     bullseye: FlightWaypoint

--- a/game/ato/flightplans/sweep.py
+++ b/game/ato/flightplans/sweep.py
@@ -54,7 +54,7 @@ class SweepFlightPlan(LoiterFlightPlan):
         return {self.layout.sweep_end}
 
     @property
-    def tot_waypoint(self) -> FlightWaypoint | None:
+    def tot_waypoint(self) -> FlightWaypoint:
         return self.layout.sweep_end
 
     @property

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
@@ -35,6 +35,7 @@ class QFlightWaypointTab(QFrame):
     def __init__(self, game: Game, package: Package, flight: Flight):
         super(QFlightWaypointTab, self).__init__()
         self.game = game
+        self.coalition = game.coalition_for(player=True)
         self.package = package
         self.flight = flight
 

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
@@ -148,7 +148,12 @@ class QFlightWaypointTab(QFrame):
         if not isinstance(self.flight.flight_plan, CustomFlightPlan):
             self.flight.flight_plan = CustomFlightPlan(
                 self.flight,
-                CustomLayout(custom_waypoints=self.flight.flight_plan.waypoints),
+                CustomLayout(
+                    departure=WaypointBuilder(self.flight, self.coalition).takeoff(
+                        self.flight.departure
+                    ),
+                    custom_waypoints=self.flight.flight_plan.waypoints[1:],
+                ),
             )
 
     def confirm_recreate(self, task: FlightType) -> None:


### PR DESCRIPTION
Make TOT waypoints non-optional for flight plans.

Flights without a meaningful TOT make the code around startup time (and
other scheduling behaviors) unnecessarily complicated because they have
to handle unpredictable flight plans. We can simplify this by requiring
that all flight plans have a waypoint associated with their TOT. For
custom flight plans, we can just fall back to the takeoff waypoint. For
RTB flight plans (which are only synthetic flight plans injected for
aborted flights), we can use the abort point.

This also means that all flight plans now have, at the very least, a
departure waypoint. Deleting this waypoint is invalid even for custom
flights, so that's no a problem.