### PR TITLE
Add turbulence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system
 * **[Mission Generation]** Added information about the modulation (AM/FM) of the assigned frequencies to the kneeboard and assign AM modulation instead of FM for JTAC.
 * **[Mission Generation]** Adjusted wind speeds.  Wind speeds at high altitude are generally higher now.
+* **[Mission Generation]** Added turbulance.  Higher in Summer and Winter, also higher at day time than at night time.
 * **[Factions]** Updated the Faction file structure. Older custom faction files will not work correctly and have to be updated to the new structure.
 * **[Flight Planning]**  Added preset formations for different flight types at hold, join, ingress, and split waypoints.  Air to Air flights will tend toward line-abreast and spread-four formations.  Air to ground flights will tend towards trail formation.
 * **[Flight Planning]** Added the ability to plan tankers for recovery on package flights.  AI does not plan.

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ Saves from 5.x are not compatible with 6.0.
 * **[Mission Generation]** Reworked the ground object generation which now uses a new layout system
 * **[Mission Generation]** Added information about the modulation (AM/FM) of the assigned frequencies to the kneeboard and assign AM modulation instead of FM for JTAC.
 * **[Mission Generation]** Adjusted wind speeds.  Wind speeds at high altitude are generally higher now.
-* **[Mission Generation]** Added turbulance.  Higher in Summer and Winter, also higher at day time than at night time.
+* **[Mission Generation]** Added turbulence.  Higher in Summer and Winter, also higher at day time than at night time.
 * **[Factions]** Updated the Faction file structure. Older custom faction files will not work correctly and have to be updated to the new structure.
 * **[Flight Planning]**  Added preset formations for different flight types at hold, join, ingress, and split waypoints.  Air to Air flights will tend toward line-abreast and spread-four formations.  Air to ground flights will tend towards trail formation.
 * **[Flight Planning]** Added the ability to plan tankers for recovery on package flights.  AI does not plan.

--- a/game/missiongenerator/environmentgenerator.py
+++ b/game/missiongenerator/environmentgenerator.py
@@ -17,6 +17,7 @@ class EnvironmentGenerator:
     def set_atmospheric(self, atmospheric: AtmosphericConditions) -> None:
         self.mission.weather.qnh = atmospheric.qnh.mm_hg
         self.mission.weather.season_temperature = atmospheric.temperature_celsius
+        self.mission.weather.turbulence_at_ground = int(atmospheric.turbulance_per_10cm)
 
     def set_clouds(self, clouds: Optional[Clouds]) -> None:
         if clouds is None:

--- a/game/missiongenerator/environmentgenerator.py
+++ b/game/missiongenerator/environmentgenerator.py
@@ -17,7 +17,7 @@ class EnvironmentGenerator:
     def set_atmospheric(self, atmospheric: AtmosphericConditions) -> None:
         self.mission.weather.qnh = atmospheric.qnh.mm_hg
         self.mission.weather.season_temperature = atmospheric.temperature_celsius
-        self.mission.weather.turbulence_at_ground = int(atmospheric.turbulance_per_10cm)
+        self.mission.weather.turbulence_at_ground = int(atmospheric.turbulence_per_10cm)
 
     def set_clouds(self, clouds: Optional[Clouds]) -> None:
         if clouds is None:

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -400,6 +400,9 @@ class BriefingPage(KneeboardPage):
             f"Temperature: {round(self.weather.atmospheric.temperature_celsius)} °C at sea level"
         )
         writer.text(f"QNH: {qnh_in_hg} inHg / {qnh_mm_hg} mmHg / {qnh_hpa} hPa")
+        writer.text(
+            f"Turbulance: {round(self.weather.atmospheric.turbulance_per_10cm)} per 10cm at ground level."
+        )
 
         fl = self.flight
 

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -401,7 +401,7 @@ class BriefingPage(KneeboardPage):
         )
         writer.text(f"QNH: {qnh_in_hg} inHg / {qnh_mm_hg} mmHg / {qnh_hpa} hPa")
         writer.text(
-            f"Turbulance: {round(self.weather.atmospheric.turbulance_per_10cm)} per 10cm at ground level."
+            f"Turbulence: {round(self.weather.atmospheric.turbulence_per_10cm)} per 10cm at ground level."
         )
 
         fl = self.flight

