### PR TITLE
Update pydcs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Saves from 6.x are not compatible with 7.0.
 
 ## Features/Improvements
 
-* **[Engine]** Support for DCS 2.8.3.37556.
+* **[Engine]** Support for DCS 2.8.4.39731.
 * **[Engine]** Saved games are now a zip file of save assets for easier bug reporting. The new extension is .liberation.zip. Drag and drop that file into bug reports.
 * **[Campaign]** Added options to limit squadron sizes and to begin all squadrons at maximum strength. Maximum squadron size is defined during air wing configuration with default values provided by the campaign.
 * **[Campaign AI]** Added an option to instruct the campaign AI to prefer fulfilling missions with squadrons which have a matching primary task. Previously distance from target held a stronger influence than task preference. Primary tasks for squadrons are set by campaign designers but are user-configurable.

--- a/pydcs_extensions/a4ec/a4ec.py
+++ b/pydcs_extensions/a4ec/a4ec.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -579,7 +578,6 @@ class A_4E_C(PlaneType):
                 x_14_seconds = 7
 
     livery_name = "A-4E-C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (

--- a/pydcs_extensions/f104/f104.py
+++ b/pydcs_extensions/f104/f104.py
@@ -1,7 +1,6 @@
 from typing import Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -67,7 +66,6 @@ class VSN_F104C(PlaneType):
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "VSN_F104C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)
@@ -321,7 +319,6 @@ class VSN_F104G(PlaneType):
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "VSN_F104G"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)
@@ -584,7 +581,6 @@ class VSN_F104S(PlaneType):
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "VSN_F104S"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)
@@ -709,7 +705,6 @@ class VSN_F104S_AG(PlaneType):
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "VSN_F104S_AG"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)

--- a/pydcs_extensions/f22a/f22a.py
+++ b/pydcs_extensions/f22a/f22a.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -44,7 +43,6 @@ class F_22A(PlaneType):
             id = "BAY_DOOR_OPTION"
 
     livery_name = "F-22A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9X_Sidewinder_IR_AAM = (1, Weapons.AIM_9X_Sidewinder_IR_AAM)

--- a/pydcs_extensions/f4/f4.py
+++ b/pydcs_extensions/f4/f4.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, Set
+from typing import Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -103,7 +102,6 @@ class VSN_F4B(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "VSN_F4B"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)
@@ -469,7 +467,6 @@ class VSN_F4C(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "VSN_F4C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)

--- a/pydcs_extensions/hercules/hercules.py
+++ b/pydcs_extensions/hercules/hercules.py
@@ -1,7 +1,6 @@
 from typing import Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -730,7 +729,6 @@ class Hercules(PlaneType):
     }
 
     livery_name = "HERCULES"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Herc_JATO = (1, HerculesWeapons.Herc_JATO)

--- a/pydcs_extensions/jas39/jas39.py
+++ b/pydcs_extensions/jas39/jas39.py
@@ -1,7 +1,6 @@
 from typing import Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -275,7 +274,6 @@ class JAS39Gripen(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "JAS39GRIPEN"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         IRIS_T_IR_AAM = (1, JAS39GripenWeapons.IRIS_T_IR_AAM)
@@ -516,7 +514,6 @@ class JAS39Gripen_AG(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "JAS39GRIPEN_AG"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         IRIS_T_IR_AAM = (1, JAS39GripenWeapons.IRIS_T_IR_AAM)

--- a/pydcs_extensions/ov10a/ov10a.py
+++ b/pydcs_extensions/ov10a/ov10a.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, Set
+from typing import Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -42,7 +41,6 @@ class Bronco_OV_10A(PlaneType):
     }
 
     livery_name = "BRONCO-OV-10A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (

--- a/pydcs_extensions/su57/su57.py
+++ b/pydcs_extensions/su57/su57.py
@@ -1,7 +1,6 @@
 from typing import Set
 
 from dcs import task
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 from dcs.weapons_data import Weapons
 
@@ -42,7 +41,6 @@ class Su_57(PlaneType):
     category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "SU-57"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)

--- a/pydcs_extensions/uh60l/uh60l.py
+++ b/pydcs_extensions/uh60l/uh60l.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Set
 
 from dcs import task
 from dcs.helicopters import HelicopterType
-from dcs.liveries_scanner import Liveries
 from dcs.planes import PlaneType
 
 from game.modsupport import helicoptermod, planemod
@@ -114,7 +113,6 @@ class UH_60L(HelicopterType):
                 Equally_Responsible = -2
 
     livery_name = "UH-60L"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         CEFS_Fuel_Tank_200_gallons = (1, WeaponsUH60L.CEFS_Fuel_Tank_200_gallons)
@@ -170,7 +168,6 @@ class KC130J(PlaneType):
     category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "KC130J"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
-git+https://github.com/pydcs/dcs@632a373fb0d8799f29eed81bc41eaefc006d859c#egg=pydcs
+git+https://github.com/pydcs/dcs@60859c44a255be19f7b692f921d6fbd95f544904#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
Includes the rewritten livery scanning code. It might need some more tweaks to be fast enough, but it at least now doesn't spam the log for machines that don't have DCS (or Liberation) installed, and it's not slow until something tries to use it, so until we add the UI we won't have to pay for it during startup.