### PR TITLE
Move FlightPlan ownership from Flight to IBuilder.

### DIFF
--- a/game/ato/flightplans/ibuilder.py
+++ b/game/ato/flightplans/ibuilder.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 
+from game.navmesh import NavMeshError
 from .flightplan import FlightPlan, Layout
+from .planningerror import PlanningError
+from ..packagewaypoints import PackageWaypoints
 
 if TYPE_CHECKING:
     from game.coalition import Coalition
@@ -21,6 +24,30 @@ LayoutT = TypeVar("LayoutT", bound=Layout)
 class IBuilder(ABC, Generic[FlightPlanT, LayoutT]):
     def __init__(self, flight: Flight) -> None:
         self.flight = flight
+        self._flight_plan: FlightPlanT | None = None
+
+    def get_or_build(self) -> FlightPlanT:
+        if self._flight_plan is None:
+            self.regenerate()
+            assert self._flight_plan is not None
+        return self._flight_plan
+
+    def regenerate(self) -> None:
+        try:
+            self._generate_package_waypoints_if_needed()
+            self._flight_plan = self.build()
+        except NavMeshError as ex:
+            color = "blue" if self.flight.squadron.player else "red"
+            raise PlanningError(
+                f"Could not plan {color} {self.flight.flight_type.value} from "
+                f"{self.flight.departure} to {self.package.target}"
+            ) from ex
+
+    def _generate_package_waypoints_if_needed(self) -> None:
+        if self.package.waypoints is None:
+            self.package.waypoints = PackageWaypoints.create(
+                self.package, self.coalition
+            )
 
     @property
     def theater(self) -> ConflictTheater:


### PR DESCRIPTION
The next step in splitting up the layout and scheduling phases. This
facilitates splitting flights into two classes where one has a full
flight plan, but one used in the earlier phases of planning has only a
layout. Layout-only flights won't need TOTs, which will make them much
easier to work with once we've migrated TOTs from timedeltas to
datetimes.

Layout-only flights of course aren't actually usable, but it lets us
avoid dealing with the current sim time until we're certain the Flight
will even survive planning.

I'm not actually sure if we'll be able to split the two phases any more,
but this ends up being a nice cleanup anyway.