### PR TITLE
enable AEWC missions on FOBs

### DIFF
--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1444,6 +1444,8 @@ class Fob(ControlPoint):
         if not self.is_friendly(for_player):
             yield FlightType.STRIKE
             yield FlightType.AIR_ASSAULT
+        else:
+            yield FlightType.AEWC
 
         yield from super().mission_types(for_player)
 


### PR DESCRIPTION
This PR addresses https://github.com/dcs-liberation/dcs_liberation/issues/2048 by making AEW&C missions plannable against friendly FOBs

This PR was tested by:

- Running the development build and confirming that AEW&C missions are plannable against friendly LHAs (looks like this one already got fixed) but not against friendly FOBs
- Running the PR build and confirming that AEW&C missions are plannable against friendly FOBs but not enemy FOBs