### PR TITLE
Persist some campaign creation options.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Saves from 6.x are not compatible with 7.0.
 * **[Modding]** Custom factions can now be defined in YAML as well as JSON. JSON support may be removed in the future if having both formats causes confusion.
 * **[Modding]** Campaigns which require custom factions can now define those factions directly in the campaign YAML. See Operation Aliied Sword for an example.
 * **[Modding]** The `mission_types` field in squadron files has been removed. Squadron task capability is now determined by airframe, and the auto-assignable list has always been overridden by the campaign settings.
+* **[New Game Wizard]** Some game settings are now saved to be reused for the next game. At present this is a small set (just supercarrier and auto-purchase), but it will be expanded later.
 * **[Squadrons]** Squadron-specific mission capability lists no longer restrict players from assigning missions outside the squadron's preferences.
 
 ## Fixes

--- a/game/persistence/paths.py
+++ b/game/persistence/paths.py
@@ -18,8 +18,13 @@ def base_path() -> str:
     return str(_dcs_saved_game_folder)
 
 
+def liberation_user_dir() -> Path:
+    """The path to the Liberation user directory."""
+    return Path(base_path()) / "Liberation"
+
+
 def save_dir() -> Path:
-    return Path(base_path()) / "Liberation" / "Saves"
+    return liberation_user_dir() / "Saves"
 
 
 def mission_path_for(name: str) -> Path:

--- a/game/settings/booleanoption.py
+++ b/game/settings/booleanoption.py
@@ -18,6 +18,7 @@ def boolean_option(
     detail: Optional[str] = None,
     tooltip: Optional[str] = None,
     causes_expensive_game_update: bool = False,
+    remember_player_choice: bool = False,
     **kwargs: Any,
 ) -> bool:
     return field(
@@ -29,6 +30,7 @@ def boolean_option(
                 detail,
                 tooltip,
                 causes_expensive_game_update,
+                remember_player_choice,
                 invert,
             )
         },

--- a/game/settings/boundedfloatoption.py
+++ b/game/settings/boundedfloatoption.py
@@ -21,6 +21,7 @@ def bounded_float_option(
     divisor: int,
     detail: Optional[str] = None,
     tooltip: Optional[str] = None,
+    remember_player_choice: bool = False,
     **kwargs: Any,
 ) -> float:
     return field(
@@ -32,6 +33,7 @@ def bounded_float_option(
                 detail,
                 tooltip,
                 causes_expensive_game_update=False,
+                remember_player_choice=remember_player_choice,
                 min=min,
                 max=max,
                 divisor=divisor,

--- a/game/settings/boundedintoption.py
+++ b/game/settings/boundedintoption.py
@@ -20,6 +20,7 @@ def bounded_int_option(
     detail: Optional[str] = None,
     tooltip: Optional[str] = None,
     causes_expensive_game_update: bool = False,
+    remember_player_choice: bool = False,
     **kwargs: Any,
 ) -> int:
     return field(
@@ -31,6 +32,7 @@ def bounded_int_option(
                 detail,
                 tooltip,
                 causes_expensive_game_update,
+                remember_player_choice,
                 min=min,
                 max=max,
             )

--- a/game/settings/choicesoption.py
+++ b/game/settings/choicesoption.py
@@ -38,6 +38,9 @@ def choices_option(
                 detail,
                 tooltip,
                 causes_expensive_game_update=False,
+                # Same as minutes_option, this requires custom serialization before we
+                # can do this.
+                remember_player_choice=False,
                 choices=dict(choices),
             )
         },

--- a/game/settings/minutesoption.py
+++ b/game/settings/minutesoption.py
@@ -31,6 +31,11 @@ def minutes_option(
                 detail,
                 tooltip,
                 causes_expensive_game_update=False,
+                # Can't preserve timedelta until we create some custom serialization for
+                # it. The default serialization is as a python object, which isn't
+                # allowed in yaml.safe_load because a malicious modification of the
+                # settings file would be able to execute arbitrary code.
+                remember_player_choice=False,
                 min=min,
                 max=max,
             )

--- a/game/settings/optiondescription.py
+++ b/game/settings/optiondescription.py
@@ -13,3 +13,10 @@ class OptionDescription:
     detail: Optional[str]
     tooltip: Optional[str]
     causes_expensive_game_update: bool
+
+    # If True, the player's selection for this value will be saved to settings.yaml in
+    # the Liberation user directory when a new game is created, and those values will be
+    # used by default for new games. This is conditional because many settings are not
+    # appropriate for cross-game persistence (economy settings are, for example, usually
+    # hinted by the campaign itself).
+    remember_player_choice: bool

--- a/qt_ui/windows/settings/QSettingsWindow.py
+++ b/qt_ui/windows/settings/QSettingsWindow.py
@@ -95,7 +95,7 @@ class AutoSettingsLayout(QGridLayout):
         self.settings = settings
         self.write_full_settings = write_full_settings
 
-        for row, (name, description) in enumerate(Settings.fields(page, section)):
+        for row, (name, description) in enumerate(Settings.fields_for(page, section)):
             self.add_label(row, description)
             if isinstance(description, BooleanOption):
                 self.add_checkbox_for(row, name, description)


### PR DESCRIPTION
We should also persist mod options, but those will go in a separate file because they aren't a part of Settings.

Plugins need some work before that can be saved here. They're not configurable in the NGW currently, so that needs to be fixed first. It also appears that it may not be safe to inject the settings object with plugin options until the game is created, but that needs more investigation (see the comment in Settings.save_player_settings).

Another obvious candidate would be the desired player mission duration, but we need to implement custom serialization for that first.