### PR TITLE
Fix Airbase and FOB capture is blocked by grounded aircraft / helicopters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ Saves from 6.0.0 are compatible with 6.1.0
 ## Fixes
 
 * **[Flight Planning]** Fixes CAS flights not having landing waypoints.
+* **[Mission Generation]** Airbase and FOB capture is no longer blocked by grounded aircraft / helicopters.
 * **[Squadrons]** Fixed the livery for the VF-33 F-14A squadron.
 * **[Theaters]** Fixed Channel campaigns not having data for land/sea/obstacle boundaries, causing front lines to extend into forests and water. Requires a new campaign to get the fix.
 * **[UI]** Fixed an issue where manual submit of mission results did not end the mission correctly.

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -293,13 +293,13 @@ class GroundObjectGenerator:
         self.m.triggerrules.triggers.append(t)
 
     def generate_iads_command_unit(self, unit: SceneryUnit) -> None:
-        # Creates a static Infantry Unit next to a scenery object. This is needed
-        # because skynet can not use map objects as Comms, Power or Command and needs a
-        # "real" unit to function correctly
+        # Creates a static Unit (tyre with red flag) next to a scenery object. This is
+        # needed because skynet can not use map objects as Comms, Power or Command and
+        # needs a "real" unit to function correctly
         self.m.static_group(
             country=self.country,
             name=unit.unit_name,
-            _type=dcs.vehicles.Infantry.Soldier_M4,
+            _type=dcs.statics.Fortification.Black_Tyre_RF,
             position=unit.position,
             heading=unit.position.heading.degrees,
             dead=not unit.alive,  # Also spawn as dead!

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -104,6 +104,7 @@ class GroundObjectGenerator:
                         self.add_trigger_zone_for_scenery(unit)
                         if (
                             self.game.settings.plugin_option("skynetiads")
+                            and self.game.theater.iads_network.advanced_iads
                             and isinstance(group, IadsGroundGroup)
                             and group.iads_role.participate
                         ):

--- a/game/missiongenerator/triggergenerator.py
+++ b/game/missiongenerator/triggergenerator.py
@@ -159,7 +159,9 @@ class TriggerGenerator:
                 flag = self.get_capture_zone_flag()
                 capture_trigger = TriggerCondition(Event.NoEvent, "Capture Trigger")
                 capture_trigger.add_condition(
-                    AllOfCoalitionOutsideZone(defending_coalition, trigger_zone.id)
+                    AllOfCoalitionOutsideZone(
+                        defending_coalition, trigger_zone.id, unit_type="GROUND"
+                    )
                 )
                 capture_trigger.add_condition(
                     PartOfCoalitionInZone(
@@ -176,7 +178,9 @@ class TriggerGenerator:
 
                 recapture_trigger = TriggerCondition(Event.NoEvent, "Capture Trigger")
                 recapture_trigger.add_condition(
-                    AllOfCoalitionOutsideZone(attacking_coalition, trigger_zone.id)
+                    AllOfCoalitionOutsideZone(
+                        attacking_coalition, trigger_zone.id, unit_type="GROUND"
+                    )
                 )
                 recapture_trigger.add_condition(
                     PartOfCoalitionInZone(


### PR DESCRIPTION
Fix to prevent that captures of Airbases and FOBs are blocked by aircraft or helos and the IADS commandable unit which was required that skynet can handle static map objects.

Includes following changes:
- Changes the condition AllOfCoalitionOutsideZone to only check for ground units. Previously it was "ALL"
- Changed the static controllable unit which was required to use skynet script for static map objects to a "Fortifaction" type: Tyre with red flag which now does not count to the "Ground" UnitType of the AllOfCoalitionOutsideZone trigger condition
- Only add the controllable unit when advanced iads functions are used by the campaign. Otherwise skynet would not use them.

This requires pydcs changes: https://github.com/pydcs/dcs/pull/279

Can not be merged before these changes