### PR TITLE
Update pydcs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
--e git+https://github.com/pydcs/dcs@da35d1b908ccc13305561241b0e673ff3eb682a6#egg=pydcs
+git+https://github.com/pydcs/dcs@632a373fb0d8799f29eed81bc41eaefc006d859c#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
No new data (I think), but includes a bunch of fixes for the lua parser and rewrites some suspicious looking (but probably safe) code in the livery scanner.

Also changes this dependency to non-editable by default. Pip chose this automatically for me at some point, but the rules for whether or not a py.typed file will actually be detected for an editable install are complicated and sometimes this won't work, leading too a lot of mypy errors. There's no need for this to be editable anyway.