### PR TITLE
Recovery Tanker for carriers.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Saves from 6.0.0 are compatible with 6.1.0
 
 * **[Factions]** Defaulted bluefor modern to use Georgian and Ukrainian liveries for Russian aircraft.
 * **[Factions]** Added Peru.
+* **[Flight Planning]** Refueling flights planned on aircraft carriers will act as a recovery tanker for the carrier.
 * **[Loadouts]** Adjusted F-15E loadouts.
 * **[Modding]** Added support for the HMS Ariadne, Achilles, and Castle class.
 * **[Modding]** Added HMS Invincible to the game data as a helicopter carrier.

--- a/game/ato/flightplans/flightplanbuildertypes.py
+++ b/game/ato/flightplans/flightplanbuildertypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Type
 
 from game.ato import FlightType
+from game.ato.flightplans.shiprecoverytanker import RecoveryTankerFlightPlan
 from game.theater.controlpoint import Carrier
 from .aewc import AewcFlightPlan
 from .airassault import AirAssaultFlightPlan
@@ -38,7 +39,7 @@ class FlightPlanBuilderTypes:
             if target.is_friendly(flight.squadron.player) and isinstance(
                 target, Carrier
             ):
-                return TheaterRefuelingFlightPlan.builder_type()
+                return RecoveryTankerFlightPlan.builder_type()
             if target.is_friendly(flight.squadron.player) or isinstance(
                 target, FrontLine
             ):

--- a/game/ato/flightplans/flightplanbuildertypes.py
+++ b/game/ato/flightplans/flightplanbuildertypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Type
 
 from game.ato import FlightType
+from game.theater.controlpoint import Carrier
 from .aewc import AewcFlightPlan
 from .airassault import AirAssaultFlightPlan
 from .airlift import AirliftFlightPlan
@@ -33,8 +34,13 @@ class FlightPlanBuilderTypes:
     @staticmethod
     def for_flight(flight: Flight) -> Type[IBuilder[Any, Any]]:
         if flight.flight_type is FlightType.REFUELING:
