### PR TITLE
Update pydcs to fix Falklands airport data.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,8 @@ Saves from 6.x are not compatible with 7.0.
 
 ## Fixes
 
-* **[Campaign]** Fixed a longstanding bug where oversized airlifts could corrupt a save with empty convoys. 
+* **[Campaign]** Fixed a longstanding bug where oversized airlifts could corrupt a save with empty convoys.
+* **[Modding]** Fixed an issue where Falklands campaigns created or edited with new versions of DCS could not be loaded.
 
 # 6.1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.3
--e git+https://github.com/pydcs/dcs@7fd426bbd08794cb14a6c3371b61aff92b501853#egg=pydcs
+-e git+https://github.com/pydcs/dcs@39de3d7d905fb408ad7197b0c36a9458efea1c66#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
The Falklands data in pydcs was missing an (unfinished, unusable) airport, and that was breaking miz loading of campaigns that were edited or created with a version of DCS to include these airports which have incomplete data.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2732.