### PR TITLE
SAMs with all units operational show as "fully capable" (green bar)

### DIFF
--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -85,7 +85,12 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
 
     @property
     def sidc_status(self) -> Status:
-        return Status.PRESENT_DESTROYED if self.is_dead else Status.PRESENT
+        if self.is_dead:
+            return Status.PRESENT_DESTROYED
+        elif self.dead_units:
+            return Status.PRESENT_DAMAGED
+        else:
+            return Status.PRESENT
 
     @property
     def standard_identity(self) -> StandardIdentity:
@@ -512,9 +517,13 @@ class SamGroundObject(IadsGroundObject):
     def sidc_status(self) -> Status:
         if self.is_dead:
             return Status.PRESENT_DESTROYED
-        if self.max_threat_range() > meters(0):
-            return Status.PRESENT
-        return Status.PRESENT_DAMAGED
+        elif self.dead_units:
+            if self.max_threat_range() > meters(0):
+                return Status.PRESENT
+            else:
+                return Status.PRESENT_DAMAGED
+        else:
+            return Status.PRESENT_FULLY_CAPABLE
 
     @property
     def symbol_set_and_entity(self) -> tuple[SymbolSet, Entity]:


### PR DESCRIPTION
SAMs with all units operational show as "fully capable" (green bar). If units in the theater ground object are destroyed, the green bar is removed. If the SAM site no longer has a threat range, the "rendered ineffective" (yellow) bar is displayed. Operational SAM sites with some units destroyed will therefore not display any bar. Fully destroyed theater group objects display the red bar, as before.

For non-SAM theater ground objects, the "rendered ineffective" (yellow) bar is displayed if at least one unit (but not all) in the TGO is destroyed.

This is a potential resolution to #2438