### PR TITLE
Fix unit details screen for Qt6.

### DIFF
--- a/qt_ui/windows/QUnitInfoWindow.py
+++ b/qt_ui/windows/QUnitInfoWindow.py
@@ -2,20 +2,14 @@ from __future__ import annotations
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import (
-    QDialog,
-    QGridLayout,
-    QLabel,
-    QTextBrowser,
-    QFrame,
-)
+from PySide6.QtWidgets import QDialog, QFrame, QGridLayout, QLabel, QTextBrowser
 
 import game.ato.ai_flight_planner_db
+from game.ato.flighttype import FlightType
 from game.dcs.aircrafttype import AircraftType
 from game.dcs.groundunittype import GroundUnitType
 from game.dcs.unittype import UnitType
 from game.game import Game
-from game.ato.flighttype import FlightType
 from qt_ui.uiconstants import AIRCRAFT_BANNERS, VEHICLE_BANNERS
 
 
@@ -53,7 +47,7 @@ class QUnitInfoWindow(QDialog):
         # Build the topmost details grid.
         self.details_grid = QFrame()
         self.details_grid_layout = QGridLayout()
-        self.details_grid_layout.setMargin(0)
+        self.details_grid_layout.setContentsMargins(0, 0, 0, 0)
 
         self.name_box = QLabel(
             f"<b>Name:</b> {unit_type.manufacturer} {unit_type.name}"


### PR DESCRIPTION
The `setMargin` shorthand was apparently to simple, so Qt6 removed it in favor of `setContentMargins`, which does the same thing?

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2784.