### PR TITLE
Add a test for the Aircraft component.

### DIFF
--- a/client/src/components/aircraft/Aircraft.test.tsx
+++ b/client/src/components/aircraft/Aircraft.test.tsx
@@ -1,0 +1,53 @@
+import Aircraft from "./Aircraft";
+import { render } from "@testing-library/react";
+import { Icon } from "leaflet";
+
+const mockMarker = jest.fn();
+jest.mock("react-leaflet", () => ({
+  Marker: (props: any) => {
+    mockMarker(props);
+  },
+}));
+
+test("grounded aircraft do not render", async () => {
+  const { container } = render(
+    <Aircraft
+      flight={{
+        id: "",
+        blue: true,
+        position: undefined,
+        sidc: "",
+        waypoints: [],
+      }}
+    />
+  );
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+test("in-flight aircraft render", async () => {
+  render(
+    <Aircraft
+      flight={{
+        id: "",
+        blue: true,
+        position: {
+          lat: 10,
+          lng: 20,
+        },
+        sidc: "foobar",
+        waypoints: [],
+      }}
+    />
+  );
+
+  expect(mockMarker).toHaveBeenCalledWith(
+    expect.objectContaining({
+      position: {
+        lat: 10,
+        lng: 20,
+      },
+      icon: expect.any(Icon),
+    })
+  );
+});


### PR DESCRIPTION
Leaflet (or maybe react-leaflet?) isn't very testable, so we can really only test that mocks were called with the right props for the leaflet components we expect, but that's still better than nothing.