### PR TITLE
Added US Weapons Files

### DIFF
--- a/resources/weapons/a2a-missiles/AIM-120B.yaml
+++ b/resources/weapons/a2a-missiles/AIM-120B.yaml
@@ -1,7 +1,7 @@
 name: AIM-120B
 year: 1994
 # B model IOC in 1994, HOWEVER A model IOC in 1991 with USAF and 1993 with USN on Hornet
-fallback: AIM-7MH
+fallback: AIM-7P
 clsids:
   - "{C8E06185-7CD6-4C90-959F-044679E90751}"
   - "{LAU-115 - AIM-120B}"

--- a/resources/weapons/a2a-missiles/AIM-7E.yaml
+++ b/resources/weapons/a2a-missiles/AIM-7E.yaml
@@ -1,6 +1,6 @@
 name: AIM-7E
 year: 1963
-fallback: AIM-9X
+fallback: 2xAIM-9X
 clsids:
   - "{AIM-7E}"
   - "{LAU-115 - AIM-7E}"

--- a/resources/weapons/a2a-missiles/AIM-7P.yaml
+++ b/resources/weapons/a2a-missiles/AIM-7P.yaml
@@ -1,0 +1,9 @@
+name: AIM-7P
+year: 1992
+#Entered Production in 1987 but doesn't appear to have actually achieved IOC until 1992
+fallback: AIM-7MH
+clsids:
+  - "{SHOULDER AIM-7P}"
+  - "{BELLY AIM-7P}"
+  - "{AIM-7P}"
+  - "{LAU-115 - AIM-7P}"

--- a/resources/weapons/a2a-missiles/AIM-9J-2X.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9J-2X.yaml
@@ -1,0 +1,6 @@
+name: 2xAIM-9J
+year: 1972
+#IOC is in 1977, but was fielded in 1972 - using field date since the 9B is terrible and there are no versions in between in DCS
+fallback: 2xAIM-9B
+clsids:
+  - "{VSN_F4B_LAU105_AIM9J}"

--- a/resources/weapons/a2a-missiles/AIM-9J.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9J.yaml
@@ -1,0 +1,7 @@
+name: AIM-9J
+year: 1972
+#IOC is in 1977, but was fielded in 1972 - using field date since the 9B is terrible and there are no versions in between in DCS
+fallback: AIM-9B
+clsids:
+  - "{AIM-9J}"
+  - "{AIM-9J-ON-ADAPTER}"

--- a/resources/weapons/a2a-missiles/AIM-9Juli-2X.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9Juli-2X.yaml
@@ -1,0 +1,6 @@
+name: 2xAIM-9Juli
+year: 1990
+#BGT (German Company) upgrade to Spains existing 9J with L seeker, production started in 1990; overall performance somewhere between 9P4 and 9P5 in real life but between 9P5 and 9L in DCS
+fallback: 2xAIM-9P5
+clsids:
+  - "{VSN_F4B_LAU105_AIM9JULI}"

--- a/resources/weapons/a2a-missiles/AIM-9Juli-2X.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9Juli-2X.yaml
@@ -1,6 +1,6 @@
 name: 2xAIM-9Juli
 year: 1990
-#BGT (German Company) upgrade to Spains existing 9J with L seeker, production started in 1990; overall performance somewhere between 9P4 and 9P5 in real life but between 9P5 and 9L in DCS
+#BGT (German Company) upgrade to Spains existing 9J with L seeker, production started in 1990 (https://apps.dtic.mil/sti/pdfs/ADA278261.pdf); overall performance somewhere between 9P4 and 9P5 in real life but between 9P5 and 9L in DCS
 fallback: 2xAIM-9P5
 clsids:
   - "{VSN_F4B_LAU105_AIM9JULI}"

--- a/resources/weapons/a2a-missiles/AIM-9Juli.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9Juli.yaml
@@ -1,6 +1,6 @@
 name: AIM-9Juli
 year: 1990
-#BGT (German Company) upgrade to Spains existing 9J with L seeker, production started in 1990; overall performance somewhere between 9P4 and 9P5 in real life but between 9P5 and 9L in DCS
+#BGT (German Company) upgrade to Spains existing 9J with L seeker, production started in 1990 (https://apps.dtic.mil/sti/pdfs/ADA278261.pdf); overall performance somewhere between 9P4 and 9P5 in real life but between 9P5 and 9L in DCS
 fallback: AIM-9P5
 clsids:
   - "{AIM-9Juli}"

--- a/resources/weapons/a2a-missiles/AIM-9Juli.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9Juli.yaml
@@ -1,0 +1,6 @@
+name: AIM-9Juli
+year: 1990
+#BGT (German Company) upgrade to Spains existing 9J with L seeker, production started in 1990; overall performance somewhere between 9P4 and 9P5 in real life but between 9P5 and 9L in DCS
+fallback: AIM-9P5
+clsids:
+  - "{AIM-9Juli}"

--- a/resources/weapons/a2a-missiles/AIM-9L-2X.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9L-2X.yaml
@@ -1,6 +1,6 @@
 name: 2xAIM-9L
 year: 1977
-fallback: 2xAIM-9P5
+fallback: 2xAIM-9Juli
 clsids:
   - "LAU-105_2*AIM-9L"
   - "LAU-115_2*LAU-127_AIM-9L"

--- a/resources/weapons/a2a-missiles/AIM-9L.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9L.yaml
@@ -1,6 +1,6 @@
 name: AIM-9L
 year: 1977
-fallback: AIM-9P5
+fallback: AIM-9Juli
 clsids:
   - "{AIM-9L}"
   - "LAU-105_1*AIM-9L_L"

--- a/resources/weapons/a2a-missiles/AIM-9P-2X.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9P-2X.yaml
@@ -1,7 +1,7 @@
 name: 2xAIM-9P
 year: 1978
 #IOC is in 1978, but is an upgrade to the J so can be used as a stand in for earlier aim-9 models missing from DCS or certain mods.
-fallback: 2xAIM-9B
+fallback: 2xAIM-9J
 clsids:
   - "{3C0745ED-8B0B-42eb-B907-5BD5C1717447}"
   - "{773675AB-7C29-422f-AFD8-32844A7B7F17}"

--- a/resources/weapons/a2a-missiles/AIM-9P.yaml
+++ b/resources/weapons/a2a-missiles/AIM-9P.yaml
@@ -1,7 +1,7 @@
 name: AIM-9P
 year: 1978
 #IOC is in 1978, but is an upgrade to the J so can be used as a stand in for earlier aim-9 models missing from DCS or certain mods.
-fallback: AIM-9B
+fallback: AIM-9J
 clsids:
   - "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}"
   - "{AIM-9P-ON-ADAPTER}"


### PR DESCRIPTION
Adds US Weapons files with fallbacks in order of capability.

Aim-7P added by ED for several US fighters. Falls back to 7MH, and Aim-120B fallback adjusted from MH to P.

Aim-9J and Aim-9Juli added by ED for the Mirage F-1. Both are also used by F-4B/C mod and 9J will likely be added to the F-4E whenever it ships. Aim-9J placed between 9P and 9B, Aim-9Juli placed between 9L and 9P5.

2x9J and 2x9Juli added by VSN for F-4B/C mod. Placed between 2x versions of same missiles as above.

Aim-7E now falls back to 2xAim9x instead of single Aim9x so that it runs through the entire loop of Aim-9s.