### PR TITLE
Fixes F-14B squadrons that don't have SEAD as available mission type

### DIFF
--- a/resources/squadrons/F-14B Tomcat/VF-142.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-142.yaml
@@ -15,6 +15,7 @@ mission_types:
   - Intercept
   - OCA/Aircraft
   - OCA/Runway
+  - SEAD
   - Strike
   - Fighter sweep
   - TARCAP

--- a/resources/squadrons/F-14B Tomcat/VF-143.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-143.yaml
@@ -5,9 +5,6 @@ female_pilot_percentage: 7
 country: USA
 role: Strike Fighter
 aircraft: F-14B Tomcat
-bases:
-    carrier: true
-    shore: true
 livery: VF-143 Pukin Dogs CAG
 mission_types:
   - BAI
@@ -18,6 +15,7 @@ mission_types:
   - Intercept
   - OCA/Aircraft
   - OCA/Runway
+  - SEAD
   - Strike
   - Fighter sweep
   - TARCAP

--- a/resources/squadrons/F-14B Tomcat/VF-211.yaml
+++ b/resources/squadrons/F-14B Tomcat/VF-211.yaml
@@ -15,6 +15,7 @@ mission_types:
   - Intercept
   - OCA/Aircraft
   - OCA/Runway
+  - SEAD
   - Strike
   - Fighter sweep
   - TARCAP


### PR DESCRIPTION
Fixes the YAMLs for 3 F-14B squadrons that didn't have SEAD as an available mission type. F-14s use SEAD for TALD deployment. The other F-14B squadrons and all the F-14A squadrons are fine. I also removed "Bases:" from one of the squadrons as the other squadron yamls don't have it and it's unecessary (F-14Bs can already be based at airfields and carriers.