-            if flight.package.target.is_friendly(flight.squadron.player) or isinstance(
-                flight.package.target, FrontLine
+            target = flight.package.target
+            if target.is_friendly(flight.squadron.player) and isinstance(
+                target, Carrier
+            ):
+                return TheaterRefuelingFlightPlan.builder_type()
+            if target.is_friendly(flight.squadron.player) or isinstance(
+                target, FrontLine
             ):
                 return TheaterRefuelingFlightPlan.builder_type()
             return PackageRefuelingFlightPlan.builder_type()

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Iterator, Type
 from game.ato.flightplans.standard import StandardFlightPlan, StandardLayout
 from game.ato.flightplans.ibuilder import IBuilder
@@ -29,6 +32,22 @@ class RecoveryTankerFlightPlan(StandardFlightPlan[RecoveryTankerLayout]):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    @property
+    def tot_waypoint(self) -> FlightWaypoint:
+        return self.layout.recovery_ship
+
+    @property
+    def mission_departure_time(self) -> timedelta:
+        return timedelta(hours=2)
+
+    def tot_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:
+        # TOT planning isn't really useful. They're behind the front
+        # lines so no need to wait for escorts or for other missions to complete.
+        return None
+
+    def depart_time_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:
+        return None
 
 
 class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -43,6 +43,7 @@ class RecoveryTankerFlightPlan(StandardFlightPlan[RecoveryTankerLayout]):
 
     @property
     def patrol_start_time(self) -> timedelta:
+        assert self.tot_waypoint.tot is not None
         return self.tot_waypoint.tot
 
     @property

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -39,6 +39,7 @@ class RecoveryTankerFlightPlan(RefuelingFlightPlan):
 class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
     def layout(self) -> RecoveryTankerLayout:
 
+        # TODO: If this can be the propagated postition of the ship, that would be great.
         ship = self.package.target.position
 
         builder = WaypointBuilder(self.flight, self.coalition)

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import Iterator, Type
+from game.ato.flightplans.standard import StandardFlightPlan, StandardLayout
 from game.ato.flightplans.ibuilder import IBuilder
-from game.ato.flightplans.refuelingflightplan import RefuelingFlightPlan
 from game.ato.flightplans.standard import StandardLayout
 from game.ato.flightplans.waypointbuilder import WaypointBuilder
 from game.ato.flightwaypoint import FlightWaypoint
@@ -26,20 +25,16 @@ class RecoveryTankerLayout(StandardLayout):
         yield self.bullseye
 
 
-class RecoveryTankerFlightPlan(RefuelingFlightPlan):
+class RecoveryTankerFlightPlan(StandardFlightPlan[RecoveryTankerLayout]):
     @staticmethod
-    def builder_type() -> Type[IBuilder]:
+    def builder_type() -> Type[Builder]:
         return Builder
-
-    @property
-    def patrol_duration(self) -> timedelta:
-        return timedelta(hours=1)
 
 
 class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
     def layout(self) -> RecoveryTankerLayout:
 
-        # TODO: If this can be the propagated postition of the ship, that would be great.
+        # TODO: Propagate the ship position.
         ship = self.package.target.position
 
         builder = WaypointBuilder(self.flight, self.coalition)
@@ -47,8 +42,8 @@ class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
         recovery = builder.recovery_tanker(ship)
 
         tanker_type = self.flight.unit_type
-        if tanker_type.patrol_altitude is not None:
-            altitude = tanker_type.patrol_altitude
+        if tanker_type.ingress_altitude is not None:
+            altitude = self.doctrine.ingress_altitude
         else:
             altitude = feet(21000)
 

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -43,8 +43,7 @@ class RecoveryTankerFlightPlan(StandardFlightPlan[RecoveryTankerLayout]):
 
     @property
     def patrol_start_time(self) -> timedelta:
-        assert self.tot_waypoint.tot is not None
-        return self.tot_waypoint.tot
+        return self.package.time_over_target
 
     @property
     def patrol_end_time(self) -> timedelta:

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterator, Type
+from game.ato.flightplans.ibuilder import IBuilder
+from game.ato.flightplans.refuelingflightplan import RefuelingFlightPlan
+from game.ato.flightplans.standard import StandardLayout
+from game.ato.flightplans.waypointbuilder import WaypointBuilder
+from game.ato.flightwaypoint import FlightWaypoint
+from game.utils import feet
+
+
+@dataclass(frozen=True)
+class RecoveryTankerLayout(StandardLayout):
+    nav_to: list[FlightWaypoint]
+    recovery_ship: FlightWaypoint
+    nav_from: list[FlightWaypoint]
+
+    def iter_waypoints(self) -> Iterator[FlightWaypoint]:
+        yield self.departure
+        yield from self.nav_to
+        yield self.recovery_ship
+        yield from self.nav_from
+        yield self.arrival
+        if self.divert is not None:
+            yield self.divert
+        yield self.bullseye
+
+
+class RecoveryTankerFlightPlan(RefuelingFlightPlan):
+    @staticmethod
+    def builder_type() -> Type[IBuilder]:
+        return Builder
+
+    @property
+    def patrol_duration(self) -> timedelta:
+        return timedelta(hours=1)
+
+
+class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
+    def layout(self) -> RecoveryTankerLayout:
+
+        ship = self.package.target.position
+
+        builder = WaypointBuilder(self.flight, self.coalition)
+
+        recovery = builder.recovery_tanker(ship)
+
+        tanker_type = self.flight.unit_type
+        if tanker_type.patrol_altitude is not None:
+            altitude = tanker_type.patrol_altitude
+        else:
+            altitude = feet(21000)
+
+        return RecoveryTankerLayout(
+            departure=builder.takeoff(self.flight.departure),
+            nav_to=builder.nav_path(self.flight.departure.position, ship, altitude),
+            nav_from=builder.nav_path(ship, self.flight.arrival.position, altitude),
+            recovery_ship=recovery,
+            arrival=builder.land(self.flight.arrival),
+            divert=builder.divert(self.flight.divert),
+            bullseye=builder.bullseye(),
+        )
+
+    def build(self) -> RecoveryTankerFlightPlan:
+        return RecoveryTankerFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -42,10 +42,7 @@ class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
         recovery = builder.recovery_tanker(ship)
 
         tanker_type = self.flight.unit_type
-        if tanker_type.ingress_altitude is not None:
-            altitude = self.doctrine.ingress_altitude
-        else:
-            altitude = feet(21000)
+        altitude = tanker_type.preferred_patrol_altitude()
 
         return RecoveryTankerLayout(
             departure=builder.takeoff(self.flight.departure),

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -42,7 +42,7 @@ class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
         recovery = builder.recovery_tanker(ship)
 
         tanker_type = self.flight.unit_type
-        altitude = tanker_type.preferred_patrol_altitude()
+        altitude = tanker_type.preferred_patrol_altitude
 
         return RecoveryTankerLayout(
             departure=builder.takeoff(self.flight.departure),

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -41,12 +41,22 @@ class RecoveryTankerFlightPlan(StandardFlightPlan[RecoveryTankerLayout]):
     def mission_departure_time(self) -> timedelta:
         return timedelta(hours=2)
 
+    @property
+    def patrol_start_time(self) -> timedelta:
+        return self.tot_waypoint.tot
+
+    @property
+    def patrol_end_time(self) -> timedelta:
+        return self.tot + self.mission_departure_time
+
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:
-        # TOT planning isn't really useful. They're behind the front
-        # lines so no need to wait for escorts or for other missions to complete.
+        if waypoint == self.tot_waypoint:
+            return self.tot
         return None
 
     def depart_time_for_waypoint(self, waypoint: FlightWaypoint) -> timedelta | None:
+        if waypoint == self.tot_waypoint:
+            return self.tot + self.mission_departure_time
         return None
 
 

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -206,14 +206,12 @@ class WaypointBuilder:
 
     def recovery_tanker(self, position: Point) -> FlightWaypoint:
         alt_type: AltitudeReference = "BARO"
-        if self.is_helo:
-            alt_type = "RADIO"
 
         return FlightWaypoint(
             "REFUEL",
             FlightWaypointType.REFUEL,
             position,
-            meters(80) if self.is_helo else feet(6000).meters,
+            feet(6000).meters,
             alt_type,
             description="Recovery tanker for aircraft carriers",
             pretty_name="Recovery",

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -208,8 +208,8 @@ class WaypointBuilder:
         alt_type: AltitudeReference = "BARO"
 
         return FlightWaypoint(
-            "REFUEL",
-            FlightWaypointType.REFUEL,
+            "RECOVERY",
+            FlightWaypointType.RECOVERY_TANKER,
             position,
             feet(6000),
             alt_type,

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -23,7 +23,7 @@ from game.theater import (
     TheaterGroundObject,
     TheaterUnit,
 )
-from game.utils import Distance, meters, nautical_miles
+from game.utils import Distance, feet, meters, nautical_miles
 
 if TYPE_CHECKING:
     from game.coalition import Coalition
@@ -202,6 +202,21 @@ class WaypointBuilder:
             alt_type,
             description="Refuel from tanker",
             pretty_name="Refuel",
+        )
+
+    def recovery_tanker(self, position: Point) -> FlightWaypoint:
+        alt_type: AltitudeReference = "BARO"
+        if self.is_helo:
+            alt_type = "RADIO"
+
+        return FlightWaypoint(
+            "REFUEL",
+            FlightWaypointType.REFUEL,
+            position,
+            meters(80) if self.is_helo else feet(6000).meters,
+            alt_type,
+            description="Recovery tanker for aircraft carriers",
+            pretty_name="Recovery",
         )
 
     def split(self, position: Point) -> FlightWaypoint:

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -211,7 +211,7 @@ class WaypointBuilder:
             "REFUEL",
             FlightWaypointType.REFUEL,
             position,
-            feet(6000).meters,
+            feet(6000),
             alt_type,
             description="Recovery tanker for aircraft carriers",
             pretty_name="Recovery",

--- a/game/ato/flightwaypointtype.py
+++ b/game/ato/flightwaypointtype.py
@@ -49,3 +49,4 @@ class FlightWaypointType(IntEnum):
     REFUEL = 29  # Should look for nearby tanker to refuel from.
     CARGO_STOP = 30  # Stopover landing point using the LandingReFuAr waypoint type
     INGRESS_AIR_ASSAULT = 31
+    RECOVERY_TANKER = 32

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -24,6 +24,7 @@ from dcs.unitgroup import FlyingGroup
 
 from game.ato import Flight, FlightType
 from game.ato.flightplans.aewc import AewcFlightPlan
+from game.ato.flightplans.shiprecoverytanker import RecoveryTankerFlightPlan
 from game.ato.flightplans.theaterrefueling import TheaterRefuelingFlightPlan
 
 
@@ -246,7 +247,10 @@ class AircraftBehavior:
     def configure_refueling(self, group: FlyingGroup[Any], flight: Flight) -> None:
         group.task = Refueling.name
 
-        if not isinstance(flight.flight_plan, TheaterRefuelingFlightPlan):
+        if not (
+            isinstance(flight.flight_plan, TheaterRefuelingFlightPlan)
+            or isinstance(flight.flight_plan, RecoveryTankerFlightPlan)
+        ):
             logging.error(
                 f"Cannot configure racetrack refueling tasks for {flight} because it "
                 "does not have an racetrack refueling flight plan."

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -177,6 +177,7 @@ class AircraftGenerator:
                 self.mission_data,
                 dynamic_runways,
                 self.use_client,
+                self.unit_map,
             ).configure()
         )
         return group

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -10,6 +10,7 @@ from dcs.unit import Skill
 from dcs.unitgroup import FlyingGroup
 
 from game.ato import Flight, FlightType
+from game.ato.flightplans.shiprecoverytanker import RecoveryTankerFlightPlan
 from game.callsigns import callsign_for_support_unit
 from game.data.weapons import Pylon, WeaponType as WeaponTypeEnum
 from game.missiongenerator.missiondata import MissionData, AwacsInfo, TankerInfo
@@ -160,7 +161,9 @@ class FlightGroupConfigurator:
                     blue=self.flight.departure.captured,
                 )
             )
-        elif isinstance(self.flight.flight_plan, TheaterRefuelingFlightPlan):
+        elif isinstance(
+            self.flight.flight_plan, TheaterRefuelingFlightPlan
+        ) or isinstance(self.flight.flight_plan, RecoveryTankerFlightPlan):
             tacan = self.tacan_registry.alloc_for_band(TacanBand.Y, TacanUsage.AirToAir)
             self.mission_data.tankers.append(
                 TankerInfo(

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -19,6 +19,7 @@ from game.radio.radios import RadioFrequency, RadioRegistry
 from game.radio.tacan import TacanBand, TacanRegistry, TacanUsage
 from game.runways import RunwayData
 from game.squadrons import Pilot
+from game.unitmap import UnitMap
 from .aircraftbehavior import AircraftBehavior
 from .aircraftpainter import AircraftPainter
 from .flightdata import FlightData
@@ -44,6 +45,7 @@ class FlightGroupConfigurator:
         mission_data: MissionData,
         dynamic_runways: dict[str, RunwayData],
         use_client: bool,
+        unit_map: UnitMap,
     ) -> None:
         self.flight = flight
         self.group = group
@@ -56,6 +58,7 @@ class FlightGroupConfigurator:
         self.mission_data = mission_data
         self.dynamic_runways = dynamic_runways
         self.use_client = use_client
+        self.unit_map = unit_map
 
     def configure(self) -> FlightData:
         AircraftBehavior(self.flight.flight_type).apply_to(self.flight, self.group)
@@ -97,6 +100,7 @@ class FlightGroupConfigurator:
             self.time,
             self.game.settings,
             self.mission_data,
+            self.unit_map,
         ).create_waypoints()
 
         return FlightData(

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -12,6 +12,7 @@ from game.ato import Flight, FlightWaypoint
 from game.ato.flightwaypointtype import FlightWaypointType
 from game.missiongenerator.missiondata import MissionData
 from game.theater import MissionTarget, TheaterUnit
+from game.unitmap import UnitMap
 
 TARGET_WAYPOINTS = (
     FlightWaypointType.TARGET_GROUP_LOC,
@@ -29,6 +30,7 @@ class PydcsWaypointBuilder:
         mission: Mission,
         elapsed_mission_time: timedelta,
         mission_data: MissionData,
+        unit_map: UnitMap,
     ) -> None:
         self.waypoint = waypoint
         self.group = group
@@ -37,6 +39,7 @@ class PydcsWaypointBuilder:
         self.mission = mission
         self.elapsed_mission_time = elapsed_mission_time
         self.mission_data = mission_data
+        self.unit_map = unit_map
 
     def build(self) -> MovingPoint:
         waypoint = self.group.add_waypoint(

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -12,10 +12,8 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
             group_id = 1
             speed = 280
             altitude = feet(6000).meters
-            target_types = ["huh?"]
-            last_waypoint = 2
-            recovery_tanker = RecoveryTanker(
-                group_id, speed, altitude, target_types, last_waypoint
-            )
+            # Should this be an enum?
+            target_types = ["Ships"]
+            recovery_tanker = RecoveryTanker(group_id, speed, altitude, target_types)
 
             waypoint.add_task(recovery_tanker)

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -2,7 +2,7 @@ from dcs.point import MovingPoint
 from dcs.task import RecoveryTanker
 
 from game.ato import FlightType
-from game.utils import feet
+from game.utils import feet, knots
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
@@ -10,9 +10,10 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
         if self.flight.flight_type == FlightType.REFUELING:
             group_id = self._get_carrier_group_id()
-            speed = 280
+            speed = knots(250).meters_per_second
             altitude = feet(6000).meters
-            last_waypoint = 1
+            # Last waypoint has index of 1.
+            last_waypoint = 2
             recovery_tanker = RecoveryTanker(group_id, speed, altitude, last_waypoint)
 
             waypoint.add_task(recovery_tanker)
@@ -27,4 +28,4 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
                 theater_mapping = value
                 break
         assert theater_mapping is not None
-        return theater_mapping.dcs_unit.id
+        return theater_mapping.dcs_group_id

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -1,0 +1,21 @@
+from dcs.point import MovingPoint
+from dcs.task import RecoveryTanker
+
+from game.ato import FlightType
+from game.utils import feet
+from .pydcswaypointbuilder import PydcsWaypointBuilder
+
+
+class RecoveryTankerBuilder(PydcsWaypointBuilder):
+    def add_tasks(self, waypoint: MovingPoint) -> None:
+        if self.flight.flight_type == FlightType.REFUELING:
+            group_id = 1
+            speed = 280
+            altitude = feet(6000).meters
+            target_types = ["huh?"]
+            last_waypoint = 2
+            recovery_tanker = RecoveryTanker(
+                group_id, speed, altitude, target_types, last_waypoint
+            )
+
+            waypoint.add_task(recovery_tanker)

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -9,11 +9,20 @@ from .pydcswaypointbuilder import PydcsWaypointBuilder
 class RecoveryTankerBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
         if self.flight.flight_type == FlightType.REFUELING:
-            group_id = 1
+            group_id = self._get_carrier_group_id()
             speed = 280
             altitude = feet(6000).meters
             # Should this be an enum?
             target_types = ["Ships"]
-            recovery_tanker = RecoveryTanker(group_id, speed, altitude, target_types)
+            last_waypoint = None
+            recovery_tanker = RecoveryTanker(
+                group_id, speed, altitude, target_types, last_waypoint
+            )
 
             waypoint.add_task(recovery_tanker)
+
+    def _get_carrier_group_id(self) -> int:
+        name = self.package.target.name
+        theater_mapping = self.unit_map.theater_objects.get(name)
+        assert theater_mapping is not None
+        return theater_mapping.dcs_unit.id

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -12,17 +12,19 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
             group_id = self._get_carrier_group_id()
             speed = 280
             altitude = feet(6000).meters
-            # Should this be an enum?
-            target_types = ["Ships"]
-            last_waypoint = None
-            recovery_tanker = RecoveryTanker(
-                group_id, speed, altitude, target_types, last_waypoint
-            )
+            last_waypoint = 1
+            recovery_tanker = RecoveryTanker(group_id, speed, altitude, last_waypoint)
 
             waypoint.add_task(recovery_tanker)
 
     def _get_carrier_group_id(self) -> int:
         name = self.package.target.name
-        theater_mapping = self.unit_map.theater_objects.get(name)
+        carrier_position = self.package.target.position
+        theater_objects = self.unit_map.theater_objects
+        for key, value in theater_objects.items():
+            # Check name and position in case there are multiple of same carrier.
+            if name in key and value.theater_unit.position == carrier_position:
+                theater_mapping = value
+                break
         assert theater_mapping is not None
         return theater_mapping.dcs_unit.id

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -19,6 +19,7 @@ from game.ato.starttype import StartType
 from game.missiongenerator.aircraft.waypoints.cargostop import CargoStopBuilder
 from game.missiongenerator.missiondata import MissionData
 from game.settings import Settings
+from game.unitmap import UnitMap
 from game.utils import pairwise
 from .baiingress import BaiIngressBuilder
 from .landingzone import LandingZoneBuilder
@@ -50,6 +51,7 @@ class WaypointGenerator:
         time: datetime,
         settings: Settings,
         mission_data: MissionData,
+        unit_map: UnitMap,
     ) -> None:
         self.flight = flight
         self.group = group
@@ -58,6 +60,7 @@ class WaypointGenerator:
         self.time = time
         self.settings = settings
         self.mission_data = mission_data
+        self.unit_map = unit_map
 
     def create_waypoints(self) -> tuple[timedelta, list[FlightWaypoint]]:
         for waypoint in self.flight.points:
@@ -145,6 +148,7 @@ class WaypointGenerator:
             self.mission,
             self.elapsed_mission_time,
             self.mission_data,
+            self.unit_map,
         )
 
     def _estimate_min_fuel_for(self, waypoints: list[FlightWaypoint]) -> None:

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -17,6 +17,9 @@ from game.ato.flightstate import InFlight, WaitingForStart
 from game.ato.flightwaypointtype import FlightWaypointType
 from game.ato.starttype import StartType
 from game.missiongenerator.aircraft.waypoints.cargostop import CargoStopBuilder
+from game.missiongenerator.aircraft.waypoints.recoverytanker import (
+    RecoveryTankerBuilder,
+)
 from game.missiongenerator.missiondata import MissionData
 from game.settings import Settings
 from game.unitmap import UnitMap
@@ -138,6 +141,7 @@ class WaypointGenerator:
             FlightWaypointType.PICKUP_ZONE: LandingZoneBuilder,
             FlightWaypointType.DROPOFF_ZONE: LandingZoneBuilder,
             FlightWaypointType.REFUEL: RefuelPointBuilder,
+            FlightWaypointType.RECOVERY_TANKER: RecoveryTankerBuilder,
             FlightWaypointType.CARGO_STOP: CargoStopBuilder,
         }
         builder = builders.get(waypoint.waypoint_type, DefaultWaypointBuilder)

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -147,7 +147,7 @@ class GroundObjectGenerator:
                 vehicle_unit.position = unit.position
                 vehicle_unit.heading = unit.position.heading.degrees
                 vehicle_group.add_unit(vehicle_unit)
