### PR TITLE
Update B-52H.yaml to add anti-ship mission type

### DIFF
--- a/resources/units/aircraft/B-52H.yaml
+++ b/resources/units/aircraft/B-52H.yaml
@@ -13,6 +13,7 @@ max_range: 2000
 variants:
   B-52H Stratofortress: {}
 tasks:
+  Anti-ship: 100
   DEAD: 210
   OCA/Runway: 660
   Strike: 690


### PR DESCRIPTION
B52s can carry harpoons but currently cannot be tasked for anti-ship missions. This edit allows them to be used for anti-ship.