### PR TITLE
Fix mistake in join point placement.

### DIFF
--- a/client/src/components/waypointdebugzones/JoinZones.tsx
+++ b/client/src/components/waypointdebugzones/JoinZones.tsx
@@ -65,6 +65,7 @@ function JoinZones(props: JoinZonesProps) {
             positions={zone}
             color="#80BA80"
             interactive={false}
+            stroke={false}
           />
         );
       })}

--- a/game/flightplan/joinzonegeometry.py
+++ b/game/flightplan/joinzonegeometry.py
@@ -100,5 +100,5 @@ class JoinZoneGeometry:
         if self.preferred_lines.is_empty:
             join, _ = shapely.ops.nearest_points(self.permissible_zones, self.ip)
         else:
-            join, _ = shapely.ops.nearest_points(self.preferred_lines, self.home)
+            join, _ = shapely.ops.nearest_points(self.preferred_lines, self.ip)
         return self._target.new_in_same_map(join.x, join.y)


### PR DESCRIPTION
This looks like it was just a typo. We want to join as late as possible to allow flights coming from other airfields to take the best route to the target that is safe, rather than joining as early as possible, which isn't useful since pre-join and post-split are supposed to be safe areas anyway.