### PR TITLE
Use S_EVENT_KILL and S_EVENT_UNIT_LOST to track unit kills

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -124,22 +124,20 @@ class StateData:
         killed_aircraft = []
         killed_ground_units = []
 
-        # process killed units from S_EVENT_UNIT_LOST & S_EVENT_KILL
-        killed_units = clean_unit_list(data["unit_lost_events"] + data["kill_events"])
+        # Process killed units from S_EVENT_UNIT_LOST, S_EVENT_CRASH, S_EVENT_DEAD & S_EVENT_KILL
+        # Try to process every event that could indicate a unit was killed, even if it is
+        # inefficient and results in duplication as the logic DCS uses to trigger the various
+        # event types is not clear and may change over time.
+        killed_units = clean_unit_list(
+            data["unit_lost_events"]
+            + data["kill_events"]
+            + data["crash_events"]
+            + data["dead_events"]
+        )
         for unit in killed_units:  # organize killed units into aircraft vs ground
             if unit_map.flight(unit) is not None:
                 killed_aircraft.append(unit)
             else:
-                killed_ground_units.append(unit)
-
-        # process killed units from S_EVENT_CRASH
-        for unit in data["crash_events"]:  # no need to clean crash events
-            if unit not in killed_aircraft:
-                killed_aircraft.append(unit)
-
-        # process killed units from S_EVENT_DEAD
-        for unit in clean_unit_list(data["dead_events"]):
-            if unit not in killed_ground_units:
                 killed_ground_units.append(unit)
 
         return cls(

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -110,10 +110,9 @@ class StateData:
 
     @classmethod
     def from_json(cls, data: Dict[str, Any], unit_map: UnitMap) -> StateData:
-    
         def clean_unit_list(unit_list: List[Any]) -> List[str]:
             # Cleans list of units in state.json by
-            # - Removing duplicates. Airfields emit a new "dead" event every time a bomb 
+            # - Removing duplicates. Airfields emit a new "dead" event every time a bomb
             #   is dropped on them when they've already dead.
             # - Normalise dead map objects (which are ints) to strings. The unit map
             #   only stores strings
@@ -122,27 +121,27 @@ class StateData:
                 units.add(str(unit))
             return list(units)
 
-        killed_aircraft=[]
-        killed_ground_units=[]
-        
+        killed_aircraft = []
+        killed_ground_units = []
+
         # process killed units from S_EVENT_UNIT_LOST & S_EVENT_KILL
-        killed_units=clean_unit_list(data["unit_lost_events"] + data["kill_events"])
+        killed_units = clean_unit_list(data["unit_lost_events"] + data["kill_events"])
         for unit in killed_units:  # organize killed units into aircraft vs ground
-            if unit_map.flight(unit) is not None:  
+            if unit_map.flight(unit) is not None:
                 killed_aircraft.append(unit)
             else:
                 killed_ground_units.append(unit)
-        
+
         # process killed units from S_EVENT_CRASH
         for unit in data["crash_events"]:  # no need to clean crash events
             if unit not in killed_aircraft:
                 killed_aircraft.append(unit)
-                
+
         # process killed units from S_EVENT_DEAD
         for unit in clean_unit_list(data["dead_events"]):
             if unit not in killed_ground_units:
                 killed_ground_units.append(unit)
-                
+
         return cls(
             mission_ended=data["mission_ended"],
             killed_aircraft=killed_aircraft,

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -111,7 +111,7 @@ class StateData:
     @classmethod
     def from_json(cls, data: Dict[str, Any], unit_map: UnitMap) -> StateData:
     
-        def clean_unit_list(unit_list):
+        def clean_unit_list(unit_list: List[Any]) -> List[str]:
             # Cleans list of units in state.json by
             # - Removing duplicates. Airfields emit a new "dead" event every time a bomb 
             #   is dropped on them when they've already dead.


### PR DESCRIPTION
This PR addresses Issue 2765 (https://github.com/dcs-liberation/dcs_liberation/issues/2765) and augments the current logic with S_EVENT_UNIT_LOST and S_EVENT_UNIT_KILL events.
