### PR TITLE
Corrected Polish faction Leopard 2 variants

### DIFF
--- a/resources/factions/poland_2010.json
+++ b/resources/factions/poland_2010.json
@@ -21,7 +21,8 @@
   "frontline_units": [
     "BMP-1",
     "BRDM-2",
-    "Leopard 2",
+    "Leopard 2A4",
+    "Leopard 2A5",
     "M1043 HMMWV (M2 HMG)",
     "M1045 HMMWV (BGM-71 TOW)",
     "M1126 Stryker ICV (M2 HMG)",


### PR DESCRIPTION
Corrected the Polish faction Leopard 2 variants. The old "Leopard 2" maps to the Leopard 2A6 variant whereas The Polish Land Forces operate Leopard 2A4s and Leopard 2A5s.