### PR TITLE
Fix drop zone display for air assault.

### DIFF
--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -10,6 +10,7 @@ from game.theater.missiontarget import MissionTarget
 from game.utils import Distance, feet, meters
 from .ibuilder import IBuilder
 from .planningerror import PlanningError
+from .uizonedisplay import UiZone, UiZoneDisplay
 from .waypointbuilder import WaypointBuilder
 from ..flightwaypoint import FlightWaypointType
 
@@ -45,7 +46,7 @@ class AirAssaultLayout(StandardLayout):
         yield self.bullseye
 
 
-class AirAssaultFlightPlan(StandardFlightPlan[AirAssaultLayout]):
+class AirAssaultFlightPlan(StandardFlightPlan[AirAssaultLayout], UiZoneDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
@@ -69,6 +70,12 @@ class AirAssaultFlightPlan(StandardFlightPlan[AirAssaultLayout]):
     @property
     def mission_departure_time(self) -> timedelta:
         return self.package.time_over_target
+
+    def ui_zone(self) -> UiZone:
+        return UiZone(
+            [self.layout.target.position],
+            self.ctld_target_zone_radius,
+        )
 
 
 class Builder(IBuilder[AirAssaultFlightPlan, AirAssaultLayout]):

--- a/game/ato/flightplans/cas.py
+++ b/game/ato/flightplans/cas.py
@@ -10,6 +10,7 @@ from game.utils import Distance, Speed, kph, meters
 from .ibuilder import IBuilder
 from .invalidobjectivelocation import InvalidObjectiveLocation
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
+from .uizonedisplay import UiZone, UiZoneDisplay
 from .waypointbuilder import WaypointBuilder
 from ..flightwaypointtype import FlightWaypointType
 
@@ -34,7 +35,7 @@ class CasLayout(PatrollingLayout):
         yield self.bullseye
 
 
-class CasFlightPlan(PatrollingFlightPlan[CasLayout]):
+class CasFlightPlan(PatrollingFlightPlan[CasLayout], UiZoneDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
@@ -65,6 +66,12 @@ class CasFlightPlan(PatrollingFlightPlan[CasLayout]):
 
     def dismiss_escort_at(self) -> FlightWaypoint | None:
         return self.layout.patrol_end
+
+    def ui_zone(self) -> UiZone:
+        return UiZone(
+            [self.layout.target.position],
+            self.engagement_distance,
+        )
 
 
 class Builder(IBuilder[CasFlightPlan, CasLayout]):

--- a/game/ato/flightplans/patrolling.py
+++ b/game/ato/flightplans/patrolling.py
@@ -9,6 +9,7 @@ from typing import Any, TYPE_CHECKING, TypeGuard, TypeVar
 from game.ato.flightplans.standard import StandardFlightPlan, StandardLayout
 from game.typeguard import self_type_guard
 from game.utils import Distance, Speed
+from .uizonedisplay import UiZone, UiZoneDisplay
 
 if TYPE_CHECKING:
     from ..flightwaypoint import FlightWaypoint
@@ -37,7 +38,7 @@ class PatrollingLayout(StandardLayout):
 LayoutT = TypeVar("LayoutT", bound=PatrollingLayout)
 
 
-class PatrollingFlightPlan(StandardFlightPlan[LayoutT], ABC):
+class PatrollingFlightPlan(StandardFlightPlan[LayoutT], UiZoneDisplay, ABC):
     @property
     @abstractmethod
     def patrol_duration(self) -> timedelta:
@@ -97,3 +98,9 @@ class PatrollingFlightPlan(StandardFlightPlan[LayoutT], ABC):
         self, flight_plan: FlightPlan[Any]
     ) -> TypeGuard[PatrollingFlightPlan[Any]]:
         return True
+
+    def ui_zone(self) -> UiZone:
+        return UiZone(
+            [self.layout.patrol_start.position, self.layout.patrol_end.position],
+            self.engagement_distance,
+        )

--- a/game/ato/flightplans/uizonedisplay.py
+++ b/game/ato/flightplans/uizonedisplay.py
@@ -1,0 +1,18 @@
+import abc
+from dataclasses import dataclass
+
+from dcs import Point
+
+from game.utils import Distance
+
+
+@dataclass(frozen=True)
+class UiZone:
+    points: list[Point]
+    radius: Distance
+
+
+class UiZoneDisplay(abc.ABC):
+    @abc.abstractmethod
+    def ui_zone(self) -> UiZone:
+        ...


### PR DESCRIPTION
Troops must be dropped inside this zone or they won't attack the target. The zone needs to be drawn in the map so players don't break the flight plan by accidentally moving the drop waypoint outside the DZ.

I've move the API for doing this out of `PatrollingFlightPlan` in favor of a mixin so this is no longer presented as `engagement_distance` by the flight plan. I don't love that it's still the `commit-boundary` endpoint, but it's fine for now.

I don't know why mypy wasn't able to catch this. pycharm is also struggling to understand this class.