### PR TITLE
Support quad zones for scenery objectives.

### DIFF
--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -13,7 +13,6 @@ from dcs.planes import F_15C
 from dcs.ships import HandyWind, LHA_Tarawa, Stennis, USS_Arleigh_Burke_IIa
 from dcs.statics import Fortification, Warehouse
 from dcs.terrain import Airport
-from dcs.triggers import TriggerZoneCircular
 from dcs.unitgroup import PlaneGroup, ShipGroup, StaticGroup, VehicleGroup
 from dcs.vehicles import AirDefence, Armor, MissilesSS, Unarmed
 
@@ -237,11 +236,7 @@ class MizCampaignLoader:
 
     @property
     def scenery(self) -> List[SceneryGroup]:
-        return SceneryGroup.from_trigger_zones(
-            z
-            for z in self.mission.triggers._zones
-            if isinstance(z, TriggerZoneCircular)
-        )
+        return SceneryGroup.from_trigger_zones(z for z in self.mission.triggers.zones())
 
     @cached_property
     def control_points(self) -> dict[UUID, ControlPoint]:

--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from functools import cached_property
 from pathlib import Path
-from typing import Iterator, List, TYPE_CHECKING, Tuple
+from typing import Iterator, List, TYPE_CHECKING
 from uuid import UUID
 
 from dcs import Mission
@@ -17,7 +17,6 @@ from dcs.triggers import TriggerZoneCircular
 from dcs.unitgroup import PlaneGroup, ShipGroup, StaticGroup, VehicleGroup
 from dcs.vehicles import AirDefence, Armor, MissilesSS, Unarmed
 
-from game.positioned import Positioned
 from game.profiling import logged_duration
 from game.scenery_group import SceneryGroup
 from game.theater.controlpoint import (
@@ -29,7 +28,6 @@ from game.theater.controlpoint import (
     OffMapSpawn,
 )
 from game.theater.presetlocation import PresetLocation
-from game.utils import Distance, meters
 
 if TYPE_CHECKING:
     from game.theater.conflicttheater import ConflictTheater
@@ -355,108 +353,103 @@ class MizCampaignLoader:
                 origin, list(reversed(waypoints))
             )
 
-    def objective_info(
-        self, near: Positioned, allow_naval: bool = False
-    ) -> Tuple[ControlPoint, Distance]:
-        closest = self.theater.closest_control_point(near.position, allow_naval)
-        distance = meters(closest.position.distance_to_point(near.position))
-        return closest, distance
-
     def add_preset_locations(self) -> None:
         for static in self.offshore_strike_targets:
-            closest, distance = self.objective_info(static)
+            closest = self.theater.closest_control_point(static.position)
             closest.preset_locations.offshore_strike_locations.append(
                 PresetLocation.from_group(static)
             )
 
         for ship in self.ships:
-            closest, distance = self.objective_info(ship, allow_naval=True)
+            closest = self.theater.closest_control_point(
+                ship.position, allow_naval=True
+            )
             closest.preset_locations.ships.append(PresetLocation.from_group(ship))
 
         for group in self.missile_sites:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.missile_sites.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.coastal_defenses:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.coastal_defenses.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.long_range_sams:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.long_range_sams.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.medium_range_sams:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.medium_range_sams.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.short_range_sams:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.short_range_sams.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.aaa:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.aaa.append(PresetLocation.from_group(group))
 
         for group in self.ewrs:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.ewrs.append(PresetLocation.from_group(group))
 
         for group in self.armor_groups:
-            closest, distance = self.objective_info(group)
+            closest = self.theater.closest_control_point(group.position)
             closest.preset_locations.armor_groups.append(
                 PresetLocation.from_group(group)
             )
 
         for static in self.helipads:
-            closest, distance = self.objective_info(static)
+            closest = self.theater.closest_control_point(static.position)
             closest.helipads.append(PresetLocation.from_group(static))
 
         for static in self.factories:
-            closest, distance = self.objective_info(static)
+            closest = self.theater.closest_control_point(static.position)
             closest.preset_locations.factories.append(PresetLocation.from_group(static))
 
         for static in self.ammunition_depots:
