### PR TITLE
Update pydcs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Saves from 5.x are not compatible with 6.0.
 
 ## Features/Improvements
 
-* **[Engine]** Support for DCS 2.7.16.27869 with the new units (technicals & EWR) and the ACLS & Link4
+* **[Engine]** Support for DCS 2.7.18.30348.
 * **[Mission Generation]** Added an option to fast-forward mission generation until the point of first contact (WIP).
 * **[Mission Generation]** Added performance option to not cull IADS when culling would effect how mission is played at target area.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pluggy==1.0.0
 pre-commit==2.19.0
 py==1.11.0
 pydantic==1.9.1
--e git+https://github.com/pydcs/dcs@4c104828ecb95b0f4b095a0a9ea353bde75f48d0#egg=pydcs
+-e git+https://github.com/pydcs/dcs@dc5ba15e40f434b5d86374aa8a4c0ace5b915805#egg=pydcs
 pyinstaller==5.2
 pyinstaller-hooks-contrib==2022.8
 pyparsing==3.0.9


### PR DESCRIPTION
Includes the AIM-54C Mk 60.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2436.