### PR TITLE
Bronco loadouts: "A-4E-C" -> "Bronco-OV-10A"

### DIFF
--- a/resources/customized_payloads/Bronco-OV-10A.lua
+++ b/resources/customized_payloads/Bronco-OV-10A.lua
@@ -1,5 +1,5 @@
 local unitPayloads = {
-	["name"] = "A-4E-C",
+	["name"] = "Bronco-OV-10A",
 	["payloads"] = {
 		[1] = {
 			["name"] = "CAP",


### PR DESCRIPTION
Changed the "name" in the OV-10A Bronco loadout file from "A-4E-C" to "Bronco-OV-10A".