-            closest, distance = self.objective_info(static)
+            closest = self.theater.closest_control_point(static.position)
             closest.preset_locations.ammunition_depots.append(
                 PresetLocation.from_group(static)
             )
 
         for static in self.strike_targets:
-            closest, distance = self.objective_info(static)
+            closest = self.theater.closest_control_point(static.position)
             closest.preset_locations.strike_locations.append(
                 PresetLocation.from_group(static)
             )
 
         for iads_command_center in self.iads_command_centers:
-            closest, distance = self.objective_info(iads_command_center)
+            closest = self.theater.closest_control_point(iads_command_center.position)
             closest.preset_locations.iads_command_center.append(
                 PresetLocation.from_group(iads_command_center)
             )
 
         for iads_connection_node in self.iads_connection_nodes:
-            closest, distance = self.objective_info(iads_connection_node)
+            closest = self.theater.closest_control_point(iads_connection_node.position)
             closest.preset_locations.iads_connection_node.append(
                 PresetLocation.from_group(iads_connection_node)
             )
 
         for iads_power_source in self.iads_power_sources:
-            closest, distance = self.objective_info(iads_power_source)
+            closest = self.theater.closest_control_point(iads_power_source.position)
             closest.preset_locations.iads_power_source.append(
                 PresetLocation.from_group(iads_power_source)
             )
 
         for scenery_group in self.scenery:
-            closest, distance = self.objective_info(scenery_group)
+            closest = self.theater.closest_control_point(scenery_group.centroid)
             closest.preset_locations.scenery.append(scenery_group)
 
     def populate_theater(self) -> None:

--- a/game/scenery_group.py
+++ b/game/scenery_group.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Iterable, List
 
-from dcs import Point
 from dcs.triggers import TriggerZoneCircular
 
 from game.theater.theatergroundobject import NAME_BY_CATEGORY
@@ -28,11 +27,6 @@ class SceneryGroup:
         self.target_zones = target_zones
         self.centroid = group_zone.position
         self.category = category
-
-    @property
-    def position(self) -> Point:
-        # TODO: Remove this property. It cannot have a useful answer for quad zones.
-        return self.centroid
 
     @staticmethod
     def from_trigger_zones(

--- a/game/scenery_group.py
+++ b/game/scenery_group.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Iterable
 
+from dcs import Point
 from dcs.triggers import TriggerZoneCircular
 
 from game.theater.theatergroundobject import NAME_BY_CATEGORY
-
-
-class SceneryGroupError(RuntimeError):
-    """Error for when there are insufficient conditions to create a SceneryGroup."""
-
-    pass
 
 
 class SceneryGroup:
@@ -18,79 +13,97 @@ class SceneryGroup:
 
     def __init__(
         self,
-        group_zone: TriggerZoneCircular,
-        target_zones: Iterable[TriggerZoneCircular],
+        name: str,
+        centroid: Point,
         category: str,
+        target_zones: Iterable[TriggerZoneCircular],
     ) -> None:
+        if not target_zones:
+            raise ValueError(f"{name} has no valid target zones")
 
-        self.group_zone = group_zone
-        self.target_zones = target_zones
-        self.centroid = group_zone.position
+        if category not in NAME_BY_CATEGORY:
+            raise ValueError(
+                f"Campaign objective {name} uses unknown scenery objective "
+                f"category: {category}"
+            )
+
+        self.name = name
+        self.centroid = centroid
         self.category = category
+        self.target_zones = list(target_zones)
+
+    @staticmethod
+    def category_of(group_zone: TriggerZoneCircular) -> str:
+        try:
+            # The first (1-indexed because lua) property of the group zone defines the
+            # TGO category.
+            category = group_zone.properties[1].get("value").lower()
+        except IndexError as ex:
+            raise RuntimeError(
+                f"{group_zone.name} does not define an objective category"
+            ) from ex
+        return category
+
+    @staticmethod
+    def from_group_zone(
+        group_zone: TriggerZoneCircular,
+        unclaimed_target_zones: list[TriggerZoneCircular],
+    ) -> SceneryGroup:
+        return SceneryGroup(
+            group_zone.name,
+            group_zone.position,
+            SceneryGroup.category_of(group_zone),
+            SceneryGroup.claim_targets_for(group_zone, unclaimed_target_zones),
+        )
 
     @staticmethod
     def from_trigger_zones(
         trigger_zones: Iterable[TriggerZoneCircular],
-    ) -> List[SceneryGroup]:
-        """Define scenery objectives based on their encompassing blue/red circle."""
+    ) -> list[SceneryGroup]:
+        """Define scenery objectives based on their encompassing blue circle."""
+        group_zones, target_zones = SceneryGroup.collect_scenery_zones(trigger_zones)
+        return [SceneryGroup.from_group_zone(z, target_zones) for z in group_zones]
+
+    @staticmethod
+    def claim_targets_for(
+        group_zone: TriggerZoneCircular,
+        unclaimed_target_zones: list[TriggerZoneCircular],
+    ) -> list[TriggerZoneCircular]:
+        claimed_zones = []
+        for zone in list(unclaimed_target_zones):
+            if zone.position.distance_to_point(group_zone.position) < group_zone.radius:
+                claimed_zones.append(zone)
+                unclaimed_target_zones.remove(zone)
+        return claimed_zones
+
+    @staticmethod
+    def collect_scenery_zones(
+        zones: Iterable[TriggerZoneCircular],
+    ) -> tuple[list[TriggerZoneCircular], list[TriggerZoneCircular]]:
         group_zones = []
         target_zones = []