-            self._register_theater_unit(unit, vehicle_group.units[-1])
+            self._register_theater_unit(vehicle_group.id, unit, vehicle_group.units[-1])
         if vehicle_group is None:
             raise RuntimeError(f"Error creating VehicleGroup for {group_name}")
         return vehicle_group
@@ -180,7 +180,7 @@ class GroundObjectGenerator:
                 ship_unit.position = unit.position
                 ship_unit.heading = unit.position.heading.degrees
                 ship_group.add_unit(ship_unit)
-            self._register_theater_unit(unit, ship_group.units[-1])
+            self._register_theater_unit(ship_group.id, unit, ship_group.units[-1])
         if ship_group is None:
             raise RuntimeError(f"Error creating ShipGroup for {group_name}")
         return ship_group
@@ -194,7 +194,7 @@ class GroundObjectGenerator:
             heading=unit.position.heading.degrees,
             dead=not unit.alive,
         )
-        self._register_theater_unit(unit, static_group.units[0])
+        self._register_theater_unit(static_group.id, unit, static_group.units[0])
 
     @staticmethod
     def enable_eplrs(group: VehicleGroup, unit_type: Type[VehicleType]) -> None:
@@ -209,10 +209,11 @@ class GroundObjectGenerator:
 
     def _register_theater_unit(
         self,
+        dcs_group_id: int,
         theater_unit: TheaterUnit,
         dcs_unit: Unit,
     ) -> None:
