### PR TITLE
Fix encoding for some file reads, and some bad UTF-8 escapes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ Saves from 6.x are not compatible with 7.0.
 
 * **[Campaign]** Fixed a longstanding bug where oversized airlifts could corrupt a save with empty convoys.
 * **[Modding]** Fixed an issue where Falklands campaigns created or edited with new versions of DCS could not be loaded.
+* **[Modding]** Fixed decoding of campaign yaml files to use UTF-8 rather than the system locale's default. It's now possible to use "Bf 109 K-4 Kurfürst" as a preferred aircraft type.
 
 # 6.1.1
 

--- a/game/campaignloader/campaign.py
+++ b/game/campaignloader/campaign.py
@@ -57,7 +57,7 @@ class Campaign:
 
     @classmethod
     def from_file(cls, path: Path) -> Campaign:
-        with path.open() as campaign_file:
+        with path.open(encoding="utf-8") as campaign_file:
             data = yaml.safe_load(campaign_file)
 
         sanitized_theater = data["theater"].replace(" ", "")

--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -88,7 +88,11 @@ class DefaultSquadronAssigner:
         try:
             aircraft = AircraftType.named(preferred_aircraft)
         except KeyError:
-            # No aircraft with this name.
+            logging.warning(
+                "%s is neither a compatible squadron or a known aircraft type, "
+                "ignoring",
+                preferred_aircraft,
+            )
             return None
 
         if aircraft not in self.coalition.faction.aircrafts:

--- a/game/logging_config.py
+++ b/game/logging_config.py
@@ -16,7 +16,7 @@ def init_logging(version: str) -> None:
     log_config = resources / "default_logging.yaml"
     if (custom_log_config := resources / "logging.yaml").exists():
         log_config = custom_log_config
-    with log_config.open() as log_file:
+    with log_config.open(encoding="utf-8") as log_file:
         logging.config.dictConfig(yaml.safe_load(log_file))
 
     logging.info(f"DCS Liberation {version}")

--- a/game/theater/theaterloader.py
+++ b/game/theater/theaterloader.py
@@ -92,13 +92,13 @@ class TheaterLoader:
 
     @property
     def menu_thumbnail_dcs_relative_path(self) -> Path:
-        with self.descriptor_path.open() as descriptor_file:
+        with self.descriptor_path.open(encoding="utf-8") as descriptor_file:
             data = yaml.safe_load(descriptor_file)
         name = data.get("pydcs_name", data["name"])
         return Path("Mods/terrains") / name / "Theme/icon.png"
 
     def load(self) -> ConflictTheater:
-        with self.descriptor_path.open() as descriptor_file:
+        with self.descriptor_path.open(encoding="utf-8") as descriptor_file:
             data = yaml.safe_load(descriptor_file)
         return ConflictTheater(
             TERRAINS_BY_NAME[data.get("pydcs_name", data["name"])],

--- a/resources/campaigns/caen_to_evreux.yaml
+++ b/resources/campaigns/caen_to_evreux.yaml
@@ -2,7 +2,11 @@
 name: Normandy - From Caen to Evreux
 theater: Normandy
 authors: Khopa
-description: <p>This is a light scenario on the Normandy map.</p><p>August 1944, allied forces are pushing from Caen/Carpiquet to the cities of Lisieux and Evreux.<p>Lisieux is an important logistic hub for the Werhmacht, and Evreux airbase is hosting most of the Luftwaffe forces in the region.</p>
+description:
+  <p>This is a light scenario on the Normandy map.</p><p>August 1944, allied
+  forces are pushing from Caen/Carpiquet to the cities of Lisieux and
+  Evreux.<p>Lisieux is an important logistic hub for the Werhmacht, and Evreux
+  airbase is hosting most of the Luftwaffe forces in the region.</p>
 recommended_player_faction: Allies 1944
 recommended_enemy_faction: Germany 1944
 recommended_start_date: 1944-07-04
@@ -14,7 +18,7 @@ squadrons:
   26:
     - primary: BARCAP
       aircraft:
-        - Bf 109 K-4 Kurf\u00fcrst
+        - Bf 109 K-4 Kurfürst
     - primary: BARCAP
       aircraft:
         - Fw 190 A-8 Anton
@@ -32,7 +36,7 @@ squadrons:
   40:
     - primary: BARCAP
       aircraft:
-        - Bf 109 K-4 Kurf\u00fcrst
+        - Bf 109 K-4 Kurfürst
     - primary: BARCAP
       aircraft:
         - Fw 190 A-8 Anton
@@ -67,7 +71,7 @@ squadrons:
       secondary: any
     - primary: DEAD
       secondary: any
-  # Ford_AF 
+  # Ford_AF
   31:
     - primary: BARCAP
       aircraft:


### PR DESCRIPTION
Fix file encoding for some loads.

We've actually been pretty good at getting this right in most of the code base, but we've missed it in a few places. Python defaults to the encoding of the current locale unless otherwise specified, and for a US English Windows install that's cp1252, not UTF-8. I'm not brave enough to change the locale at startup because I don't know how that might affect CJK encoding users (or for that matter, non-Latin derived alphabet UTF-8 variants).

This PR also fixes a bad unicode escape in the Caen to Evreaux campaign (I think that campaign probably experienced this bug since its inception, but no one ever noticed) and improves the logging so it'd have been easier for the campaign author to debug (even if they couldn't have fixed it).

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2786.