### PR TITLE
Updates Germany WW2 Free - Flak 18, guard tower, Opel Blitz changes

### DIFF
--- a/resources/factions/germany_1944_free.yaml
+++ b/resources/factions/germany_1944_free.yaml
@@ -10,7 +10,7 @@ aircrafts:
   - Fw 190 A-8 Anton
   - Fw 190 D-9 Dora
 frontline_units:
-  - 8.8 cm Flak 18
+  - Truck Opel Blitz
   - Panzerkampfwagen IV Ausf. H
   - Sd.Kfz.251 "Hanomag"
 artillery_units: []
@@ -19,7 +19,7 @@ logistics_units:
 infantry_units:
   - Infantry AK-74 Rus
 air_defense_units:
-  - 8.8 cm Flak 18
+  - Watch tower armed
 preset_groups: []
 naval_units: []
 requirements: {}


### PR DESCRIPTION
Three proposed changes:

1. Removes Flak18 as these currently require Kdo.G.40. (part of the WW2 Asset Pack) to fire at player. ED-supplied single missions are having Flak18s w/out WW2 Asset Pack firing at a point in the air. 

2. Adds Opel Blitz to frontline for more variety, balance, and some little bit of historical accuracy. My understanding is late war was more truck strafing than HVARing Panzers.

3. Adds guard tower to AAA units to have a functioning AAA since Flak18s don't work. 