### PR TITLE
Fix offshore targets for WW2 factions.

### DIFF
--- a/game/data/building_data.py
+++ b/game/data/building_data.py
@@ -1,10 +1,12 @@
 import inspect
+
 import dcs
 
 REQUIRED_BUILDINGS = [
     "ammo",
     "factory",
     "fob",
+    "oil",
 ]
 
 IADS_BUILDINGS = [
@@ -15,7 +17,6 @@ IADS_BUILDINGS = [
 
 DEFAULT_AVAILABLE_BUILDINGS = [
     "fuel",
-    "oil",
     "ware",
     "farp",
     "derrick",


### PR DESCRIPTION
This makes the oil platform a required building so that all factions can use it. Alternatively, we could pick a different offshore target for WW2 factions, or gracefully degrade to not generating these targets for WW2 factions. This approach seems to best match the designer's intent.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2322.
