### PR TITLE
Update ADM141 data to include clsids for hornet

### DIFF
--- a/resources/weapons/standoff/ADM-141A.yaml
+++ b/resources/weapons/standoff/ADM-141A.yaml
@@ -7,3 +7,6 @@ clsids:
   - "{BRU3242_ADM141}"
   - "{ADM_141A}"
   - "{ADM_141B}"
+  - "{BRU_42A_x1_ADM_141A}"
+  - "{BRU_42A_x2_ADM_141A}"
+  - "{BRU_42A_x3_ADM_141A}"


### PR DESCRIPTION
This PR adds clsids for ADM141 that were missed so that the decoy behavior works properly on the Hornet.