### PR TITLE
Makes guard tower (house2arm) a AAA unit

### DIFF
--- a/resources/units/ground_units/house2arm.yaml
+++ b/resources/units/ground_units/house2arm.yaml
@@ -1,4 +1,4 @@
-class: Fortification
+class: AAA
 price: 0
 variants:
   Watch tower armed: null


### PR DESCRIPTION
Makes house2arm guard tower a AAA unit in order to have a small-arms caliber AAA for WW2 and COIN faction/campaigns