### PR TITLE
Unfilter the custom waypoint targets.

### DIFF
--- a/game/ato/flightwaypoint.py
+++ b/game/ato/flightwaypoint.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Literal, TYPE_CHECKING
@@ -12,8 +11,7 @@ from game.theater.theatergroup import TheaterUnit
 from game.utils import Distance, meters
 
 if TYPE_CHECKING:
-    from game.theater import ControlPoint, MissionTarget
-
+    from game.theater import ControlPoint
 
 AltitudeReference = Literal["BARO", "RADIO"]
 
@@ -32,7 +30,7 @@ class FlightWaypoint:
     # having three names. A short and long form is enough.
     description: str = ""
 
-    targets: Sequence[MissionTarget | TheaterUnit] = field(default_factory=list)
+    targets: list[TheaterUnit] = field(default_factory=list)
     obj_name: str = ""
     pretty_name: str = ""
     only_for_player: bool = False

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -1,8 +1,9 @@
 import copy
 
+from dcs import Point
 from dcs.planes import B_17G, B_52H, Tu_22M3
 from dcs.point import MovingPoint
-from dcs.task import Bombing, OptFormation, WeaponType, Expend
+from dcs.task import Bombing, Expend, OptFormation, WeaponType
 
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
@@ -21,7 +22,7 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
         if not targets:
             return
 
-        center = copy.copy(targets[0].position)
+        center: Point = copy.copy(targets[0].position)
         for target in targets[1:]:
             center += target.position
         center /= len(targets)


### PR DESCRIPTION
There doesn't appear to be any reason for us to be poking at implementation details here aside from changing the name from "unit" to "building" for that case. Just iterate over the known strike targets.

Making this change uncovered some latent type errors.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2564.