### PR TITLE
Don't allow helicopters at non-FARP FOBs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Fixed adding additional mission types for a squadron causing error messages when the mission type is not supported by the aircraft type by default
 * **[Mission Generation]** AAA ground units now spawn correctly at the frontline
 * **[Modding]** Loadouts with invalid weapons (typically new DCS weapons not yet available in Liberation) will be ignored rather than causing an error.
+* **[Squadrons]** Helicopter squadrons can no longer be assigned to FOBs that are not FARPs.
 * **[UI]** Fixed and issue where the liberation main exe was still running after application close.
 * **[UI]** Disable player slots for non-flyable aircraft.
 

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1432,7 +1432,10 @@ class Fob(ControlPoint):
         return len(self.helipads)
 
     def can_operate(self, aircraft: AircraftType) -> bool:
-        return aircraft.helicopter
+        # FOBs and FARPs are the same class, distinguished only by non-FARP FOBs having
+        # zero parking.
+        # https://github.com/dcs-liberation/dcs_liberation/issues/2378
+        return aircraft.helicopter and self.total_aircraft_parking > 0
 
     @property
     def heading(self) -> Heading:


### PR DESCRIPTION
Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2378.