--- a/game/theater/seasonalconditions.py
+++ b/game/theater/seasonalconditions.py
@@ -45,4 +45,9 @@ class SeasonalConditions:
     winter_avg_temperature: float
     temperature_day_night_difference: float
 
+    high_avg_yearly_turbulance_per_10cm: float
+    low_avg_yearly_turbulance_per_10cm: float
+    solar_noon_turbulance_per_10cm: float
+    midnight_turbulance_per_10cm: float
+
     weather_type_chances: dict[Season, WeatherTypeChances]

--- a/game/theater/seasonalconditions.py
+++ b/game/theater/seasonalconditions.py
@@ -45,9 +45,9 @@ class SeasonalConditions:
     winter_avg_temperature: float
     temperature_day_night_difference: float
 
-    high_avg_yearly_turbulance_per_10cm: float
-    low_avg_yearly_turbulance_per_10cm: float
-    solar_noon_turbulance_per_10cm: float
-    midnight_turbulance_per_10cm: float
+    high_avg_yearly_turbulence_per_10cm: float
+    low_avg_yearly_turbulence_per_10cm: float
+    solar_noon_turbulence_per_10cm: float
+    midnight_turbulence_per_10cm: float
 
     weather_type_chances: dict[Season, WeatherTypeChances]

--- a/game/theater/theaterloader.py
+++ b/game/theater/theaterloader.py
@@ -57,6 +57,23 @@ class SeasonData:
         )
 
 
+@dataclass(frozen=True)
+class TurbulanceData:
+    high_avg_yearly_turbulance_per_10cm: float | None
+    low_avg_yearly_turbulance_per_10cm: float | None
+    solar_noon_turbulance_per_10cm: float | None
+    midnight_turbulance_per_10cm: float | None
+
+    @staticmethod
+    def from_yaml(data: dict[str, Any]) -> TurbulanceData:
+        return TurbulanceData(
+            data.get("high_avg_yearly_turbulance_per_10cm"),
+            data.get("low_avg_yearly_turbulance_per_10cm"),
+            data.get("solar_noon_turbulance_per_10cm"),
+            data.get("midnight_turbulance_per_10cm"),
+        )
+
+
 class TheaterLoader:
     THEATER_RESOURCE_DIR = Path("resources/theaters")
 
@@ -113,6 +130,7 @@ class TheaterLoader:
         spring = SeasonData.from_yaml(climate_data["seasons"]["spring"])
         summer = SeasonData.from_yaml(climate_data["seasons"]["summer"])
         fall = SeasonData.from_yaml(climate_data["seasons"]["fall"])
