### PR TITLE
AI to perform SEAD missions as such

### DIFF
--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -18,6 +18,7 @@ from dcs.task import (
     OptRestrictJettison,
     Refueling,
     RunwayAttack,
+    SEAD,
     Transport,
 )
 from dcs.unitgroup import FlyingGroup
@@ -167,7 +168,7 @@ class AircraftBehavior:
         # CAS is able to perform all the same tasks as SEAD using a superset of the
         # available aircraft, and F-14s are not able to be SEAD despite having TALDs.
         # https://forums.eagle.ru/topic/272112-cannot-assign-f-14-to-sead/
-        group.task = CAS.name
+        group.task = SEAD.name
         self.configure_behavior(
             flight,
             group,


### PR DESCRIPTION
**Killing surface-to-air-missiles 101**
1. Frag a SEAD flight carrying high speed anti-radiation missile (HARM). 
2. Launch missiles from a safe distance which follow the radar emitters. 
3. After the radar emitters are toast, frag a DEAD flight to safely engage the now useless SAM(s).

I noticed that HARMs were ineffectively used by the AI. Basically, they would fly towards their target and wait for the radar energy from these SAMs to hit them. This is a risky maneuver, especially against SAMs that can kill you from up 50 nm away. 

Once the SAM fires a missile, the AI is programmed to start defending instead of firing their missiles, and promptly dying afterwards.

After looking at the mission editor, I noticed that dcs_liberation creates SEAD flights as CAS:
![image](https://user-images.githubusercontent.com/24258135/232964983-8fbacf83-4245-42d0-8201-a3e630849ed2.png)

I changed this manually to SEAD and ran the mission. The result was the AI flight firing their missile from a safe distance towards a waypoint that is near their target (with the correct HARM code), and returning to base. In the F/A-18, this option of launching the HARM is called [prebriefed (PB)](https://www.youtube.com/watch?v=59-gnHmGQs4).

Will test out how the F-16 behaves with this new change, although I suspect SEAD tasking in-game makes sense for any SEAD flights that were created in the UI.