### PR TITLE
Fix errors in log with 204 response endpoints.

### DIFF
--- a/game/server/controlpoints/routes.py
+++ b/game/server/controlpoints/routes.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from dcs import Point
 from dcs.mapping import LatLng
 from fastapi import APIRouter, Body, Depends, HTTPException, status
+from starlette.responses import Response
 
 from game import Game
 from .models import ControlPointJs
@@ -59,6 +60,7 @@ def destination_in_range(
     "/{cp_id}/destination",
     operation_id="set_control_point_destination",
     status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
 )
 def set_destination(
     cp_id: UUID,
@@ -98,6 +100,7 @@ def set_destination(
     "/{cp_id}/cancel-travel",
     operation_id="clear_control_point_destination",
     status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
 )
 def cancel_travel(cp_id: UUID, game: Game = Depends(GameContext.require)) -> None:
     cp = game.theater.find_control_point_by_id(cp_id)

--- a/game/server/waypoints/routes.py
+++ b/game/server/waypoints/routes.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from dcs.mapping import LatLng, Point
 from fastapi import APIRouter, Depends, HTTPException, status
+from starlette.responses import Response
 
 from game import Game
 from game.ato import Flight
@@ -49,6 +50,7 @@ def all_waypoints_for_flight(
     "/{flight_id}/{waypoint_idx}/position",
     operation_id="set_waypoint_position",
     status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
 )
 def set_position(
     flight_id: UUID,


### PR DESCRIPTION
FastAPI uses JsonResponse by default, which will convert the empty response None to null. We need to forcibly use Response instead to prevent that for No Content responses.

This didn't cause any observable issues but was polluting the log.