### PR TITLE
Russian Weapon File Fixes

### DIFF
--- a/resources/weapons/a2a-missiles/R-24R.yaml
+++ b/resources/weapons/a2a-missiles/R-24R.yaml
@@ -1,5 +1,5 @@
 name: R-24R
 year: 1981
-fallback: R-3R
+fallback: R-3R - AAM, radar guided
 clsids:
   - "{CCF898C9-5BC7-49A4-9D1E-C3ED3D5166A1}"

--- a/resources/weapons/standoff/KH-25MP.yaml
+++ b/resources/weapons/standoff/KH-25MP.yaml
@@ -1,5 +1,5 @@
 name: KH-25MP
 year: 1981
-fallback: KH-28
+fallback: KH-29L
 clsids:
   - "{Kh-25MP}"

--- a/resources/weapons/standoff/KH-28.yaml
+++ b/resources/weapons/standoff/KH-28.yaml
@@ -1,5 +1,0 @@
-name: KH-28
-year: 1973
-fallback: KH-29L
-clsids:
-  - "{Kh-28}"


### PR DESCRIPTION
Bug fix - R-24R weapons file correction to R-3R fallback name (R-3R - AAM, radar guided) - now matches name used in R-3R file. 

Remove KH-28 weapons file due to removal from DCS.

Update KH-25MP weapons file to  fallback to KH-29L instead of Kh-28. Kh-28 previously fell back to Kh-29L.
