### PR TITLE
pass now to fix_tots

### DIFF
--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -169,10 +169,10 @@ class QTopPanel(QFrame):
         return packages
 
     @staticmethod
-    def fix_tots(packages: List[Package]) -> None:
+    def fix_tots(packages: List[Package], now: datetime) -> None:
         for package in packages:
             estimator = TotEstimator(package)
-            package.time_over_target = estimator.earliest_tot()
+            package.time_over_target = estimator.earliest_tot(now)
 
     def ato_has_clients(self) -> bool:
         for package in self.game.blue.ato.packages:
@@ -235,7 +235,7 @@ class QTopPanel(QFrame):
         mbox.exec_()
         clicked = mbox.clickedButton()
         if clicked == auto:
-            self.fix_tots(negative_starts)
+            self.fix_tots(negative_starts, self.sim_controller.current_time_in_sim)
             return True
         elif clicked == ignore:
             return True


### PR DESCRIPTION
This PR addresses https://github.com/dcs-liberation/dcs_liberation/issues/2746 

Steps taken to test this PR are:

1. Load attached save in development build, noting that the starting time is 11:00:00
[test.liberation.zip](https://github.com/dcs-liberation/dcs_liberation/files/11300044/test.liberation.zip)
2. Press Take Off and note the following times in the DCS mission editor for the generated .miz file

Mission time: 11:00:00

Player flight BARCAP Sukhumi-Babushara
Start: 11:00:00
Racetrack Start: 11:21:07
Racetrack End: 11:26:16
Land: 11:32:49

Example AI Flight AEW&C Kobuleti
Start: 11:03:51
Racetrack Start: 11:15:43

3. Re-load the attached save, or else Liberation generates another error. Advance time in Liberation, in this example to 11:03:25
4. Click Take Off. In the development build, the error described in https://github.com/dcs-liberation/dcs_liberation/issues/2746 is seen. With this PR, a mission is generated, with the following times in the DCS mission editor for the same player and AI flights.

Mission time: 11:03:26

Player flight BARCAP Sukhumi-Babushara
Start: 11:03:26
Racetrack Start: 11:24:33 (original + 00:03:26)
Racetrack End: 11:29:42 (as above)
Land: 11:36:15 (as above)

Example AI Flight AEW&C Kobuleti
Start: 11:03:26 (set to mission start)
Racetrack Start: 11:15:43 (unchaged)