### PR TITLE
Use weibull distribution for wind generation.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Saves from 6.x are not compatible with 7.0.
 * **[Mission Generation]** Units on the front line are now hidden on MFDs.
 * **[Mission Generation]** Preset radio channels will now be configured for both A-10C modules.
 * **[Mission Generation]** The A-10C II now uses separate radios for inter- and intra-flight comms (similar to other modern aircraft).
+* **[Mission Generation]** Wind speeds no longer follow a uniform distribution. Median wind speeds are now much lower and the standard deviation has been reduced considerably at altitude but increased somewhat at MSL.
 * **[Modding]** Updated Community A-4E-C mod version support to 2.1.0 release.
 * **[Modding]** Add support for VSN F-4B and F-4C mod.
 * **[Modding]** Custom factions can now be defined in YAML as well as JSON. JSON support may be removed in the future if having both formats causes confusion.


### PR DESCRIPTION
Wind speeds should not be uniformly distributed. This switches to a Weibull distribution which allegedly (see the bug) is good enough. Experimentally that seems true as well, though I know nothing about how wind works irl. This at least looks like it'll generate reasonable variation in missions while keeping the 1st through 3rd quartile behaviors from getting out of hand.

I'm very uncertain about the scaling factor aspect of this. Naively the wind speeds at different altitudes ought to be somewhat correlated, but I'm not sure how much, and whether this kind of scaling is at all the right way to do it. As before, meh, close enough?

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2861.