-
-        scenery_groups = []
-
-        # Aggregate trigger zones into different groups based on color.
-        for zone in trigger_zones:
+        for zone in zones:
             if SceneryGroup.is_group_zone(zone):
                 group_zones.append(zone)
             if SceneryGroup.is_target_zone(zone):
                 target_zones.append(zone)
+            # No error on else. We're iterating over all the trigger zones in the miz,
+            # and others might be used for something else.
+        return group_zones, target_zones
 
-        # For each objective definition.
-        for group_zone in group_zones:
-
-            zone_def_radius = group_zone.radius
-            zone_def_position = group_zone.position
-            zone_def_name = group_zone.name
-
-            if len(group_zone.properties) == 0:
-                raise SceneryGroupError(
-                    "Undefined SceneryGroup category in TriggerZone: " + zone_def_name
-                )
-
-            # Arbitrary campaign design requirement:  First property must define the category.
-            zone_def_category = group_zone.properties[1].get("value").lower()
-
-            valid_target_zones = []
-
-            for zone in list(target_zones):
-                if zone.position.distance_to_point(zone_def_position) < zone_def_radius:
-                    valid_target_zones.append(zone)
-                    target_zones.remove(zone)
-
-            if len(valid_target_zones) > 0 and zone_def_category in NAME_BY_CATEGORY:
-                scenery_groups.append(
-                    SceneryGroup(group_zone, valid_target_zones, zone_def_category)
-                )
-            elif len(valid_target_zones) == 0:
-                raise SceneryGroupError(
-                    "No white triggerzones found in: " + zone_def_name
-                )
-            elif zone_def_category not in NAME_BY_CATEGORY:
-                raise SceneryGroupError(
-                    "Incorrect TriggerZone category definition for: "
-                    + zone_def_name
-                    + " in campaign definition.  TriggerZone category: "
-                    + zone_def_category
-                )
-
-        return scenery_groups
+    @staticmethod
+    def zone_has_color_rgb(
+        zone: TriggerZoneCircular, r: float, g: float, b: float
+    ) -> bool:
+        # TriggerZone.color is a dict with keys 1 through 4, each being a component of
+        # RGBA. It's absurd that it's a dict, but that's a lua quirk that's leaking from
+        # pydcs.
+        return (zone.color[1], zone.color[2], zone.color[3]) == (r, g, b)
 
     @staticmethod
     def is_group_zone(zone: TriggerZoneCircular) -> bool:
-        # Blue in RGB is [0 Red], [0 Green], [1 Blue]. Ignore the fourth position: Transparency.
-        return zone.color[1] == 0 and zone.color[2] == 0 and zone.color[3] == 1
+        return SceneryGroup.zone_has_color_rgb(zone, r=0, g=0, b=1)
 
     @staticmethod
     def is_target_zone(zone: TriggerZoneCircular) -> bool:
