### PR TITLE
Pin version of black used in GHA.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
+          version: ~=22.12
           src: "."
           options: "--check"
 


### PR DESCRIPTION
Black rolls out style changes every year, and using "stable" means that the check run on PRs might start formatting differently than we do locally, or require a reformat of the codebase to make a PR submittable.

Pin to the version that we've been using. We should update to 23 at some point, but we want to do that deliberately.