### PR TITLE
Airassault capture trigger

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -338,9 +338,7 @@ class Debriefing:
         seen = set()
         captures = []
         for capture in reversed(self.state_data.base_capture_events):
-            # The ID string in the JSON file will be an airport ID for airport captures
-            # but will be a UUID for all other types, since DCS doesn't know the UUIDs
-            # for the captured FOBs.
+            # The ID string in the JSON file will be the UUID generated from liberation
             cp_id, new_owner_id_str, _name = capture.split("||")
 
             # Only the most recent capture event matters.
@@ -349,13 +347,8 @@ class Debriefing:
             seen.add(cp_id)
 
             try:
-                control_point = self.game.theater.find_control_point_by_airport_id(
-                    int(cp_id)
-                )
-            except ValueError:
-                # The CP ID could not be converted to an int, so it's a UUID.
                 control_point = self.game.theater.find_control_point_by_id(UUID(cp_id))
-            except KeyError:
+            except (KeyError, ValueError):
                 # Captured base is not a part of the campaign. This happens when neutral
                 # bases are near the conflict. Nothing to do.
                 continue

--- a/game/missiongenerator/triggergenerator.py
+++ b/game/missiongenerator/triggergenerator.py
@@ -44,7 +44,7 @@ class Silence(Option):
 
 
 class TriggerGenerator:
-    capture_zone_types = (Fob,)
+    capture_zone_types = (Fob, Airfield)
     capture_zone_flag = 600
 
     def __init__(self, mission: Mission, game: Game) -> None:

--- a/resources/plugins/base/dcs_liberation.lua
+++ b/resources/plugins/base/dcs_liberation.lua
@@ -160,11 +160,6 @@ local function onEvent(event)
         write_state()
     end
 
-    if event.id == world.event.S_EVENT_BASE_CAPTURED and event.place then
-        base_capture_events[#base_capture_events + 1] = event.place.getID(event.place) .. "||" .. event.place.getCoalition(event.place) .. "||" .. event.place.getName(event.place)
-        write_state()
-    end
-
     if event.id == world.event.S_EVENT_MISSION_END then
         mission_ended = true
         write_state()


### PR DESCRIPTION
Adds a capture trigger zone and a corresponding trigger rule for AirAssault target ControlPoints whenever the TriggerGenerator would not automatically generate them (which is only done for Fobs at the moment).

I've choosen that approach instead of just adding Airfield to capture_zone_types to prevent adding more trigger rules then needed which may cost performance (dont know about that but well its DCS..)

fixes #2566 