### PR TITLE
Update pydcs for the plane helipad spawning fix.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Saves from 6.x are not compatible with 7.0.
 * **[Campaign]** Fixed a longstanding bug where oversized airlifts could corrupt a save with empty convoys.
 * **[Modding]** Fixed an issue where Falklands campaigns created or edited with new versions of DCS could not be loaded.
 * **[Modding]** Fixed decoding of campaign yaml files to use UTF-8 rather than the system locale's default. It's now possible to use "Bf 109 K-4 Kurfürst" as a preferred aircraft type.
+* **[Mission Generation]** Planes will no longer spawn in helipads that are not also designated for fixed wing parking.
 
 # 6.1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.3
--e git+https://github.com/pydcs/dcs@39de3d7d905fb408ad7197b0c36a9458efea1c66#egg=pydcs
+-e git+https://github.com/pydcs/dcs@832c8a361319553cb6f2b46f5b2542180b7f72b6#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2782.