### PR TITLE
Update f4.py

### DIFF
--- a/pydcs_extensions/f4/f4.py
+++ b/pydcs_extensions/f4/f4.py
@@ -50,8 +50,27 @@ class WeaponsF4:
         "name": "Fuel tank Wing R 370 Gal",
         "weight": 1240,
     }
-
-
+    F4B_LAU105_AIM9J_2_BRU42A_M117_3 = {
+        "clsid": "{F4B_LAU105_AIM9J_2_BRU42A_M117_3}", 
+        "name": "F4B_LAU105_AIM9J_2_BRU42A_M117_3", 
+        "weight": 332,
+    }
+    F4B_LAU105_AIM9J_2_BRU42A_MK82_3 = {
+        "clsid": "{F4B_LAU105_AIM9J_2_BRU42A_MK82_3}", 
+        "name": "F4B_LAU105_AIM9J_2_BRU42A_MK82_3", 
+        "weight": 332,
+    }
+    F4B_LAU105_AIM9J_2_MER_MK20_3 = {
+        "clsid": "{F4B_LAU105_AIM9J_2_MER_MK20_3}", 
+        "name": "F4B_LAU105_AIM9J_2_MER_MK20_3", 
+        "weight": 332,
+    }
+    F4B_LAU105_AIM9J_2_TER9A_MK82SE_3 = {
+        "clsid": "{F4B_LAU105_AIM9J_2_TER9A_MK82SE_3}",
+        "name": "F4B_LAU105_AIM9J_2_TER9A_MK82SE_3", 
+        "weight": 332,
+    }
+    
 inject_weapons(WeaponsF4)
 
 
