### PR TITLE
Add support for Leander class HMS Andromeda from Razbam South Atlantic Assets Pack

### DIFF
--- a/resources/units/ships/leander-gun-andromeda.yaml
+++ b/resources/units/ships/leander-gun-andromeda.yaml
@@ -1,0 +1,4 @@
+class: Frigate
+price: 0
+variants:
+  HMS Andromeda (F57): null


### PR DESCRIPTION
Adds HMS Andromeda from Razbam South Atlantic assets pack that comes with Falklands map 