-        self.unit_map.add_theater_unit_mapping(theater_unit, dcs_unit)
+        self.unit_map.add_theater_unit_mapping(dcs_group_id, theater_unit, dcs_unit)
 
     def add_trigger_zone_for_scenery(self, scenery: SceneryUnit) -> None:
         # Align the trigger zones to the faction color on the DCS briefing/F10 map.

--- a/game/unitmap.py
+++ b/game/unitmap.py
@@ -22,14 +22,12 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class FlyingUnit:
-    dcs_group_id: int
     flight: Flight
     pilot: Optional[Pilot]
 
 
 @dataclass(frozen=True)
 class FrontLineUnit:
-    dcs_group_id: int
     unit_type: GroundUnitType
     origin: ControlPoint
 
@@ -49,14 +47,12 @@ class SceneryObjectMapping:
 
 @dataclass(frozen=True)
 class ConvoyUnit:
-    dcs_group_id: int
     unit_type: GroundUnitType
     convoy: Convoy
 
 
 @dataclass(frozen=True)
 class AirliftUnits:
-    dcs_group_id: int
     cargo: tuple[GroundUnitType, ...]
     transfer: TransferOrder
 
@@ -79,7 +75,7 @@ class UnitMap:
             name = str(unit.name)
             if name in self.aircraft:
                 raise RuntimeError(f"Duplicate unit name: {name}")
