### PR TITLE
Add F-15E to DEAD_CAPABLE in AI flight planner.

### DIFF
--- a/game/ato/ai_flight_planner_db.py
+++ b/game/ato/ai_flight_planner_db.py
@@ -308,6 +308,7 @@ SEAD_CAPABLE = [
 # Aircraft used for DEAD tasks. Must be capable of the CAS DCS task.
 DEAD_CAPABLE = SEAD_CAPABLE + [
     AJS37,
+    F_15E,
     F_14B,
     F_14A_135_GR,
     JAS39Gripen_AG,


### PR DESCRIPTION
Squadron definitions have already defined the F-15E with a DEAD mission set.