### PR TITLE
Save the last turn for bug reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -73,7 +73,8 @@ body:
 
         The `state.json` file for the most recently completed turn, located at
         `<Liberation install directory>/state.json`. This file is essential for
-        investigating any issues with end-of-turn results processing.
+        investigating any issues with end-of-turn results processing. **If you
+        include this file, also include `last_turn.liberation`.**
 
 
         You can attach files to the bug by dragging and dropping the file

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Saves from 6.0.0 are compatible with 6.1.0
 * **[Factions]** Defaulted bluefor modern to use Georgian and Ukrainian liveries for Russian aircraft.
 * **[Factions]** Added Peru.
 * **[Loadouts]** Adjusted F-15E loadouts.
+* **[Mission Generation]** The previous turn will now be saved as last_turn.liberation when submitting mission results. This is often essential for debugging bug reports. **Include this file in the bug report whenever it is available.**
 * **[Modding]** Added support for the HMS Ariadne, Achilles, and Castle class.
 * **[Modding]** Added HMS Invincible to the game data as a helicopter carrier.
 

--- a/game/game.py
+++ b/game/game.py
@@ -332,6 +332,8 @@ class Game:
         from .server import EventStream
         from .sim import GameUpdateEvents
 
+        persistency.save_last_turn_state(self)
+
         events = GameUpdateEvents()
 
         logging.info("Pass turn")

--- a/game/persistency.py
+++ b/game/persistency.py
@@ -31,8 +31,8 @@ def save_dir() -> Path:
     return Path(base_path()) / "Liberation" / "Saves"
 
 
-def _temporary_save_file() -> str:
-    return str(save_dir() / "tmpsave.liberation")
+def _temporary_save_file() -> Path:
+    return save_dir() / "tmpsave.liberation"
 
 
 def _autosave_path() -> str:
@@ -54,16 +54,18 @@ def load_game(path: str) -> Optional[Game]:
             return None
 
 
-def save_game(game: Game) -> bool:
+def save_game(game: Game, destination: Path | None = None) -> None:
+    if destination is None:
+        destination = Path(game.savepath)
+
+    temp_save_file = _temporary_save_file()
     with logged_duration("Saving game"):
         try:
-            with open(_temporary_save_file(), "wb") as f:
+            with temp_save_file.open("wb") as f:
                 pickle.dump(game, f)
-            shutil.copy(_temporary_save_file(), game.savepath)
-            return True
+            shutil.copy(temp_save_file, destination)
         except Exception:
             logging.exception("Could not save game")
-            return False
 
 
 def autosave(game: Game) -> bool:
@@ -79,3 +81,7 @@ def autosave(game: Game) -> bool:
     except Exception:
         logging.exception("Could not save game")
         return False
+
+
+def save_last_turn_state(game: Game) -> None:
+    save_game(game, save_dir() / "last_turn.liberation")

--- a/game/sim/missionsimulation.py
+++ b/game/sim/missionsimulation.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
+from game import persistency
 from game.debriefing import Debriefing
 from game.missiongenerator import MissionGenerator
 from game.unitmap import UnitMap
@@ -73,6 +74,7 @@ class MissionSimulation:
                 "was generated."
             )
 
+        persistency.save_last_turn_state(self.game)
         MissionResultsProcessor(self.game).commit(debriefing, events)
 
     def finish(self) -> None:


### PR DESCRIPTION
We often get save games uploaded with bug reports that are already in a broken state with nothing we can do about it. This saves that turn to `last_turn.liberation` so users are less likely to have clobbered the useful data before filing the report.

(cherry picked from commit 22503d4e958613bea654ac382761b89fb6f03843)