-            self.aircraft[name] = FlyingUnit(group.id, flight, pilot)
+            self.aircraft[name] = FlyingUnit(flight, pilot)
         if flight.cargo is not None:
             self.add_airlift_units(group, flight.cargo)
 
@@ -103,7 +99,7 @@ class UnitMap:
             name = str(unit.name)
             if name in self.front_line_units:
                 raise RuntimeError(f"Duplicate front line unit: {name}")
-            self.front_line_units[name] = FrontLineUnit(group.id, unit_type, origin)
+            self.front_line_units[name] = FrontLineUnit(unit_type, origin)
 
     def front_line_unit(self, name: str) -> Optional[FrontLineUnit]:
         return self.front_line_units.get(name, None)
@@ -130,7 +126,7 @@ class UnitMap:
             name = str(unit.name)
             if name in self.convoys:
                 raise RuntimeError(f"Duplicate convoy unit: {name}")
-            self.convoys[name] = ConvoyUnit(group.id, unit_type, convoy)
+            self.convoys[name] = ConvoyUnit(unit_type, convoy)
 
     def convoy_unit(self, name: str) -> Optional[ConvoyUnit]:
         return self.convoys.get(name, None)
@@ -172,7 +168,7 @@ class UnitMap:
             name = str(transport.name)
             if name in self.airlifts:
                 raise RuntimeError(f"Duplicate airlift unit: {name}")
