### PR TITLE
Increase wind speed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Added performance option to not cull IADS when culling would effect how mission is played at target area.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system
 * **[Mission Generation]** Added information about the modulation (AM/FM) of the assigned frequencies to the kneeboard and assign AM modulation instead of FM for JTAC.
+* **[Mission Generation]** Adjusted wind speeds.  Wind speeds at high altitude are generally higher now.
 * **[Factions]** Updated the Faction file structure. Older custom faction files will not work correctly and have to be updated to the new structure.
 * **[Flight Planning]**  Added preset formations for different flight types at hold, join, ingress, and split waypoints.  Air to Air flights will tend toward line-abreast and spread-four formations.  Air to ground flights will tend towards trail formation.
 * **[Flight Planning]** Added the ability to plan tankers for recovery on package flights.  AI does not plan.

--- a/game/weather.py
+++ b/game/weather.py
@@ -12,7 +12,15 @@ from dcs.weather import CloudPreset, Weather as PydcsWeather, Wind
 from game.theater.daytimemap import DaytimeMap
 from game.theater.seasonalconditions import determine_season
 from game.timeofday import TimeOfDay
-from game.utils import Distance, Heading, Pressure, inches_hg, interpolate, meters
+from game.utils import (
+    Distance,
+    Heading,
+    Pressure,
+    inches_hg,
+    interpolate,
+    knots,
+    meters,
+)
 
 if TYPE_CHECKING:
     from game.settings import Settings
@@ -176,15 +184,24 @@ class Weather:
                 3,
             ]
         )
-        at_8000m_factor = 8 + high_alt_variation
+        at_8000m_factor = at_2000m_factor + 5 + high_alt_variation
 
         base_wind = random.randint(minimum, maximum)
+
+        # DCS is limited to 97 knots wind speed.
+        max_supported_wind_speed = knots(97).meters_per_second
 
         return WindConditions(
             # Always some wind to make the smoke move a bit.
             at_0m=Wind(wind_direction.degrees, max(1, base_wind * at_0m_factor)),
-            at_2000m=Wind(wind_direction_2000m.degrees, base_wind * at_2000m_factor),
-            at_8000m=Wind(wind_direction_8000m.degrees, base_wind * at_8000m_factor),
+            at_2000m=Wind(
+                wind_direction_2000m.degrees,
+                min(max_supported_wind_speed, base_wind * at_2000m_factor),
+            ),
+            at_8000m=Wind(
+                wind_direction_8000m.degrees,
+                min(max_supported_wind_speed, base_wind * at_8000m_factor),
+            ),
         )
 
     @staticmethod

--- a/game/weather.py
+++ b/game/weather.py
@@ -148,8 +148,36 @@ class Weather:
         wind_direction_2000m = wind_direction + Heading.random(-90, 90)
         wind_direction_8000m = wind_direction + Heading.random(-90, 90)
         at_0m_factor = 1
-        at_2000m_factor = 2
-        at_8000m_factor = 3
+        at_2000m_factor = 3 + random.choice([0, 0, 0, 0, 0, 1, 1])
+
+        high_alt_variation = random.choice(
+            [
+                -3,
+                -3,
+                -2,
+                -2,
+                -2,
+                -2,
+                -2,
+                -2,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                0,
+                0,
+                0,
+                1,
+                1,
+                2,
+                3,
+            ]
+        )
+        at_8000m_factor = 8 + high_alt_variation
+
         base_wind = random.randint(minimum, maximum)
 
         return WindConditions(
@@ -235,7 +263,7 @@ class Cloudy(Weather):
         return None
 
     def generate_wind(self) -> WindConditions:
-        return self.random_wind(1, 4)
+        return self.random_wind(2, 4)
 
 
 class Raining(Weather):
@@ -255,7 +283,7 @@ class Raining(Weather):
         return None
 
     def generate_wind(self) -> WindConditions:
-        return self.random_wind(1, 6)
+        return self.random_wind(2, 6)
 
 
 class Thunderstorm(Weather):
@@ -276,7 +304,7 @@ class Thunderstorm(Weather):
         )
 
     def generate_wind(self) -> WindConditions:
-        return self.random_wind(1, 8)
+        return self.random_wind(2, 8)
 
 
 @dataclass


### PR DESCRIPTION
Increased wind speeds at elevation, and used a histogram to influence wind speed variation.

I couldn't find any models that we could use to generate data at elevation.  The models that are out there that we could use are already handled for us by DCS.  I ended up taking an educated guess.  Wind speeds at elevation generally hover at around 40 knots.  Occasional spikes to 20 or 60 knots, and the very infrequent spike to 100+ knots.

One issue I had come across which I didn't do anything until I got feedback on is that DCS has a hard limit of 97 knots for most of the wind speed fields.  Should we limit ourselves to 97 knots too (otherwise we get mismatched weather preview and in game weather)?
