### PR TITLE
Restores Flak 18 to free German faction

### DIFF
--- a/resources/factions/germany_1944_free.yaml
+++ b/resources/factions/germany_1944_free.yaml
@@ -19,7 +19,7 @@ logistics_units:
 infantry_units:
   - Infantry AK-74 Rus
 air_defense_units:
-  - Watch tower armed
+  - 8.8 cm Flak 18
 preset_groups: []
 naval_units: []
 requirements: {}


### PR DESCRIPTION
Restored Flak 18 to free German faction since AI assigned to CAS won't attack watch tower. Flak 18 still non-functioning without WW2 Asset Pack KDO40 unit; Flak18 will be a passive AAA target for now until ED fixes.