### PR TITLE
update _flight_plan_builder whenever flight_type is changed so that w…

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -171,6 +171,15 @@ class Flight(SidcDescribable):
     def missing_pilots(self) -> int:
         return self.roster.missing_pilots
 
+    def set_flight_type(self, var: FlightType) -> None:
+        self.flight_type = var
+
+        # Update _flight_plan_builder so that the builder class remains relevant
+        # to the flight type
+        from .flightplans.flightplanbuildertypes import FlightPlanBuilderTypes
+
+        self._flight_plan_builder = FlightPlanBuilderTypes.for_flight(self)(self)
+
     def return_pilots_and_aircraft(self) -> None:
         self.roster.clear()
         self.squadron.claim_inventory(-self.count)

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
@@ -162,11 +162,11 @@ class QFlightWaypointTab(QFrame):
         )
         original_task = self.flight.flight_type
         if result == QMessageBox.Yes:
-            self.flight.flight_type = task
+            self.flight.set_flight_type(task)
             try:
                 self.flight.recreate_flight_plan()
             except PlanningError as ex:
-                self.flight.flight_type = original_task
+                self.flight.set_flight_type(original_task)
                 logging.exception("Could not recreate flight")
                 QMessageBox.critical(
                     self, "Could not recreate flight", str(ex), QMessageBox.Ok


### PR DESCRIPTION
This PR addresses https://github.com/dcs-liberation/dcs_liberation/issues/2779.

The mechanism for how this bug arises is that the *WaypointGenerator* uses the *FlightWaypoint.waypoint_type* to decide whether to generate the waypoint in the .miz file using a *DeadIngressBuilder* or a *SeadIngressBuilder*. This *waypoint_type* is set by *ato.flightplans.<sead|dead>.Builder*, which is set when *ato.flight* is initialised in the *Flight._flight_plan_builder* member variable based on *Flight.flight_type*. When *Flight.flight_type* is updated when the flight is changed from SEAD->DEAD, *Flight._flight_plan_builder* is not updated in the development build, resulting in it continuing to generate SEAD waypoints.

This PR adds *set_flight_type()* which sets the *flight_type* property and updates *Flight._flight_plan_builder* and uses this function when converting flight types. Ideally, *flight_type* should be made private and only accessed through getter/setter functions that encapsulate this behavior, but that would mess up any existing liberation save files. 

This PR was tested by:
1. Opening the save file from Issue 2779 in the development build
2. Clicking "Take Off" and confirming that the Weapon Release Type is "Guided" at the Ingress Waypoint as described in the issue. 
3. Opening the save file from Issue 2779 in this PR
4. Converting the SEAD2DEAD flight from DEAD back to SEAD, and then from SEAD to DEAD
5. Clicking "Take Off" and confirming in the mission editor that the SEAD2DEAD flight has Weapon Release Type set to "Auto" at the Ingress Waypoint.