### PR TITLE
Clean up refuel waypoint behavior.

### DIFF
--- a/game/ato/flightplans/escort.py
+++ b/game/ato/flightplans/escort.py
@@ -27,9 +27,7 @@ class Builder(FormationAttackBuilder[EscortFlightPlan, FormationAttackLayout]):
         hold = builder.hold(self._hold_point())
         join = builder.join(self.package.waypoints.join)
         split = builder.split(self.package.waypoints.split)
-        refuel = None
-        if self.package.waypoints.refuel is not None:
-            refuel = builder.refuel(self.package.waypoints.refuel)
+        refuel = builder.refuel(self.package.waypoints.refuel)
 
         return FormationAttackLayout(
             departure=builder.takeoff(self.flight.departure),
@@ -43,7 +41,7 @@ class Builder(FormationAttackBuilder[EscortFlightPlan, FormationAttackLayout]):
             split=split,
             refuel=refuel,
             nav_from=builder.nav_path(
-                split.position,
+                refuel.position,
                 self.flight.arrival.position,
                 self.doctrine.ingress_altitude,
             ),

--- a/game/ato/flightplans/formationattack.py
+++ b/game/ato/flightplans/formationattack.py
@@ -181,9 +181,7 @@ class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
         hold = builder.hold(self._hold_point())
         join = builder.join(self.package.waypoints.join)
         split = builder.split(self.package.waypoints.split)
-        refuel = None
-        if self.package.waypoints.refuel is not None:
-            refuel = builder.refuel(self.package.waypoints.refuel)
+        refuel = builder.refuel(self.package.waypoints.refuel)
 
         return FormationAttackLayout(
             departure=builder.takeoff(self.flight.departure),
@@ -199,7 +197,7 @@ class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
             split=split,
             refuel=refuel,
             nav_from=builder.nav_path(
-                split.position,
+                refuel.position,
                 self.flight.arrival.position,
                 self.doctrine.ingress_altitude,
             ),

--- a/game/ato/flightplans/sweep.py
+++ b/game/ato/flightplans/sweep.py
@@ -22,7 +22,6 @@ class SweepLayout(LoiterLayout):
     nav_to: list[FlightWaypoint]
     sweep_start: FlightWaypoint
     sweep_end: FlightWaypoint
-    refuel: FlightWaypoint | None
     nav_from: list[FlightWaypoint]
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
@@ -31,8 +30,6 @@ class SweepLayout(LoiterLayout):
         yield from self.nav_to
         yield self.sweep_start
         yield self.sweep_end
-        if self.refuel is not None:
-            yield self.refuel
         yield from self.nav_from
         yield self.arrival
         if self.divert is not None:
@@ -112,11 +109,6 @@ class Builder(IBuilder[SweepFlightPlan, SweepLayout]):
 
         hold = builder.hold(self._hold_point())
 
-        refuel = None
-
-        if self.package.waypoints is not None:
-            refuel = builder.refuel(self.package.waypoints.refuel)
-
         return SweepLayout(
             departure=builder.takeoff(self.flight.departure),
             hold=hold,
@@ -130,7 +122,6 @@ class Builder(IBuilder[SweepFlightPlan, SweepLayout]):
             ),
             sweep_start=start,
             sweep_end=end,
-            refuel=refuel,
             arrival=builder.land(self.flight.arrival),
             divert=builder.divert(self.flight.divert),
             bullseye=builder.bullseye(),

--- a/game/ato/flightplans/tarcap.py
+++ b/game/ato/flightplans/tarcap.py
@@ -105,9 +105,11 @@ class Builder(CapBuilder[TarCapFlightPlan, TarCapLayout]):
         start, end = builder.race_track(orbit0p, orbit1p, patrol_alt)
 
         refuel = None
+        nav_from_origin = orbit1p
 
         if self.package.waypoints is not None:
             refuel = builder.refuel(self.package.waypoints.refuel)
+            nav_from_origin = refuel.position
 
         return TarCapLayout(
             departure=builder.takeoff(self.flight.departure),
@@ -115,7 +117,7 @@ class Builder(CapBuilder[TarCapFlightPlan, TarCapLayout]):
                 self.flight.departure.position, orbit0p, patrol_alt
             ),
             nav_from=builder.nav_path(
-                orbit1p, self.flight.arrival.position, patrol_alt
+                nav_from_origin, self.flight.arrival.position, patrol_alt
             ),
             patrol_start=start,
             patrol_end=end,


### PR DESCRIPTION
This fixes the layouts for escort, TARCAP, and anything strike-like so that nav waypoints won't cause the flight to go _back_ to the target area after refueling.

The second commit removes refueling waypoints from sweep flights, because the sweep will be gone before the tanker is on station.