### PR TITLE
Add an option to prefer primary tasked aircraft.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@ Saves from 6.x are not compatible with 7.0.
 
 * **[Engine]** Support for DCS 2.8.3.37556.
 * **[Engine]** Saved games are now a zip file of save assets for easier bug reporting. The new extension is .liberation.zip. Drag and drop that file into bug reports.
-* **[Flight Planning]** Package TOT and composition can be modified after advancing time in Liberation.
+* **[Campaign AI]** Added an option to instruct the campaign AI to prefer fulfilling missions with squadrons which have a matching primary task. Previously distance from target held a stronger influence than task preference. Primary tasks for squadrons are set by campaign designers but are user-configurable.
+* **[Flight Planning]** Package TOT and composition can be modified after advancing time in Liberation. 
 * **[Mission Generation]** Units on the front line are now hidden on MFDs.
 * **[Mission Generation]** Preset radio channels will now be configured for both A-10C modules.
 * **[Mission Generation]** The A-10C II now uses separate radios for inter- and intra-flight comms (similar to other modern aircraft).

--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -43,7 +43,11 @@ class DefaultSquadronAssigner:
                     continue
 
                 squadron = Squadron.create_from(
-                    squadron_def, control_point, self.coalition, self.game
+                    squadron_def,
+                    squadron_config.primary,
+                    control_point,
+                    self.coalition,
+                    self.game,
                 )
                 squadron.set_auto_assignable_mission_types(
                     squadron_config.auto_assignable

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -195,6 +195,18 @@ class Settings:
             "future release."
         ),
     )
+    prefer_squadrons_with_matching_primary_task: bool = boolean_option(
+        "Prefer squadrons with matching primary task when planning missions",
+        page=CAMPAIGN_MANAGEMENT_PAGE,
+        section=GENERAL_SECTION,
+        default=False,
+        detail=(
+            "If checked, squadrons with a primary task matching the mission will be "
+            "preferred even if there is a closer squadron capable of the mission as a"
+            "secondary task. Expect longer flights, but squadrons will be more often "
+            "assigned to their primary task."
+        ),
+    )
     # Pilots and Squadrons
     ai_pilot_levelling: bool = boolean_option(
         "Allow AI pilot leveling",

--- a/game/squadrons/airwing.py
+++ b/game/squadrons/airwing.py
@@ -23,6 +23,7 @@ class AirWing:
         self.squadrons: dict[AircraftType, list[Squadron]] = defaultdict(list)
         self.squadron_defs = SquadronDefLoader(game, faction).load()
         self.squadron_def_generator = SquadronDefGenerator(faction)
+        self.settings = game.settings
 
     def unclaim_squadron_def(self, squadron: Squadron) -> None:
         if squadron.aircraft in self.squadron_defs:
@@ -65,6 +66,17 @@ class AirWing:
                     capable_at_base,
                     key=lambda s: best_aircraft.index(s.aircraft),
                 )
+            )
+
+        if self.settings.prefer_squadrons_with_matching_primary_task:
+            return sorted(
+                ordered,
+                key=lambda s: (
+                    # This looks like the opposite of what we want because False sorts
+                    # before True.
+                    s.primary_task != task,
+                    s.location.distance_to(location),
+                ),
             )
         return ordered
 

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -32,6 +32,7 @@ class Squadron:
     role: str
     aircraft: AircraftType
     livery: Optional[str]
+    primary_task: FlightType
     auto_assignable_mission_types: set[FlightType]
     operating_bases: OperatingBases
     female_pilot_percentage: int
@@ -422,6 +423,7 @@ class Squadron:
     def create_from(
         cls,
         squadron_def: SquadronDef,
+        primary_task: FlightType,
         base: ControlPoint,
         coalition: Coalition,
         game: Game,
@@ -434,6 +436,7 @@ class Squadron:
             squadron_def.role,
             squadron_def.aircraft,
             squadron_def.livery,
+            primary_task,
             squadron_def.auto_assignable_mission_types,
             squadron_def.operating_bases,
             squadron_def.female_pilot_percentage,

--- a/qt_ui/widgets/combos/primarytaskselector.py
+++ b/qt_ui/widgets/combos/primarytaskselector.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QComboBox
+
+from game.ato import FlightType
+from game.dcs.aircrafttype import AircraftType
+from game.squadrons import Squadron
+
+
+class PrimaryTaskSelector(QComboBox):
+    def __init__(self, aircraft: AircraftType | None) -> None:
+        super().__init__()
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        self.set_aircraft(aircraft)
+
+    @staticmethod
+    def for_squadron(squadron: Squadron) -> PrimaryTaskSelector:
+        selector = PrimaryTaskSelector(squadron.aircraft)
+        selector.setCurrentText(squadron.primary_task.value)
+        return selector
+
+    def set_aircraft(self, aircraft: AircraftType | None) -> None:
+        self.clear()
+        if aircraft is None:
+            self.addItem("Select aircraft type first", None)
+            self.setEnabled(False)
+            self.update()
+            return
+
+        self.setEnabled(True)
+        for task in aircraft.iter_task_capabilities():
+            self.addItem(task.value, task)
+        self.model().sort(0)
+        self.setEnabled(True)
+        self.update()
+
+    @property
+    def selected_task(self) -> FlightType | None:
+        return self.currentData()


### PR DESCRIPTION
We're still using mostly the same aircraft selection as we have before we added squadrons: the closest aircraft is the best choice.

This adds an option to obey the primary task set by the campaign designer (can be overridden by players), even if the squadron is farther away than one that is capable of it as a secondary task.

I don't expect this option to live very long. I'm making it optional for now to give people a chance to test it, but it'll either replace the old selection strategy or will be removed.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/1892.