### PR TITLE
Hide sim speed controls behind a flag.

### DIFF
--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -28,6 +28,7 @@ from qt_ui import (
     liberation_theme,
     uiconstants,
 )
+from qt_ui.uiflags import UiFlags
 from qt_ui.windows.GameUpdateSignal import GameUpdateSignal
 from qt_ui.windows.QLiberationWindow import QLiberationWindow
 from qt_ui.windows.preferences.QLiberationFirstStartWindow import (
@@ -61,7 +62,7 @@ def on_game_load(game: Game | None) -> None:
     EventStream.put_nowait(GameUpdateEvents().game_loaded(game))
 
 
-def run_ui(game: Game | None, dev: bool) -> None:
+def run_ui(game: Game | None, ui_flags: UiFlags) -> None:
     os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"  # Potential fix for 4K screens
     QApplication.setHighDpiScaleFactorRoundingPolicy(
         Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
@@ -150,7 +151,7 @@ def run_ui(game: Game | None, dev: bool) -> None:
     GameUpdateSignal.get_instance().game_loaded.connect(on_game_load)
 
     # Start window
-    window = QLiberationWindow(game, dev)
+    window = QLiberationWindow(game, ui_flags)
     window.showMaximized()
     splash.finish(window)
     qt_execution_code = app.exec_()
@@ -179,6 +180,19 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument("--dev", action="store_true", help="Enable development mode.")
+
+    speed_controls_group = parser.add_argument_group()
+    speed_controls_group.add_argument(
+        "--show-sim-speed-controls",
+        action="store_true",
+        help="Shows the sim speed controls in the top panel.",
+    )
+    speed_controls_group.add_argument(
+        "--no-show-sim-speed-controls",
+        dest="show_sim_speed_controls",
+        action="store_false",
+        help="Hides the sim speed controls in the top panel (default).",
+    )
 
     parser.add_argument("--new-map", help="Deprecated. Does nothing.")
     parser.add_argument("--old-map", help="Deprecated. Does nothing.")
@@ -364,7 +378,7 @@ def main():
         return
 
     with Server().run_in_thread():
-        run_ui(game, args.dev)
+        run_ui(game, UiFlags(args.dev, args.show_sim_speed_controls))
 
 
 if __name__ == "__main__":

--- a/qt_ui/uiflags.py
+++ b/qt_ui/uiflags.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class UiFlags:
+    """Flags for the UI that are not exposed in settings.
+
+    These flags are hidden from the settings UI because they can only be controlled from
+    the command-line during startup.
+    """
+
+    # True if the front-end should connect to the development react webserver instead of
+    # the built front-end app.
+    dev_ui_webserver: bool
+
+    # True if the play/pause/speed controls should be visible in the top panel.
+    show_sim_speed_controls: bool

--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -17,6 +17,7 @@ from game.profiling import logged_duration
 from game.utils import meters
 from qt_ui.models import GameModel
 from qt_ui.simcontroller import SimController
+from qt_ui.uiflags import UiFlags
 from qt_ui.widgets.QBudgetBox import QBudgetBox
 from qt_ui.widgets.QConditionsWidget import QConditionsWidget
 from qt_ui.widgets.QFactionsInfos import QFactionsInfos
@@ -30,7 +31,9 @@ from qt_ui.windows.QWaitingForMissionResultWindow import QWaitingForMissionResul
 
 
 class QTopPanel(QFrame):
-    def __init__(self, game_model: GameModel, sim_controller: SimController) -> None:
+    def __init__(
+        self, game_model: GameModel, sim_controller: SimController, ui_flags: UiFlags
+    ) -> None:
         super(QTopPanel, self).__init__()
         self.game_model = game_model
         self.sim_controller = sim_controller
@@ -80,7 +83,8 @@ class QTopPanel(QFrame):
 
         self.proceedBox = QGroupBox("Proceed")
         self.proceedBoxLayout = QHBoxLayout()
-        self.proceedBoxLayout.addLayout(SimSpeedControls(sim_controller))
+        if ui_flags.show_sim_speed_controls:
+            self.proceedBoxLayout.addLayout(SimSpeedControls(sim_controller))
         self.proceedBoxLayout.addLayout(MaxPlayerCount(self.game_model.ato_model))
         self.proceedBoxLayout.addWidget(self.passTurnButton)
         self.proceedBoxLayout.addWidget(self.proceedButton)

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -29,6 +29,7 @@ from qt_ui import liberation_install
 from qt_ui.dialogs import Dialog
 from qt_ui.models import GameModel
 from qt_ui.simcontroller import SimController
+from qt_ui.uiflags import UiFlags
 from qt_ui.uncaughtexceptionhandler import UncaughtExceptionHandler
 from qt_ui.widgets.QTopPanel import QTopPanel
 from qt_ui.widgets.ato import QAirTaskingOrderPanel
@@ -54,7 +55,7 @@ class QLiberationWindow(QMainWindow):
     tgo_info_signal = Signal(TheaterGroundObject)
     control_point_info_signal = Signal(ControlPoint)
 
-    def __init__(self, game: Game | None, dev: bool) -> None:
+    def __init__(self, game: Game | None, ui_flags: UiFlags) -> None:
         super().__init__()
 
         self._uncaught_exception_handler = UncaughtExceptionHandler(self)
@@ -79,14 +80,16 @@ class QLiberationWindow(QMainWindow):
         Dialog.set_game(self.game_model)
         self.ato_panel = QAirTaskingOrderPanel(self.game_model)
         self.info_panel = QInfoPanel(self.game)
-        self.liberation_map = QLiberationMap(self.game_model, dev, self)
+        self.liberation_map = QLiberationMap(
+            self.game_model, ui_flags.dev_ui_webserver, self
+        )
 
         self.setGeometry(300, 100, 270, 100)
         self.updateWindowTitle()
         self.setWindowIcon(QIcon("./resources/icon.png"))
         self.statusBar().showMessage("Ready")
 
-        self.initUi()
+        self.initUi(ui_flags)
         self.initActions()
         self.initToolbar()
         self.initMenuBar()
@@ -116,7 +119,7 @@ class QLiberationWindow(QMainWindow):
         else:
             self.onGameGenerated(self.game)
 
-    def initUi(self):
+    def initUi(self, ui_flags: UiFlags) -> None:
         hbox = QSplitter(Qt.Horizontal)
         vbox = QSplitter(Qt.Vertical)
         hbox.addWidget(self.ato_panel)
@@ -131,7 +134,7 @@ class QLiberationWindow(QMainWindow):
 
         vbox = QVBoxLayout()
         vbox.setMargin(0)
-        vbox.addWidget(QTopPanel(self.game_model, self.sim_controller))
+        vbox.addWidget(QTopPanel(self.game_model, self.sim_controller, ui_flags))
         vbox.addWidget(hbox)
 
         central_widget = QWidget()


### PR DESCRIPTION
Flag is only controlled from the command-line because redoing Qt layout usually breaks things. Off by default in 6 since this feature is nowhere near done enough to even be used experimentally (most changes to the ATO made after the sim begins will break the game).

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2535.