### PR TITLE
Fix pydcs extension packages.

### DIFF
--- a/pydcs_extensions/__init__.py
+++ b/pydcs_extensions/__init__.py
@@ -6,9 +6,9 @@ from .frenchpack import *
 from .hercules import *
 from .highdigitsams import *
 from .jas39 import *
+from .ov10a import *
 from .su57 import *
 from .uh60l import *
-from .ov10a import *
 
 
 def load_mods() -> None:

--- a/pydcs_extensions/a4ec/__init__.py
+++ b/pydcs_extensions/a4ec/__init__.py
@@ -1,0 +1,1 @@
+from .a4ec import *

--- a/pydcs_extensions/f104/__init__.py
+++ b/pydcs_extensions/f104/__init__.py
@@ -1,0 +1,1 @@
+from .f104 import *

--- a/pydcs_extensions/f22a/__init__.py
+++ b/pydcs_extensions/f22a/__init__.py
@@ -1,0 +1,1 @@
+from .f22a import *

--- a/pydcs_extensions/f4/__init__.py
+++ b/pydcs_extensions/f4/__init__.py
@@ -1,0 +1,1 @@
+from .f4 import *

--- a/pydcs_extensions/hercules/__init__.py
+++ b/pydcs_extensions/hercules/__init__.py
@@ -1,0 +1,1 @@
+from .hercules import *

--- a/pydcs_extensions/jas39/__init__.py
+++ b/pydcs_extensions/jas39/__init__.py
@@ -1,0 +1,1 @@
+from .jas39 import *

--- a/pydcs_extensions/ov10a/__init__.py
+++ b/pydcs_extensions/ov10a/__init__.py
@@ -1,0 +1,1 @@
+from .ov10a import *

--- a/pydcs_extensions/su57/__init__.py
+++ b/pydcs_extensions/su57/__init__.py
@@ -1,0 +1,1 @@
+from .su57 import *

--- a/pydcs_extensions/uh60l/__init__.py
+++ b/pydcs_extensions/uh60l/__init__.py
@@ -1,0 +1,1 @@
+from .uh60l import *


### PR DESCRIPTION
pydcs_extensions.__init__ wasn't actually doing anything because without an __init__.py each of these "packages" was empty. This has been working by accident because of ai_flight_planner_db.py.