### PR TITLE
Clarify `AirAssault` flight plan method name.

### DIFF
--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -63,8 +63,7 @@ class AirAssaultFlightPlan(StandardFlightPlan[AirAssaultLayout]):
         return None
 
     @property
-    def engagement_distance(self) -> Distance:
-        # The radius of the WaypointZone created at the target location
+    def ctld_target_zone_radius(self) -> Distance:
         return meters(2500)
 
     @property

--- a/game/missiongenerator/logisticsgenerator.py
+++ b/game/missiongenerator/logisticsgenerator.py
@@ -1,14 +1,15 @@
 from typing import Any, Optional
+
 from dcs import Mission
-from dcs.unitgroup import FlyingGroup
 from dcs.statics import Fortification
+from dcs.unitgroup import FlyingGroup
+
 from game.ato import Flight
 from game.ato.flightplans.airassault import AirAssaultFlightPlan
 from game.ato.flightwaypointtype import FlightWaypointType
 from game.missiongenerator.missiondata import CargoInfo, LogisticsInfo
 from game.settings.settings import Settings
 from game.transfers import TransferOrder
-
 
 ZONE_RADIUS = 300
 CRATE_ZONE_RADIUS = 50
@@ -45,7 +46,7 @@ class LogisticsGenerator:
             target_zone = f"{self.group.name}TARGET_ZONE"
             self.mission.triggers.add_triggerzone(
                 self.flight.flight_plan.layout.target.position,
-                self.flight.flight_plan.engagement_distance.meters,
+                self.flight.flight_plan.ctld_target_zone_radius.meters,
                 False,
                 target_zone,
             )


### PR DESCRIPTION
`engagement_distance` is used elsewhere to mean commit distance, so this looked like a bug when I stumbled across it. Rename it to be more explicit.