+        turbulance = TurbulanceData.from_yaml(climate_data["turbulance"])
         if summer.average_pressure is None:
             raise RuntimeError(
                 f"{self.descriptor_path} does not define a summer average pressure"
@@ -129,12 +147,32 @@ class TheaterLoader:
             raise RuntimeError(
                 f"{self.descriptor_path} does not define a winter average temperature"
             )
+        if turbulance.high_avg_yearly_turbulance_per_10cm is None:
+            raise RuntimeError(
+                f"{self.descriptor_path} does not define a yearly average high turbulance"
+            )
+        if turbulance.low_avg_yearly_turbulance_per_10cm is None:
+            raise RuntimeError(
+                f"{self.descriptor_path} does not define a yearly average low turbulance"
+            )
+        if turbulance.solar_noon_turbulance_per_10cm is None:
+            raise RuntimeError(
+                f"{self.descriptor_path} does not define a solar noon turbulance"
+            )
+        if turbulance.midnight_turbulance_per_10cm is None:
+            raise RuntimeError(
+                f"{self.descriptor_path} does not define a midnight turbulance"
+            )
         return SeasonalConditions(
             summer.average_pressure,
             winter.average_pressure,
             summer.average_temperature,
             winter.average_temperature,
             climate_data["day_night_temperature_difference"],
+            turbulance.high_avg_yearly_turbulance_per_10cm,
+            turbulance.low_avg_yearly_turbulance_per_10cm,
+            turbulance.solar_noon_turbulance_per_10cm,
+            turbulance.midnight_turbulance_per_10cm,
             {
                 Season.Winter: winter.weather,
                 Season.Spring: spring.weather,

--- a/game/theater/theaterloader.py
+++ b/game/theater/theaterloader.py
@@ -58,19 +58,19 @@ class SeasonData:
 
 
 @dataclass(frozen=True)
-class TurbulanceData:
-    high_avg_yearly_turbulance_per_10cm: float | None
-    low_avg_yearly_turbulance_per_10cm: float | None
-    solar_noon_turbulance_per_10cm: float | None
-    midnight_turbulance_per_10cm: float | None
+class TurbulenceData:
+    high_avg_yearly_turbulence_per_10cm: float | None
+    low_avg_yearly_turbulence_per_10cm: float | None
+    solar_noon_turbulence_per_10cm: float | None
+    midnight_turbulence_per_10cm: float | None
 
     @staticmethod
-    def from_yaml(data: dict[str, Any]) -> TurbulanceData:
-        return TurbulanceData(
-            data.get("high_avg_yearly_turbulance_per_10cm"),
-            data.get("low_avg_yearly_turbulance_per_10cm"),
-            data.get("solar_noon_turbulance_per_10cm"),
-            data.get("midnight_turbulance_per_10cm"),
+    def from_yaml(data: dict[str, Any]) -> TurbulenceData:
+        return TurbulenceData(
+            data.get("high_avg_yearly_turbulence_per_10cm"),
+            data.get("low_avg_yearly_turbulence_per_10cm"),
+            data.get("solar_noon_turbulence_per_10cm"),
+            data.get("midnight_turbulence_per_10cm"),
         )
 
 
@@ -130,7 +130,7 @@ class TheaterLoader:
         spring = SeasonData.from_yaml(climate_data["seasons"]["spring"])
         summer = SeasonData.from_yaml(climate_data["seasons"]["summer"])
         fall = SeasonData.from_yaml(climate_data["seasons"]["fall"])
-        turbulance = TurbulanceData.from_yaml(climate_data["turbulance"])
+        turbulence = TurbulenceData.from_yaml(climate_data["turbulence"])
         if summer.average_pressure is None:
             raise RuntimeError(
                 f"{self.descriptor_path} does not define a summer average pressure"
@@ -147,21 +147,21 @@ class TheaterLoader:
             raise RuntimeError(
                 f"{self.descriptor_path} does not define a winter average temperature"
             )
-        if turbulance.high_avg_yearly_turbulance_per_10cm is None:
+        if turbulence.high_avg_yearly_turbulence_per_10cm is None:
             raise RuntimeError(
-                f"{self.descriptor_path} does not define a yearly average high turbulance"
+                f"{self.descriptor_path} does not define a yearly average high turbulence"
             )
-        if turbulance.low_avg_yearly_turbulance_per_10cm is None:
+        if turbulence.low_avg_yearly_turbulence_per_10cm is None:
             raise RuntimeError(
-                f"{self.descriptor_path} does not define a yearly average low turbulance"
+                f"{self.descriptor_path} does not define a yearly average low turbulence"
             )
-        if turbulance.solar_noon_turbulance_per_10cm is None:
+        if turbulence.solar_noon_turbulence_per_10cm is None:
             raise RuntimeError(
-                f"{self.descriptor_path} does not define a solar noon turbulance"
+                f"{self.descriptor_path} does not define a solar noon turbulence"
             )
-        if turbulance.midnight_turbulance_per_10cm is None:
+        if turbulence.midnight_turbulence_per_10cm is None:
             raise RuntimeError(
-                f"{self.descriptor_path} does not define a midnight turbulance"
+                f"{self.descriptor_path} does not define a midnight turbulence"
             )
         return SeasonalConditions(
             summer.average_pressure,
@@ -169,10 +169,10 @@ class TheaterLoader:
             summer.average_temperature,
             winter.average_temperature,
             climate_data["day_night_temperature_difference"],
-            turbulance.high_avg_yearly_turbulance_per_10cm,
-            turbulance.low_avg_yearly_turbulance_per_10cm,
-            turbulance.solar_noon_turbulance_per_10cm,
-            turbulance.midnight_turbulance_per_10cm,
+            turbulence.high_avg_yearly_turbulence_per_10cm,
+            turbulence.low_avg_yearly_turbulence_per_10cm,
+            turbulence.solar_noon_turbulence_per_10cm,
+            turbulence.midnight_turbulence_per_10cm,
             {
                 Season.Winter: winter.weather,
                 Season.Spring: spring.weather,

--- a/game/weather.py
+++ b/game/weather.py
@@ -319,7 +319,7 @@ class ClearSkies(Weather):
 
     @property
     def turbulence_adjustment(self) -> float:
-        return 0.3
+        return 0.0
 
     def generate_clouds(self) -> Optional[Clouds]:
         return None
@@ -342,7 +342,7 @@ class Cloudy(Weather):
 
     @property
     def turbulence_adjustment(self) -> float:
-        return 0.6
+        return 0.75
 
     def generate_clouds(self) -> Optional[Clouds]:
         return Clouds.random_preset(rain=False)
@@ -366,7 +366,7 @@ class Raining(Weather):
 
     @property
     def turbulence_adjustment(self) -> float:
-        return 0.9
+        return 1.5
 
     def generate_clouds(self) -> Optional[Clouds]:
         return Clouds.random_preset(rain=True)
@@ -390,7 +390,7 @@ class Thunderstorm(Weather):
 
     @property
     def turbulence_adjustment(self) -> float:
-        return 1.2
+        return 3.0
 
     def generate_clouds(self) -> Optional[Clouds]:
         return Clouds(

--- a/game/weather.py
+++ b/game/weather.py
@@ -37,8 +37,8 @@ class AtmosphericConditions:
     #: Temperature at sea level in Celcius.
     temperature_celsius: float
 
-    #: Turbulance per 10 cm.
-    turbulance_per_10cm: float
+    #: Turbulence per 10 cm.
+    turbulence_per_10cm: float
 
 
 @dataclass(frozen=True)
@@ -112,22 +112,22 @@ class Weather:
             day,
         )
 
-        seasonal_turbulance = self.interpolate_seasonal_turbulance(
-            seasonal_conditions.high_avg_yearly_turbulance_per_10cm,
-            seasonal_conditions.low_avg_yearly_turbulance_per_10cm,
+        seasonal_turbulence = self.interpolate_seasonal_turbulence(
+            seasonal_conditions.high_avg_yearly_turbulence_per_10cm,
+            seasonal_conditions.low_avg_yearly_turbulence_per_10cm,
             day,
         )
 
-        day_turbulance = seasonal_conditions.solar_noon_turbulance_per_10cm
-        night_turbulance = seasonal_conditions.midnight_turbulance_per_10cm
-        time_of_day_turbulance = self.interpolate_solar_activity(
-            time_of_day, day_turbulance, night_turbulance
+        day_turbulence = seasonal_conditions.solar_noon_turbulence_per_10cm
+        night_turbulence = seasonal_conditions.midnight_turbulence_per_10cm
+        time_of_day_turbulence = self.interpolate_solar_activity(
+            time_of_day, day_turbulence, night_turbulence
         )
 
-        random_turbulance = random.normalvariate(mu=0, sigma=0.5)
+        random_turbulence = random.normalvariate(mu=0, sigma=0.5)
 
-        turbulance = abs(
-            seasonal_turbulance + time_of_day_turbulance + random_turbulance
+        turbulence = abs(
+            seasonal_turbulence + time_of_day_turbulence + random_turbulence
         )
 
         if time_of_day == TimeOfDay.Day:
@@ -136,14 +136,14 @@ class Weather:
             temperature -= seasonal_conditions.temperature_day_night_difference / 2
         pressure += self.pressure_adjustment
         temperature += self.temperature_adjustment
-        turbulance += self.turbulance_adjustment
+        turbulence += self.turbulence_adjustment
         logging.debug(
             "Weather: Before random: temp {} press {}".format(temperature, pressure)
         )
         conditions = AtmosphericConditions(
             qnh=self.random_pressure(pressure),
             temperature_celsius=self.random_temperature(temperature),
-            turbulance_per_10cm=turbulance,
+            turbulence_per_10cm=turbulence,
         )
         logging.debug(
             "Weather: After random: temp {} press {}".format(
@@ -161,7 +161,7 @@ class Weather:
         raise NotImplementedError
 
     @property
-    def turbulance_adjustment(self) -> float:
+    def turbulence_adjustment(self) -> float:
         raise NotImplementedError
 
     def generate_clouds(self) -> Optional[Clouds]:
@@ -272,7 +272,7 @@ class Weather:
         return interpolate(summer_value, winter_value, winter_factor, clamp=True)
 
     @staticmethod
-    def interpolate_seasonal_turbulance(
+    def interpolate_seasonal_turbulence(
         high_value: float, low_value: float, day: datetime.date
     ) -> float:
         day_of_year = day.timetuple().tm_yday
@@ -318,7 +318,7 @@ class ClearSkies(Weather):
         return 3.0
 
     @property
-    def turbulance_adjustment(self) -> float:
+    def turbulence_adjustment(self) -> float:
         return 0.3
 
     def generate_clouds(self) -> Optional[Clouds]:
@@ -341,7 +341,7 @@ class Cloudy(Weather):
         return 0.0
 
     @property
-    def turbulance_adjustment(self) -> float:
+    def turbulence_adjustment(self) -> float:
         return 0.6
 
     def generate_clouds(self) -> Optional[Clouds]:
@@ -365,7 +365,7 @@ class Raining(Weather):
         return -3.0
 
     @property
-    def turbulance_adjustment(self) -> float:
+    def turbulence_adjustment(self) -> float:
         return 0.9
 
     def generate_clouds(self) -> Optional[Clouds]:
@@ -389,7 +389,7 @@ class Thunderstorm(Weather):
         return -3.0
 
     @property
-    def turbulance_adjustment(self) -> float:
+    def turbulence_adjustment(self) -> float:
         return 1.2
 
     def generate_clouds(self) -> Optional[Clouds]:

--- a/resources/theaters/caucasus/info.yaml
+++ b/resources/theaters/caucasus/info.yaml
@@ -38,7 +38,7 @@ climate:
         cloudy: 50
         clear: 20
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 4
-    low_avg_yearly_turbulence_per_10cm: 1
-    solar_noon_turbulence_per_10cm: 1
-    midnight_turbulence_per_10cm: 0
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 3.5
+    solar_noon_turbulence_per_10cm: 3.5
+    midnight_turbulence_per_10cm: -3

--- a/resources/theaters/caucasus/info.yaml
+++ b/resources/theaters/caucasus/info.yaml
@@ -37,8 +37,8 @@ climate:
         raining: 30
         cloudy: 50
         clear: 20
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 4
-    low_avg_yearly_turbulance_per_10cm: 1
-    solar_noon_turbulance_per_10cm: 1
-    midnight_turbulance_per_10cm: 0
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 4
+    low_avg_yearly_turbulence_per_10cm: 1
+    solar_noon_turbulence_per_10cm: 1
+    midnight_turbulence_per_10cm: 0

--- a/resources/theaters/caucasus/info.yaml
+++ b/resources/theaters/caucasus/info.yaml
@@ -37,3 +37,8 @@ climate:
         raining: 30
         cloudy: 50
         clear: 20
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 4
+    low_avg_yearly_turbulance_per_10cm: 1
+    solar_noon_turbulance_per_10cm: 1
+    midnight_turbulance_per_10cm: 0

--- a/resources/theaters/falklands/info.yaml
+++ b/resources/theaters/falklands/info.yaml
@@ -47,7 +47,7 @@ climate:
         cloudy: 45
         clear: 25
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 9
-    low_avg_yearly_turbulence_per_10cm: 3
-    solar_noon_turbulence_per_10cm: 2
-    midnight_turbulence_per_10cm: 0
+    high_avg_yearly_turbulence_per_10cm: 8
+    low_avg_yearly_turbulence_per_10cm: 4.5
+    solar_noon_turbulence_per_10cm: 3
+    midnight_turbulence_per_10cm: -2

--- a/resources/theaters/falklands/info.yaml
+++ b/resources/theaters/falklands/info.yaml
@@ -46,3 +46,8 @@ climate:
         raining: 30
         cloudy: 45
         clear: 25
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 9
+    low_avg_yearly_turbulance_per_10cm: 3
+    solar_noon_turbulance_per_10cm: 2
+    midnight_turbulance_per_10cm: 0

--- a/resources/theaters/falklands/info.yaml
+++ b/resources/theaters/falklands/info.yaml
@@ -46,8 +46,8 @@ climate:
         raining: 30
         cloudy: 45
         clear: 25
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 9
-    low_avg_yearly_turbulance_per_10cm: 3
-    solar_noon_turbulance_per_10cm: 2
-    midnight_turbulance_per_10cm: 0
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 3
+    solar_noon_turbulence_per_10cm: 2
+    midnight_turbulence_per_10cm: 0

--- a/resources/theaters/marianaislands/info.yaml
+++ b/resources/theaters/marianaislands/info.yaml
@@ -38,3 +38,8 @@ climate:
         raining: 45
         cloudy: 30
         clear: 20
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 3
+    low_avg_yearly_turbulance_per_10cm: 1
+    solar_noon_turbulance_per_10cm: 2
+    midnight_turbulance_per_10cm: 1

--- a/resources/theaters/marianaislands/info.yaml
+++ b/resources/theaters/marianaislands/info.yaml
@@ -38,8 +38,8 @@ climate:
         raining: 45
         cloudy: 30
         clear: 20
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 3
-    low_avg_yearly_turbulance_per_10cm: 1
-    solar_noon_turbulance_per_10cm: 2
-    midnight_turbulance_per_10cm: 1
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 3
+    low_avg_yearly_turbulence_per_10cm: 1
+    solar_noon_turbulence_per_10cm: 2
+    midnight_turbulence_per_10cm: 1

--- a/resources/theaters/marianaislands/info.yaml
+++ b/resources/theaters/marianaislands/info.yaml
@@ -39,7 +39,7 @@ climate:
         cloudy: 30
         clear: 20
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 3
-    low_avg_yearly_turbulence_per_10cm: 1
+    high_avg_yearly_turbulence_per_10cm: 6.5
+    low_avg_yearly_turbulence_per_10cm: 4.5
     solar_noon_turbulence_per_10cm: 2
-    midnight_turbulence_per_10cm: 1
+    midnight_turbulence_per_10cm: -1

--- a/resources/theaters/nevada/info.yaml
+++ b/resources/theaters/nevada/info.yaml
@@ -38,7 +38,7 @@ climate:
         cloudy: 45
         clear: 45
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 9
-    low_avg_yearly_turbulence_per_10cm: 1
-    solar_noon_turbulence_per_10cm: 6
-    midnight_turbulence_per_10cm: 0
+    high_avg_yearly_turbulence_per_10cm: 17
+    low_avg_yearly_turbulence_per_10cm: 3.5
+    solar_noon_turbulence_per_10cm: 3.5
+    midnight_turbulence_per_10cm: -3

--- a/resources/theaters/nevada/info.yaml
+++ b/resources/theaters/nevada/info.yaml
@@ -37,8 +37,8 @@ climate:
         raining: 10
         cloudy: 45
         clear: 45
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 9
-    low_avg_yearly_turbulance_per_10cm: 1
-    solar_noon_turbulance_per_10cm: 6
-    midnight_turbulance_per_10cm: 0
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 1
+    solar_noon_turbulence_per_10cm: 6
+    midnight_turbulence_per_10cm: 0

--- a/resources/theaters/nevada/info.yaml
+++ b/resources/theaters/nevada/info.yaml
@@ -37,3 +37,8 @@ climate:
         raining: 10
         cloudy: 45
         clear: 45
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 9
+    low_avg_yearly_turbulance_per_10cm: 1
+    solar_noon_turbulance_per_10cm: 6
+    midnight_turbulance_per_10cm: 0

--- a/resources/theaters/normandy/info.yaml
+++ b/resources/theaters/normandy/info.yaml
@@ -37,3 +37,8 @@ climate:
         raining: 30
         cloudy: 50
         clear: 20
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 5
+    low_avg_yearly_turbulance_per_10cm: 2
+    solar_noon_turbulance_per_10cm: 3
+    midnight_turbulance_per_10cm: 1

--- a/resources/theaters/normandy/info.yaml
+++ b/resources/theaters/normandy/info.yaml
@@ -37,8 +37,8 @@ climate:
         raining: 30
         cloudy: 50
         clear: 20
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 5
-    low_avg_yearly_turbulance_per_10cm: 2
-    solar_noon_turbulance_per_10cm: 3
-    midnight_turbulance_per_10cm: 1
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 5
+    low_avg_yearly_turbulence_per_10cm: 2
+    solar_noon_turbulence_per_10cm: 3
+    midnight_turbulence_per_10cm: 1

--- a/resources/theaters/normandy/info.yaml
+++ b/resources/theaters/normandy/info.yaml
@@ -38,7 +38,7 @@ climate:
         cloudy: 50
         clear: 20
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 5
-    low_avg_yearly_turbulence_per_10cm: 2
-    solar_noon_turbulence_per_10cm: 3
-    midnight_turbulence_per_10cm: 1
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 3.5
+    solar_noon_turbulence_per_10cm: 3.5
+    midnight_turbulence_per_10cm: -3

--- a/resources/theaters/persian gulf/info.yaml
+++ b/resources/theaters/persian gulf/info.yaml
@@ -38,3 +38,8 @@ climate:
         raining: 2
         cloudy: 28
         clear: 70
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 8
+    low_avg_yearly_turbulance_per_10cm: 1
+    solar_noon_turbulance_per_10cm: 5
+    midnight_turbulance_per_10cm: 0

--- a/resources/theaters/persian gulf/info.yaml
+++ b/resources/theaters/persian gulf/info.yaml
@@ -39,7 +39,7 @@ climate:
         cloudy: 28
         clear: 70
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 8
-    low_avg_yearly_turbulence_per_10cm: 1
-    solar_noon_turbulence_per_10cm: 5
-    midnight_turbulence_per_10cm: 0
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 4.5
+    solar_noon_turbulence_per_10cm: 5.5
+    midnight_turbulence_per_10cm: -2

--- a/resources/theaters/persian gulf/info.yaml
+++ b/resources/theaters/persian gulf/info.yaml
@@ -38,8 +38,8 @@ climate:
         raining: 2
         cloudy: 28
         clear: 70
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 8
-    low_avg_yearly_turbulance_per_10cm: 1
-    solar_noon_turbulance_per_10cm: 5
-    midnight_turbulance_per_10cm: 0
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 8
+    low_avg_yearly_turbulence_per_10cm: 1
+    solar_noon_turbulence_per_10cm: 5
+    midnight_turbulence_per_10cm: 0

--- a/resources/theaters/syria/info.yaml
+++ b/resources/theaters/syria/info.yaml
@@ -38,7 +38,7 @@ climate:
         cloudy: 35
         clear: 50
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 7
-    low_avg_yearly_turbulence_per_10cm: 2
-    solar_noon_turbulence_per_10cm: 4
-    midnight_turbulence_per_10cm: 1
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 3.5
+    solar_noon_turbulence_per_10cm: 3.5
+    midnight_turbulence_per_10cm: -3

--- a/resources/theaters/syria/info.yaml
+++ b/resources/theaters/syria/info.yaml
@@ -37,3 +37,8 @@ climate:
         raining: 15
         cloudy: 35
         clear: 50
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 7
+    low_avg_yearly_turbulance_per_10cm: 2
+    solar_noon_turbulance_per_10cm: 4
+    midnight_turbulance_per_10cm: 1

--- a/resources/theaters/syria/info.yaml
+++ b/resources/theaters/syria/info.yaml
@@ -37,8 +37,8 @@ climate:
         raining: 15
         cloudy: 35
         clear: 50
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 7
-    low_avg_yearly_turbulance_per_10cm: 2
-    solar_noon_turbulance_per_10cm: 4
-    midnight_turbulance_per_10cm: 1
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 7
+    low_avg_yearly_turbulence_per_10cm: 2
+    solar_noon_turbulence_per_10cm: 4
+    midnight_turbulence_per_10cm: 1

--- a/resources/theaters/the channel/info.yaml
+++ b/resources/theaters/the channel/info.yaml
@@ -39,7 +39,7 @@ climate:
         cloudy: 50
         clear: 20
   turbulence:
-    high_avg_yearly_turbulence_per_10cm: 5
-    low_avg_yearly_turbulence_per_10cm: 2
-    solar_noon_turbulence_per_10cm: 3
-    midnight_turbulence_per_10cm: 1
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 3.5
+    solar_noon_turbulence_per_10cm: 3.5
+    midnight_turbulence_per_10cm: -3

--- a/resources/theaters/the channel/info.yaml
+++ b/resources/theaters/the channel/info.yaml
@@ -38,8 +38,8 @@ climate:
         raining: 30
         cloudy: 50
         clear: 20
-  turbulance:
-    high_avg_yearly_turbulance_per_10cm: 5
-    low_avg_yearly_turbulance_per_10cm: 2
-    solar_noon_turbulance_per_10cm: 3
-    midnight_turbulance_per_10cm: 1
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 5
+    low_avg_yearly_turbulence_per_10cm: 2
+    solar_noon_turbulence_per_10cm: 3
+    midnight_turbulence_per_10cm: 1

--- a/resources/theaters/the channel/info.yaml
+++ b/resources/theaters/the channel/info.yaml
@@ -38,3 +38,8 @@ climate:
         raining: 30
         cloudy: 50
         clear: 20
+  turbulance:
+    high_avg_yearly_turbulance_per_10cm: 5
+    low_avg_yearly_turbulance_per_10cm: 2
+    solar_noon_turbulance_per_10cm: 3
+    midnight_turbulance_per_10cm: 1


### PR DESCRIPTION
Turbulence is based off time of day, and day of year. Each theater may adjust their turbulence parameters.

The values used for turbulence are a guesstimate based off of information found in the DCS forums.  They seem to be reasonable(?).  They can be adjusted later if needed.  Edit:  Wrote a copy of the code in Octave to plot it so it can be tuned easier.

Happy to have feedback, but mostly wanted feedback on the YAML changes/additions.


Here are some charts (units are imperial):
I'm unsure if the day-night swings should be smaller in winter or not, because the form of turbulence changes.  (Solar to Clear Air Turbulence)
![Caucasus_Clear](https://user-images.githubusercontent.com/74509817/202869533-3c4b002a-2cb2-4f37-91e2-8b47da8d2f34.jpeg)
![Nevada_Clear](https://user-images.githubusercontent.com/74509817/202869536-93006293-6680-4c01-91e6-16593ea9a860.jpeg)
![PersianGulf_Clear](https://user-images.githubusercontent.com/74509817/202869537-f4cee1d4-fc90-4160-9b3a-9da6840f036d.jpeg)
[TurbulenceData.zip](https://github.com/dcs-liberation/dcs_liberation/files/10047869/TurbulenceData.zip)