-            self.airlifts[name] = AirliftUnits(group.id, cargo, transfer)
+            self.airlifts[name] = AirliftUnits(cargo, transfer)
 
     def airlift_unit(self, name: str) -> Optional[AirliftUnits]:
         return self.airlifts.get(name, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pluggy==1.0.0
 pre-commit==2.19.0
 py==1.11.0
 pydantic==1.9.1
--e git+https://github.com/pydcs/dcs@f12d70ea844076f95c74ffab92ec3dc9fdee32e4#egg=pydcs
+-e git+https://github.com/pydcs/dcs@e755b655b7b28e9af3c1fa42263424b568413c04#egg=pydcs
 pyinstaller==5.2
 pyinstaller-hooks-contrib==2022.8
 pyparsing==3.0.9


### PR DESCRIPTION
This adds support for a recovery tanker at a carriers.  It still needs a changelog, and depends on https://github.com/pydcs/dcs/pull/278.

This works on 6.x, but I haven't tested tankers that have already been scheduled on a carrier.  I will try that before deciding if this is a 6.x or 7.x feature.

@DanAlbert I wanted to get your thoughts on what I've done with `UnitMap` (adding the `dcs_group_id` field, and passing it into `pydcswaypointbuilder.py`.  Another option would be to pass in the group itself instead of just the id, with the hope of being able to use the waypoints to interpolate positions, but the carrier's waypoints are set pretty late (see `steam_into_wind`).