### PR TITLE
update recoverytanker waypoint to have tanker task

### DIFF
--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -1,5 +1,5 @@
 from dcs.point import MovingPoint
-from dcs.task import ActivateBeaconCommand, RecoveryTanker
+from dcs.task import ActivateBeaconCommand, RecoveryTanker, Tanker
 
 from game.ato import FlightType
 from game.utils import feet, knots
@@ -10,6 +10,11 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
 
         assert self.flight.flight_type == FlightType.REFUELING
+
+        waypoint.add_task(
+            Tanker()
+        )  # Tanker task required in conjunction with RecoveryTanker task
+
         group_id = self._get_carrier_group_id()
         speed = knots(250).meters_per_second
         altitude = feet(6000).meters

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -11,9 +11,10 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
 
         assert self.flight.flight_type == FlightType.REFUELING
 
-        waypoint.add_task(
-            Tanker()
-        )  # Tanker task required in conjunction with RecoveryTanker task
+        # Tanker task required in conjunction with RecoveryTanker task.
+        # See link below for details.
+        # https://github.com/dcs-liberation/dcs_liberation/issues/2771
+        waypoint.add_task(Tanker())
 
         group_id = self._get_carrier_group_id()
         speed = knots(250).meters_per_second


### PR DESCRIPTION
This PR addresses Issue 2771 by adding a Tanker task in the RecoveryTankerBuilder class.

The problem described in the issue can be reproduced in the following Liberation save (v7). 
[test.liberation.zip](https://github.com/dcs-liberation/dcs_liberation/files/11286080/test.liberation.zip)

1. Take off as the Hornet
2. Wait for the S3B recovery tanker to take off and reach the recovery tanking waypoint
3. Open the comms menu. In the develop build, you will not be able to contact the tanker. In this PR, you will be able to contact the tanker and refuel