### PR TITLE
Fix AdjustToContents use for Qt6.

### DIFF
--- a/qt_ui/widgets/combos/QAircraftTypeSelector.py
+++ b/qt_ui/widgets/combos/QAircraftTypeSelector.py
@@ -1,5 +1,6 @@
 """Combo box for selecting aircraft types."""
 from PySide6.QtWidgets import QComboBox
+
 from game.dcs.aircrafttype import AircraftType
 
 
@@ -10,7 +11,7 @@ class QAircraftTypeSelector(QComboBox):
         super().__init__()
 
         self.model().sort(0)
-        self.setSizeAdjustPolicy(self.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.update_items(aircraft_types)
 
     def update_items(self, aircraft_types: list[AircraftType]):

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -115,7 +115,7 @@ class SquadronBaseSelector(QComboBox):
         aircraft_type: Optional[AircraftType],
     ) -> None:
         super().__init__()
-        self.setSizeAdjustPolicy(self.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.bases = list(bases)
         self.set_aircraft_type(aircraft_type)
 
@@ -567,7 +567,7 @@ class SquadronAircraftTypeSelector(QComboBox):
         self, types: list[AircraftType], selected_aircraft: Optional[str]
     ) -> None:
         super().__init__()
-        self.setSizeAdjustPolicy(self.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
 
         for type in sorted(types, key=lambda type: type.name):
             self.addItem(type.name, type)
@@ -583,7 +583,7 @@ class SquadronDefSelector(QComboBox):
         aircraft: Optional[AircraftType],
     ) -> None:
         super().__init__()
-        self.setSizeAdjustPolicy(self.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.squadron_defs = squadron_defs
         self.set_aircraft_type(aircraft)
 

--- a/qt_ui/windows/mission/flight/SquadronSelector.py
+++ b/qt_ui/windows/mission/flight/SquadronSelector.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 from PySide6.QtWidgets import QComboBox
 
+from game.ato.flighttype import FlightType
 from game.dcs.aircrafttype import AircraftType
 from game.squadrons.airwing import AirWing
-from game.ato.flighttype import FlightType
 
 
 class SquadronSelector(QComboBox):
@@ -21,7 +21,7 @@ class SquadronSelector(QComboBox):
         self.air_wing = air_wing
 
         self.model().sort(0)
-        self.setSizeAdjustPolicy(self.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.update_items(task, aircraft)
 
     @property


### PR DESCRIPTION
This is no longer a property exposed directly on QComboBox.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2684.