### PR TITLE
Fix saving of saves from other machines.

### DIFF
--- a/game/persistence/savegamebundle.py
+++ b/game/persistence/savegamebundle.py
@@ -73,7 +73,7 @@ class SaveGameBundle:
         with ZipFile(self.bundle_path) as zip_bundle:
             with zip_bundle.open(name, "r") as save:
                 game = pickle.load(save)
-                game.save_bundle = self
+                game.save_manager.set_loaded_from(self)
                 return game
 
     def _update_bundle_member(

--- a/tests/persistence/conftest.py
+++ b/tests/persistence/conftest.py
@@ -4,11 +4,13 @@ from typing import cast
 import pytest
 
 from game import Game
+from game.persistence import SaveManager
 
 
 class StubGame:
     def __init__(self) -> None:
         self.date = datetime.date.min
+        self.save_manager = SaveManager(cast(Game, self))
 
 
 @pytest.fixture


### PR DESCRIPTION
Need to reset the persisted save paths on load, since the file that was loaded may have been moved since it was saved and the original location may no longer be accessible.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2756.