-        # White in RGB is [1 Red], [1 Green], [1 Blue]. Ignore the fourth position: Transparency.
-        return zone.color[1] == 1 and zone.color[2] == 1 and zone.color[3] == 1
+        return SceneryGroup.zone_has_color_rgb(zone, r=1, g=1, b=1)

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -380,12 +380,12 @@ class AirbaseGroundObjectGenerator(ControlPointGroundObjectGenerator):
         g = tgo_type(
             namegen.random_objective_name(),
             scenery.category,
-            PresetLocation(scenery.group_zone.name, scenery.centroid),
+            PresetLocation(scenery.name, scenery.centroid),
             self.control_point,
         )
         ground_group = TheaterGroup(
             self.game.next_group_id(),
-            scenery.group_zone.name,
+            scenery.name,
             PointWithHeading.from_point(scenery.centroid, Heading.from_degrees(0)),
             [],
             g,

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -380,13 +380,13 @@ class AirbaseGroundObjectGenerator(ControlPointGroundObjectGenerator):
         g = tgo_type(
             namegen.random_objective_name(),
             scenery.category,
-            PresetLocation(scenery.zone_def.name, scenery.position),
+            PresetLocation(scenery.group_zone.name, scenery.centroid),
             self.control_point,
         )
         ground_group = TheaterGroup(
             self.game.next_group_id(),
-            scenery.zone_def.name,
-            PointWithHeading.from_point(scenery.position, Heading.from_degrees(0)),
+            scenery.group_zone.name,
+            PointWithHeading.from_point(scenery.centroid, Heading.from_degrees(0)),
             [],
             g,
         )
@@ -396,7 +396,7 @@ class AirbaseGroundObjectGenerator(ControlPointGroundObjectGenerator):
 
         g.groups.append(ground_group)
         # Each nested trigger zone is a target/building/unit for an objective.
-        for zone in scenery.zones:
+        for zone in scenery.target_zones:
             zone.name = escape_string_for_lua(zone.name)
             scenery_unit = SceneryUnit(
                 zone.id,

--- a/game/version.py
+++ b/game/version.py
@@ -166,4 +166,7 @@ VERSION = _build_version_string()
 #:
 #: Version 10.4
 #: * Support for the Falklands.
-CAMPAIGN_FORMAT_VERSION = (10, 4)
+#:
+#: Version 10.5
+#: * Support for scenery objectives defined by quad zones.
+CAMPAIGN_FORMAT_VERSION = (10, 5)

--- a/resources/campaigns/golan_heights_lite.yaml
+++ b/resources/campaigns/golan_heights_lite.yaml
@@ -7,7 +7,7 @@ recommended_enemy_faction: Syria 2011
 description: <p>In this scenario, you start in Israel and the conflict is focused around the golan heights, an historically disputed territory.<br/><br/>This scenario is designed to be performance and helicopter friendly.</p>
 miz: golan_heights_lite.miz
 performance: 1
-version: "10.1"
+version: "10.5"
 advanced_iads: true # Campaign has connection_nodes / power_sources / command_centers
 iads_config:
   - LHA-1 Tarawa # A Naval Group without connections but still participating as EWR

--- a/resources/campaigns/operation_peace_spring.yaml
+++ b/resources/campaigns/operation_peace_spring.yaml
@@ -8,7 +8,7 @@ description: <p>This is a semi-fictional what-if scenario for Operation Peace Sp
 miz: operation_peace_spring.miz
 performance: 1
 recommended_start_date: 2019-12-23
-version: "10.0"
+version: "10.5"
 squadrons:
 # Ramat David
   30:

--- a/resources/campaigns/operation_vectrons_claw.yaml
+++ b/resources/campaigns/operation_vectrons_claw.yaml
@@ -8,7 +8,7 @@ description: <p>United Nations Observer Mission in Georgia (UNOMIG) observers st
 miz: operation_vectrons_claw.miz
 performance: 1
 recommended_start_date: 2008-08-08
-version: "10.0"
+version: "10.5"
 squadrons:
   Blue CV-1:
     - primary: BARCAP


### PR DESCRIPTION
This works by recreating the trigger zone in the generated mission to exactly (aside from the ID, and a possibly escaped name) match the one from the campaign definition.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2377.
Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2473.