### PR TITLE
Add missing IADS Network update functionality

### DIFF
--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -132,10 +132,20 @@ class MissionResultsProcessor:
 
     @staticmethod
     def commit_ground_losses(debriefing: Debriefing, events: GameUpdateEvents) -> None:
+        killed_ground_objects = []
         for ground_object_loss in debriefing.ground_object_losses:
             ground_object_loss.theater_unit.kill(events)
+            killed_ground_objects.append(ground_object_loss.theater_unit.ground_object)
         for scenery_object_loss in debriefing.scenery_object_losses:
             scenery_object_loss.ground_unit.kill(events)
+            killed_ground_objects.append(scenery_object_loss.ground_unit.ground_object)
+
+        # Update the IADS network if any participant had losses
+        iads_network = debriefing.game.theater.iads_network
+        for killed_ground_object in killed_ground_objects:
+            if killed_ground_object in iads_network.participating:
+                iads_network.update_network(events)
+                return
 
     @staticmethod
     def commit_damaged_runways(debriefing: Debriefing) -> None:

--- a/game/theater/iadsnetwork/iadsnetwork.py
+++ b/game/theater/iadsnetwork/iadsnetwork.py
@@ -261,19 +261,20 @@ class IadsNetwork:
 
     def _add_connections_by_range(self, node: IadsNetworkNode) -> None:
         """Add all connections for the given primary node based range calculation"""
-        go = node.group.ground_object
+        primary_tgo = node.group.ground_object
         for nearby_go in self.ground_objects.values():
             # Find nearby Power or Connection
-            if nearby_go == go:
+            if nearby_go == primary_tgo:
                 continue
+            nearby_iads_role = IadsRole.for_category(nearby_go.category)
             if (
-                IadsRole.for_category(go.category)
+                nearby_iads_role
                 in [
                     IadsRole.POWER_SOURCE,
                     IadsRole.CONNECTION_NODE,
                 ]
-                and nearby_go.position.distance_to_point(go.position)
-                <= node.group.iads_role.connection_range.meters
+                and nearby_go.position.distance_to_point(primary_tgo.position)
+                <= nearby_iads_role.connection_range.meters
             ):
                 node.add_connection_for_tgo(nearby_go)
 

--- a/game/theater/iadsnetwork/iadsnetwork.py
+++ b/game/theater/iadsnetwork/iadsnetwork.py
@@ -119,6 +119,9 @@ class IadsNetwork:
         for node in self.nodes:
             yield node.group.ground_object
             for connection in node.connections.values():
+                # Check for duplicate secondary node as a secondary node can be
+                # connected to 1..N primary nodes but we do not want to yiel them
+                # multiple times so we prevent dups
                 if connection.ground_object not in secondary_nodes:
                     secondary_nodes.append(connection.ground_object)
         yield from secondary_nodes
@@ -278,7 +281,7 @@ class IadsNetwork:
             try:
                 node.add_connection_for_tgo(self.ground_objects[secondary_node])
             except KeyError:
-                logging.error(
+                logging.exception(
                     f"IADS: No ground object found for connection {secondary_node}"
                 )
                 continue


### PR DESCRIPTION
Finish up the missing updating of the IADS network implementation.

It will now be updated correctly on the following events:
- Capture of CPs with participating TGOs
- MissionDebriefing with killed GroundUnits which were participating in the IADS
- SAM and EWR buys from the BuyMenu

this implements the missing map updates as well #2253