### PR TITLE
Do not create refueling tasks without tankers.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@ Saves from 6.x are not compatible with 7.0.
 * **[Modding]** Fixed decoding of campaign yaml files to use UTF-8 rather than the system locale's default. It's now possible to use "Bf 109 K-4 Kurfürst" as a preferred aircraft type.
 * **[Mission Generation]** Planes will no longer spawn in helipads that are not also designated for fixed wing parking.
 * **[Mission Generation]** Potentially an issue where ground war planning game state could become corrupted, preventing mission generation.
+* **[Mission Generation]** Refueling tasks will now only be created for flights that have a tanker in their package.
 
 # 6.1.1
 

--- a/game/ato/package.py
+++ b/game/ato/package.py
@@ -225,3 +225,7 @@ class Package:
             if not flight.state.is_waiting_for_start:
                 return False
         return True
+
+    def has_flight_with_task(self, task: FlightType) -> bool:
+        """Returns True if any flight in the package has the given task."""
+        return task in (f.flight_type for f in self.flights)

--- a/game/missiongenerator/aircraft/waypoints/refuel.py
+++ b/game/missiongenerator/aircraft/waypoints/refuel.py
@@ -1,9 +1,12 @@
 from dcs.point import MovingPoint
 from dcs.task import RefuelingTaskAction
+
+from game.ato import FlightType
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
 class RefuelPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
-        waypoint.add_task(RefuelingTaskAction())
+        if self.package.has_flight_with_task(FlightType.REFUELING):
+            waypoint.add_task(RefuelingTaskAction())
         return super().add_tasks(waypoint)


### PR DESCRIPTION
If the package does not have a tanker, the refueling task will cause AI flights to go to an arbitrary tanker, which may cause them to fly through enemy territory or even go farther than their arrival airbase.

It's also not remotely possible for every AI flight in the game to refuel in most missions. There's typically one tanker and dozens of aircraft that would previously attempt to refuel.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2716.