### PR TITLE
Remove GroundPlanners from the save state.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Saves from 6.x are not compatible with 7.0.
 * **[Modding]** Fixed an issue where Falklands campaigns created or edited with new versions of DCS could not be loaded.
 * **[Modding]** Fixed decoding of campaign yaml files to use UTF-8 rather than the system locale's default. It's now possible to use "Bf 109 K-4 Kurfürst" as a preferred aircraft type.
 * **[Mission Generation]** Planes will no longer spawn in helipads that are not also designated for fixed wing parking.
+* **[Mission Generation]** Potentially an issue where ground war planning game state could become corrupted, preventing mission generation.
 
 # 6.1.1
 

--- a/game/game.py
+++ b/game/game.py
@@ -7,7 +7,6 @@ from collections.abc import Iterator
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from typing import Any, List, TYPE_CHECKING, Type, Union, cast
-from uuid import UUID
 
 from dcs.countries import Switzerland, USAFAggressors, UnitedNationsPeacekeepers
 from dcs.country import Country
@@ -17,7 +16,6 @@ from dcs.vehicles import AirDefence
 from faker import Faker
 
 from game.ato.closestairfields import ObjectiveDistanceCache
-from game.ground_forces.ai_ground_planner import GroundPlanner
 from game.models.game_stats import GameStats
 from game.plugins import LuaPluginManager
 from game.utils import Distance
@@ -109,7 +107,6 @@ class Game:
         self.date = date(start_date.year, start_date.month, start_date.day)
         self.game_stats = GameStats()
         self.notes = ""
-        self.ground_planners: dict[UUID, GroundPlanner] = {}
         self.informations: list[Information] = []
         self.message("Game Start", "-" * 40)
         # Culling Zones are for areas around points of interest that contain things we may not wish to cull.
@@ -431,14 +428,6 @@ class Game:
             self.blue.initialize_turn()
         if for_red:
             self.red.initialize_turn()
-
-        # Plan GroundWar
-        self.ground_planners = {}
-        for cp in self.theater.controlpoints:
-            if cp.has_frontline:
-                gplanner = GroundPlanner(cp, self)
-                gplanner.plan_groundwar()
-                self.ground_planners[cp.id] = gplanner
 
         # Update cull zones
         with logged_duration("Computing culling positions"):


### PR DESCRIPTION
These are only used during mission generation. Remove them from the save state to reduce compatibility requirements. We also have at least one report of this data being corrupted... somehow. I don't know how that could have happened, but if there's no data to corrupt in the first place that's not a problem. If the corruption _does_ recur, it'll be much easier to repro if it corrupts during mission generation rather than during turn initialization.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2729.