### PR TITLE
Attempt at fixing Carrier killed in state.json but not being removed from game

### DIFF
--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -373,7 +373,17 @@ class GenericCarrierGenerator(GroundObjectGenerator):
                 logging.warning(f"Found empty carrier group in {self.control_point}")
                 continue
 
-            ship_group = self.create_ship_group(group.group_name, group.units, atc)
+            ship_units = []
+            for unit in group.units:
+                if unit.alive:
+                    # All alive Ships
+                    ship_units.append(unit)
+
+            if not ship_units:
+                # Empty array (no alive units), stop here
+                return
+
+            ship_group = self.create_ship_group(group.group_name, ship_units, atc)
 
             # Always steam into the wind, even if the carrier is being moved.
             # There are multiple unsimulated hours between turns, so we can
@@ -382,7 +392,7 @@ class GenericCarrierGenerator(GroundObjectGenerator):
             brc = self.steam_into_wind(ship_group)
 
             # Set Carrier Specific Options
-            if g_id == 0:
+            if g_id == 0 and self.control_point.runway_is_operational():
                 # Get Correct unit type for the carrier.
                 # This will upgrade to super carrier if option is enabled
                 carrier_type = self.carrier_type

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1194,7 +1194,7 @@ class NavalControlPoint(ControlPoint, ABC):
         # while its escorts are still alive.
         for group in self.find_main_tgo().groups:
             for u in group.units:
-                if u.type in [
+                if u.alive and u.type in [
                     Forrestal,
                     Stennis,
                     LHA_Tarawa,


### PR DESCRIPTION
Attempt at fixing Carrier killed in state.json but not being removed from game, issue #2405. GenericCarrierGenerator.generate() will now generate the ship group with an array that only contains alive ship units, just like GroundObjectGenerator.generate() has previously done.

Carrier groups will now also show up as destroyed/damaged on the map when the carrier is sunk.

I am only creating this as a draft PR for now, because while this seems to fix the actual issue, I don't think the change addresses the actual root cause of the problem. The carrier generator doesn't seem to have considered the alive/dead status of the units in the past, so some other change must have introduced this behavior. Hopefully this PR will help point in the right direction whoever will resolve the actual root cause.