### PR TITLE
Support modification of TOTs after sim start.

### DIFF
--- a/game/ato/flightstate/flightstate.py
+++ b/game/ato/flightstate/flightstate.py
@@ -24,13 +24,10 @@ class FlightState(ABC):
     def reinitialize(self, now: datetime) -> None:
         from game.ato.flightstate import WaitingForStart
 
-        start_time = self.flight.flight_plan.startup_time()
-        if start_time <= now:
+        if self.flight.flight_plan.startup_time() <= now:
             self._set_active_flight_state(now)
         else:
-            self.flight.set_state(
-                WaitingForStart(self.flight, self.settings, start_time)
-            )
+            self.flight.set_state(WaitingForStart(self.flight, self.settings))
 
     def _set_active_flight_state(self, now: datetime) -> None:
         from game.ato.flightstate import StartUp

--- a/game/ato/flightstate/waitingforstart.py
+++ b/game/ato/flightstate/waitingforstart.py
@@ -18,18 +18,16 @@ if TYPE_CHECKING:
 
 
 class WaitingForStart(AtDeparture):
-    def __init__(
-        self,
-        flight: Flight,
-        settings: Settings,
-        start_time: datetime,
-    ) -> None:
+    def __init__(self, flight: Flight, settings: Settings) -> None:
         super().__init__(flight, settings)
-        self.start_time = start_time
 
     @property
     def start_type(self) -> StartType:
         return self.flight.start_type
+
+    @property
+    def start_time(self) -> datetime:
+        return self.flight.flight_plan.startup_time()
 
     def on_game_tick(
         self, events: GameUpdateEvents, time: datetime, duration: timedelta

--- a/game/ato/package.py
+++ b/game/ato/package.py
@@ -207,3 +207,10 @@ class Package:
                 if flight.departure == airfield:
                     return airfield
         raise RuntimeError("Could not find any airfield assigned to this package")
+
+    def all_flights_waiting_for_start(self) -> bool:
+        """Returns True if all flights in the package are waiting for start."""
+        for flight in self.flights:
+            if not flight.state.is_waiting_for_start:
+                return False
+        return True

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -185,10 +185,18 @@ class PackageModel(QAbstractListModel):
         """Returns the flight located at the given index."""
         return self.package.flights[index.row()]
 
-    def set_tot(self, tot: datetime.datetime) -> None:
+    def set_tot(self, tot: datetime.datetime) -> datetime:
         with self.game_model.sim_controller.paused_sim():
+            previous_tot = self.package.time_over_target
             self.package.time_over_target = tot
+            for flight in self.package.flights:
+                if (
+                    flight.flight_plan.startup_time()
+                    < self.game_model.sim_controller.current_time_in_sim
+                ):
+                    self.package.time_over_target = previous_tot
             self.update_tot()
+            return self.package.time_over_target
 
     def set_asap(self, asap: bool) -> None:
         with self.game_model.sim_controller.paused_sim():

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -149,11 +149,12 @@ class QPackageDialog(QDialog):
     def save_tot(self) -> None:
         # TODO: This is going to break horribly around midnight.
         time = self.tot_spinner.time()
-        self.package_model.set_tot(
+        tot = self.package_model.set_tot(
             self.package_model.package.time_over_target.replace(
                 hour=time.hour(), minute=time.minute(), second=time.second()
             )
         )
+        self.tot_spinner.setTime(self.tot_qtime())
 
     def set_asap(self, checked: bool) -> None:
         self.package_model.set_asap(checked)

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -79,7 +79,10 @@ class QPackageDialog(QDialog):
         self.tot_spinner.setDisplayFormat("hh:mm:ss")
         self.tot_spinner.timeChanged.connect(self.save_tot)
         self.tot_spinner.setToolTip("Package TOT relative to mission TOT")
-        self.tot_spinner.setEnabled(not self.package_model.package.auto_asap)
+        self.tot_spinner.setEnabled(
+            not self.package_model.package.auto_asap
+            and self.package_model.package.all_flights_waiting_for_start()
+        )
         self.tot_column.addWidget(self.tot_spinner)
 
         self.auto_asap = QCheckBox("ASAP")
@@ -88,6 +91,9 @@ class QPackageDialog(QDialog):
             "arrive at the target."
         )
         self.auto_asap.setChecked(self.package_model.package.auto_asap)
+        self.auto_asap.setEnabled(
+            self.package_model.package.all_flights_waiting_for_start()
+        )
         self.auto_asap.toggled.connect(self.set_asap)
         self.tot_column.addWidget(self.auto_asap)
 


### PR DESCRIPTION
* Update TOTs as seen by the sim when changed in the UI
* Prevent the user from setting TOTs that would require startup times in the past
* Do not allow modification of the TOT after any flight in the package has started