### PR TITLE
Ignore parse errors of preferences file.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ Saves from 6.x are not compatible with 7.0.
 ## Fixes
 
 * **[Campaign]** Fixed a longstanding bug where oversized airlifts could corrupt a save with empty convoys.
+* **[Engine]** Fixed crash in startup caused by a corrupted Liberation preferences file.
 * **[Modding]** Fixed an issue where Falklands campaigns created or edited with new versions of DCS could not be loaded.
 * **[Modding]** Fixed decoding of campaign yaml files to use UTF-8 rather than the system locale's default. It's now possible to use "Bf 109 K-4 Kurfürst" as a preferred aircraft type.
 * **[Mission Generation]** Planes will no longer spawn in helipads that are not also designated for fixed wing parking.

--- a/qt_ui/liberation_install.py
+++ b/qt_ui/liberation_install.py
@@ -36,7 +36,9 @@ def init():
                 "ignore_empty_install_directory", False
             )
             is_first_start = False
-        except KeyError:
+        except (KeyError, ValueError):
+            # KeyError in case of missing contents, ValueError in case of decoding
+            # errors from a corrupted file.
             __dcs_saved_game_directory = ""
             __dcs_installation_directory = ""
             __last_save_file = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
--e git+https://github.com/pydcs/dcs@832c8a361319553cb6f2b46f5b2542180b7f72b6#egg=pydcs
+-e git+https://github.com/pydcs/dcs@da35d1b908ccc13305561241b0e673ff3eb682a6#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
Includes both the Liberation fix and the pydcs update with the fix on that side.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2613.