### PR TITLE
make BAI plannable against vehicles only

### DIFF
--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -164,7 +164,6 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
         else:
             yield from [
                 FlightType.STRIKE,
-                FlightType.BAI,
                 FlightType.REFUELING,
             ]
         yield from super().mission_types(for_player)
@@ -583,6 +582,13 @@ class VehicleGroupGroundObject(TheaterGroundObject):
     @property
     def should_head_to_conflict(self) -> bool:
         return True
+
+    def mission_types(self, for_player: bool) -> Iterator[FlightType]:
+        from game.ato import FlightType
+
+        if not self.is_friendly(for_player):
+            yield FlightType.BAI
+        yield from super().mission_types(for_player)
 
 
 class EwrGroundObject(IadsGroundObject):


### PR DESCRIPTION
This PR addresses https://github.com/dcs-liberation/dcs_liberation/issues/2618 by making BAI plannable against VehicleGroupGroundObject only. This PR was tested by:

1. Running the development build and confirming that BAIs can be planned manually against buildings
2. Running the PR and confirming that BAIs cannot be planned manually against buildings
3. Running the PR and confirming that BAIs can be planned manually  against enemy vehicle groups
4. Running the PR and confirming that BAIs cannot be planned manually  against friendly vehicle groups