### PR TITLE
Update mypy, fastapi, pydantic.

### DIFF
--- a/game/ato/flightplans/sweep.py
+++ b/game/ato/flightplans/sweep.py
@@ -93,6 +93,7 @@ class SweepFlightPlan(LoiterFlightPlan):
     def mission_begin_on_station_time(self) -> datetime | None:
         return None
 
+    @property
     def mission_departure_time(self) -> datetime:
         return self.sweep_end_time
 

--- a/game/commander/tasks/packageplanningtask.py
+++ b/game/commander/tasks/packageplanningtask.py
@@ -31,8 +31,7 @@ class RangeType(IntEnum):
 
 
 # TODO: Refactor so that we don't need to call up to the mission planner.
-# Bypass type checker due to https://github.com/python/mypy/issues/5374
-@dataclass  # type: ignore
+@dataclass
 class PackagePlanningTask(TheaterCommanderTask, Generic[MissionTargetT]):
     target: MissionTargetT
     flights: list[ProposedFlight] = field(init=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ idna==3.4
 iniconfig==1.1.1
 Jinja2==3.1.2
 MarkupSafe==2.1.1
-mypy==0.961
-mypy-extensions==0.4.3
+mypy==1.2.0
+mypy-extensions==1.0.0
 nodeenv==1.7.0
 packaging==22.0
 pathspec==0.10.3
@@ -31,7 +31,7 @@ Pillow==9.3.0
 platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
-pydantic==1.10.3
+pydantic==1.10.7
 -e git+https://github.com/pydcs/dcs@832c8a361319553cb6f2b46f5b2542180b7f72b6#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14


### PR DESCRIPTION
mypy update is needed for typing.Self support. It caught an existing bug (missing @property on override), and fixed a bug so we can drop an ignore.

Upgrading mypy requires upgrading pydantic to get the newest pydantic mypy plugin, and since that's what's driving fastapi it's probably smart to upgrade those together.