### PR TITLE
Fix dead carriers

### DIFF
--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -412,8 +412,8 @@ class GenericCarrierGenerator(GroundObjectGenerator):
                     ship_units.append(unit)
 
             if not ship_units:
-                # Empty array (no alive units), stop here
-                return
+                # No alive units in this group, continue with next group
+                continue
 
             ship_group = self.create_ship_group(group.group_name, ship_units, atc)
 

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -405,7 +405,17 @@ class GenericCarrierGenerator(GroundObjectGenerator):
                 logging.warning(f"Found empty carrier group in {self.control_point}")
                 continue
 
-            ship_group = self.create_ship_group(group.group_name, group.units, atc)
+            ship_units = []
+            for unit in group.units:
+                if unit.alive:
+                    # All alive Ships
+                    ship_units.append(unit)
+
+            if not ship_units:
+                # Empty array (no alive units), stop here
+                return
+
+            ship_group = self.create_ship_group(group.group_name, ship_units, atc)
 
             # Always steam into the wind, even if the carrier is being moved.
             # There are multiple unsimulated hours between turns, so we can
@@ -414,7 +424,7 @@ class GenericCarrierGenerator(GroundObjectGenerator):
             brc = self.steam_into_wind(ship_group)
 
             # Set Carrier Specific Options
-            if g_id == 0:
+            if g_id == 0 and self.control_point.runway_is_operational():
                 # Get Correct unit type for the carrier.
                 # This will upgrade to super carrier if option is enabled
                 carrier_type = self.carrier_type

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1200,7 +1200,7 @@ class NavalControlPoint(ControlPoint, ABC):
         # while its escorts are still alive.
         for group in self.find_main_tgo().groups:
             for u in group.units:
-                if u.type in [
+                if u.alive and u.type in [
                     Forrestal,
                     Stennis,
                     LHA_Tarawa,


### PR DESCRIPTION
Reopen #2435 as i am not able to push commits to this pr

@MetalStormGhost With V6 i reworked the ground object handling completly and adopted all other generators but must have missed the carrier generator.  Before the rework units were removed from the units list of a group and therefore would not be generated. Now we use the alive flag for that instead of removing them from the list.

I fixed a small bug in the PR but otherwise it looks good. Thanks!