### PR TITLE
Prevent transfer splitting from leaving empty units.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@ Saves from 6.x are not compatible with 7.0.
 
 ## Fixes
 
+* **[Campaign]** Fixed a longstanding bug where oversized airlifts could corrupt a save with empty convoys. 
+
 # 6.1.1
 
 ## Fixes


### PR DESCRIPTION
If the transport were able to move exactly the quantity of units of the given type remaining in the transfer without moving the whole order, the transfer order would be left with instructions to transfer zero of that unit. That's an invariant violation, and was resulting in _later_ transfers attempting to create a convoy with zero units, which pydcs rightly rejects.

For example: if 2 Abrams and 2 Paladins are ordered to transfer from a disconnected FOB to a distant location that is connected by road, and only two cargo slots are available, that transfer could be split into:

```
{
    Abrams: 2
}
```

and

```
{
    Abrams: 0,
    Paladin: 2
}
```

Depending on the route, those airlifted units might end up still needing road transit (we prefer short airlifts rather than direct routes because it gives the player more opportunities to intercept enemy convoys). The current turn would airlift the Abrams-only group and the Paladin group would wait. On the next turn the Abrams would travel by road and the Paladins would be airlifted. On the _third_ turn, the Paladins (and zero Abrams) would generate an invalid convoy.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2761.