@@ -69,7 +88,7 @@ class VSN_F4B(PlaneType):
     charge_total = 96
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     livery_name = "VSN_F4B"  # from type
@@ -84,120 +103,61 @@ class VSN_F4B(PlaneType):
         Smoke_Generator___orange_ = (1, Weapons.Smoke_Generator___orange_)
 
     class Pylon2:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            2,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            2,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (2, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            2,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            2,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         Smokewinder___red = (2, Weapons.Smokewinder___red)
         Smokewinder___green = (2, Weapons.Smokewinder___green)
         Smokewinder___blue = (2, Weapons.Smokewinder___blue)
         Smokewinder___white = (2, Weapons.Smokewinder___white)
         Smokewinder___yellow = (2, Weapons.Smokewinder___yellow)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            2,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
-            2,
-            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
-        )
-        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (
-            2,
-            Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
-        )
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (2, Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         BIN_200 = (2, Weapons.BIN_200)
         VSN_F4EL_PTB = (2, Weapons.VSN_F4EL_PTB)
 
     class Pylon3:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            3,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            3,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
-        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
-            3,
-            Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD,
-        )
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (3, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            3,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            3,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_105_2_AIM_9L = (3, Weapons.LAU_105_2_AIM_9L)
-        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (
-            3,
-            Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM,
-        )
+        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (3, Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9P5 = (3, Weapons.LAU_105_2_AIM_9P5)
-        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (
-            3,
-            Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM,
-        )
+        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (3, Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9J = (3, Weapons.LAU_105_2_AIM_9J)
         LAU_105_2_AIM_9JULI = (3, Weapons.LAU_105_2_AIM_9JULI)
         AIM_7F_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
-        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
-            3,
-            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
-        )
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (3, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (
-            3,
-            Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
-        )
-        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (
-            3,
-            Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD,
-        )
+        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (3, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BIN_200 = (3, Weapons.BIN_200)
+        F4B_LAU105_AIM9J_2_BRU42A_M117_3 = (3, Weapons.F4B_LAU105_AIM9J_2_BRU42A_M117_3)
+        F4B_LAU105_AIM9J_2_BRU42A_MK82_3 = (3, Weapons.F4B_LAU105_AIM9J_2_BRU42A_MK82_3)
+        F4B_LAU105_AIM9J_2_TER9A_MK82SE_3 = (3, Weapons.F4B_LAU105_AIM9J_2_TER9A_MK82SE_3)
+        F4B_LAU105_AIM9J_2_MER_MK20_3 = (3, Weapons.F4B_LAU105_AIM9J_2_MER_MK20_3)
 
     class Pylon4:
         AIM_7F_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon5:
         AIM_7F_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon6:
         Smokewinder___red = (6, Weapons.Smokewinder___red)
@@ -205,159 +165,79 @@ class VSN_F4B(PlaneType):
         Smokewinder___blue = (6, Weapons.Smokewinder___blue)
         Smokewinder___white = (6, Weapons.Smokewinder___white)
         Smokewinder___yellow = (6, Weapons.Smokewinder___yellow)
-        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
-            6,
-            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            6,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
-            6,
-            Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD,
-        )
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (6, Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (6, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         ALQ_131___ECM_Pod = (6, Weapons.ALQ_131___ECM_Pod)
         F4B_Gunpod_w_SAPHEI_T = (6, Weapons.F4B_Gunpod_w_SAPHEI_T)
         VSN_F4EC_PTB = (6, Weapons.VSN_F4EC_PTB)
-        VSN_F4ER_PTB = (6, Weapons.VSN_F4ER_PTB)
+        VSN_F4B_C2_PTB = (6, Weapons.VSN_F4B_C2_PTB)
 
     class Pylon7:
         AIM_7F_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon8:
         AIM_7F_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon9:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            9,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (9, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            9,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
-        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
-            9,
-            Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD,
-        )
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (9, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (9, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (9, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            9,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            9,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            9,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            9,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (9, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (9, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_105_2_AIM_9L = (9, Weapons.LAU_105_2_AIM_9L)
-        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (
-            9,
-            Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM,
-        )
+        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (9, Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9P5 = (9, Weapons.LAU_105_2_AIM_9P5)
-        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (
-            9,
-            Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM,
-        )
+        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (9, Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9J = (9, Weapons.LAU_105_2_AIM_9J)
         LAU_105_2_AIM_9JULI = (9, Weapons.LAU_105_2_AIM_9JULI)
         AIM_7F_Sparrow_Semi_Active_Radar = (9, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
-        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
-            9,
-            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
-        )
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (9, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (9, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (9, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (
-            9,
-            Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
-        )
-        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (
-            9,
-            Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD,
-        )
+        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (9, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (9, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BIN_200 = (9, Weapons.BIN_200)
+        F4B_LAU105_AIM9J_2_BRU42A_M117_3 = (9, Weapons.F4B_LAU105_AIM9J_2_BRU42A_M117_3)
+        F4B_LAU105_AIM9J_2_BRU42A_MK82_3 = (9, Weapons.F4B_LAU105_AIM9J_2_BRU42A_MK82_3)
+        F4B_LAU105_AIM9J_2_TER9A_MK82SE_3 = (9, Weapons.F4B_LAU105_AIM9J_2_TER9A_MK82SE_3)
+        F4B_LAU105_AIM9J_2_MER_MK20_3 = (9, Weapons.F4B_LAU105_AIM9J_2_MER_MK20_3)
 
     class Pylon10:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.GBU_12___500lb_Laser_Guided_Bomb,
-        )
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            10,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (10, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
+        GBU_12___500lb_Laser_Guided_Bomb = (10, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (10, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (10, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            10,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            10,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            10,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            10,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (10, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         Smokewinder___red = (10, Weapons.Smokewinder___red)
         Smokewinder___green = (10, Weapons.Smokewinder___green)
         Smokewinder___blue = (10, Weapons.Smokewinder___blue)
         Smokewinder___white = (10, Weapons.Smokewinder___white)
         Smokewinder___yellow = (10, Weapons.Smokewinder___yellow)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            10,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            10,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
-            10,
-            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
-        )
-        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
-        )
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (10, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (10, Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (10, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         BIN_200 = (10, Weapons.BIN_200)
         VSN_F4ER_PTB = (10, Weapons.VSN_F4ER_PTB)
+#ERRR <CLEAN>
+#ERRR <CLEAN>
 
-    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
-    tasks = [
-        task.CAP,
-        task.Escort,
-        task.FighterSweep,
-        task.Intercept,
-        task.Reconnaissance,
-        task.GroundAttack,
-        task.CAS,
-        task.AFAC,
-        task.RunwayAttack,
-    ]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack]
     task_default = task.CAP
 
 
-@planemod
 class VSN_F4C(PlaneType):
     id = "VSN_F4C"
     flyable = True
@@ -371,7 +251,7 @@ class VSN_F4C(PlaneType):
     charge_total = 96
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     livery_name = "VSN_F4C"  # from type
@@ -386,120 +266,57 @@ class VSN_F4C(PlaneType):
         Smoke_Generator___orange_ = (1, Weapons.Smoke_Generator___orange_)
 
     class Pylon2:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            2,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            2,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (2, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            2,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            2,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         Smokewinder___red = (2, Weapons.Smokewinder___red)
         Smokewinder___green = (2, Weapons.Smokewinder___green)
         Smokewinder___blue = (2, Weapons.Smokewinder___blue)
         Smokewinder___white = (2, Weapons.Smokewinder___white)
         Smokewinder___yellow = (2, Weapons.Smokewinder___yellow)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            2,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
-            2,
-            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
-        )
-        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (
-            2,
-            Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
-        )
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (2, Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         BIN_200 = (2, Weapons.BIN_200)
         VSN_F4EL_PTB = (2, Weapons.VSN_F4EL_PTB)
 
     class Pylon3:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            3,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            3,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
-        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
-            3,
-            Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD,
-        )
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (3, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            3,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            3,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
+        AGM_45B_Shrike_ARM__Imp_ = (3, Weapons.AGM_45B_Shrike_ARM__Imp_)
+        AGM_45A_Shrike_ARM = (3, Weapons.AGM_45A_Shrike_ARM)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_105_2_AIM_9L = (3, Weapons.LAU_105_2_AIM_9L)
-        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (
-            3,
-            Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM,
-        )
+        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (3, Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9P5 = (3, Weapons.LAU_105_2_AIM_9P5)
-        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (
-            3,
-            Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM,
-        )
+        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (3, Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9J = (3, Weapons.LAU_105_2_AIM_9J)
         LAU_105_2_AIM_9JULI = (3, Weapons.LAU_105_2_AIM_9JULI)
-        AIM_7F_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
-        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
-            3,
-            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
-        )
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (3, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (
-            3,
-            Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
-        )
-        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (
-            3,
-            Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD,
-        )
+        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (3, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BIN_200 = (3, Weapons.BIN_200)
 
     class Pylon4:
         AIM_7F_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon5:
         AIM_7F_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon6:
         Smokewinder___red = (6, Weapons.Smokewinder___red)
@@ -507,153 +324,70 @@ class VSN_F4C(PlaneType):
         Smokewinder___blue = (6, Weapons.Smokewinder___blue)
         Smokewinder___white = (6, Weapons.Smokewinder___white)
         Smokewinder___yellow = (6, Weapons.Smokewinder___yellow)
-        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
-            6,
-            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            6,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
-            6,
-            Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD,
-        )
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (6, Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (6, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         ALQ_131___ECM_Pod = (6, Weapons.ALQ_131___ECM_Pod)
         F4B_Gunpod_w_SAPHEI_T = (6, Weapons.F4B_Gunpod_w_SAPHEI_T)
         VSN_F4EC_PTB = (6, Weapons.VSN_F4EC_PTB)
-        VSN_F4ER_PTB = (6, Weapons.VSN_F4ER_PTB)
+        VSN_F4B_C2_PTB = (6, Weapons.VSN_F4B_C2_PTB)
 
     class Pylon7:
         AIM_7F_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon8:
         AIM_7F_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
+        AIM_7E_2_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
 
     class Pylon9:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            9,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (9, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            9,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
-        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
-            9,
-            Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD,
-        )
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (9, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (9, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (9, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            9,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            9,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            9,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            9,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
+        AGM_45B_Shrike_ARM__Imp_ = (9, Weapons.AGM_45B_Shrike_ARM__Imp_)
+        AGM_45A_Shrike_ARM = (9, Weapons.AGM_45A_Shrike_ARM)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (9, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (9, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_105_2_AIM_9L = (9, Weapons.LAU_105_2_AIM_9L)
-        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (
-            9,
-            Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM,
-        )
+        LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM = (9, Weapons.LAU_105_with_2_x_AIM_9P_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9P5 = (9, Weapons.LAU_105_2_AIM_9P5)
-        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (
-            9,
-            Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM,
-        )
+        LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM = (9, Weapons.LAU_7_with_2_x_AIM_9B_Sidewinder_IR_AAM)
         LAU_105_2_AIM_9J = (9, Weapons.LAU_105_2_AIM_9J)
         LAU_105_2_AIM_9JULI = (9, Weapons.LAU_105_2_AIM_9JULI)
-        AIM_7F_Sparrow_Semi_Active_Radar = (9, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
-        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
-            9,
-            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
-        )
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (9, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (9, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (
-            9,
-            Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
-        )
-        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (
-            9,
-            Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD,
-        )
+        TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (9, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (9, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BIN_200 = (9, Weapons.BIN_200)
 
     class Pylon10:
-        GBU_10___2000lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.GBU_12___500lb_Laser_Guided_Bomb,
-        )
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
-            10,
-            Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
-        )
+        GBU_10___2000lb_Laser_Guided_Bomb = (10, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
+        GBU_12___500lb_Laser_Guided_Bomb = (10, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (10, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (10, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            10,
-            Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            10,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            10,
-            Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            10,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (10, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         Smokewinder___red = (10, Weapons.Smokewinder___red)
         Smokewinder___green = (10, Weapons.Smokewinder___green)
         Smokewinder___blue = (10, Weapons.Smokewinder___blue)
         Smokewinder___white = (10, Weapons.Smokewinder___white)
         Smokewinder___yellow = (10, Weapons.Smokewinder___yellow)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
-            10,
-            Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            10,
-            Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
-            10,
-            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
-        )
-        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
-        )
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (10, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (10, Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (10, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         BIN_200 = (10, Weapons.BIN_200)
         VSN_F4ER_PTB = (10, Weapons.VSN_F4ER_PTB)
+#ERRR <CLEAN>
+#ERRR <CLEAN>
 
-    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
-    tasks = [
-        task.CAP,
-        task.Escort,
-        task.FighterSweep,
-        task.Intercept,
-        task.Reconnaissance,
-        task.GroundAttack,
-        task.CAS,
-        task.AFAC,
-        task.RunwayAttack,
-    ]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack]
     task_default = task.CAP

--- a/pydcs_extensions/f4/f4.py
+++ b/pydcs_extensions/f4/f4.py
@@ -237,7 +237,7 @@ class VSN_F4B(PlaneType):
     tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack]
     task_default = task.CAP
 
-
+@planemod
 class VSN_F4C(PlaneType):
     id = "VSN_F4C"
     flyable = True


### PR DESCRIPTION
There were a number of weapons changes for the F-4. This is a direct paste from planes.py with the new weapons injected above it, I did not bother reformatting each line like I did last time (breaking each pylon weapons line into 3 or 4 different lines to match the A-4 formatting), this seems much easier to read and will be easier to update in the future. If that is incorrect and I need to reformat it let me know and I will do so.

Summary of changes since it might be hard to follow - really all this commit does is -

Add back in the AIM_7E_2_Sparrow_Semi_Active_Radar - matching DCS's new name for it

Add in the following F-4B/C specific weapons -

{F4B_LAU105_AIM9J_2_BRU42A_M117_3}": Weapons.F4B_LAU105_AIM9J_2_BRU42A_M117_3,
{F4B_LAU105_AIM9J_2_BRU42A_MK82_3}": Weapons.F4B_LAU105_AIM9J_2_BRU42A_MK82_3,
{F4B_LAU105_AIM9J_2_MER_MK20_3}": Weapons.F4B_LAU105_AIM9J_2_MER_MK20_3,
{F4B_LAU105_AIM9J_2_TER9A_MK82SE_3": Weapons.F4B_LAU105_AIM9J_2_TER9A_MK82SE_3,

Add in the two new pylons for the TERs for the above weapons.

I'll update the weapons fallback files to reflect all of this later today or this week.