### PR TITLE
Update pydcs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Saves from 6.x are not compatible with 7.0.
 
 ## Features/Improvements
 
-* **[Engine]** Support for DCS 2.8.4.39731.
+* **[Engine]** Support for DCS 2.8.5.40170.
 * **[Engine]** Saved games are now a zip file of save assets for easier bug reporting. The new extension is .liberation.zip. Drag and drop that file into bug reports.
 * **[Campaign]** Added options to limit squadron sizes and to begin all squadrons at maximum strength. Maximum squadron size is defined during air wing configuration with default values provided by the campaign.
 * **[Campaign]** Added handling for more DCS death events. This probably does not catch any deaths that weren't previously tracked, but it should record them sooner, which will improve results for game crashes or other early exits.

--- a/pydcs_extensions/f104/f104.py
+++ b/pydcs_extensions/f104/f104.py
@@ -97,19 +97,11 @@ class VSN_F104C(PlaneType):
             4,
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             4,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (4, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
@@ -197,19 +189,11 @@ class VSN_F104C(PlaneType):
             8,
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            8,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             8,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (8, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            8,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (8, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
@@ -350,19 +334,11 @@ class VSN_F104G(PlaneType):
             4,
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             4,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (4, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
@@ -459,19 +435,11 @@ class VSN_F104G(PlaneType):
             8,
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            8,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             8,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (8, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            8,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (8, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
@@ -749,19 +717,11 @@ class VSN_F104S_AG(PlaneType):
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
         CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            3,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             3,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (3, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            3,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         AIM_9L_Sidewinder_IR_AAM = (3, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9B_Sidewinder_IR_AAM = (3, Weapons.AIM_9B_Sidewinder_IR_AAM)
         AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
@@ -794,19 +754,11 @@ class VSN_F104S_AG(PlaneType):
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
         CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             4,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (4, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
@@ -915,19 +867,11 @@ class VSN_F104S_AG(PlaneType):
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
         CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            8,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             8,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (8, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            8,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (8, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
@@ -1016,19 +960,11 @@ class VSN_F104S_AG(PlaneType):
             Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets,
         )
         CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            9,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
             9,
             Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__,
         )
         B_8M1___20_S_8OFP2 = (9, Weapons.B_8M1___20_S_8OFP2)
-        B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
-            9,
-            Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk,
-        )
         AIM_9P_Sidewinder_IR_AAM = (9, Weapons.AIM_9P_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (9, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (9, Weapons.AIM_9L_Sidewinder_IR_AAM)

--- a/pydcs_extensions/su57/su57.py
+++ b/pydcs_extensions/su57/su57.py
@@ -96,10 +96,6 @@ class Su_57(PlaneType):
             2,
             Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
         )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            2,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
             2,
             Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag,
@@ -216,10 +212,6 @@ class Su_57(PlaneType):
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
             4,
             Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            4,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
         )
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
             4,
@@ -346,10 +338,6 @@ class Su_57(PlaneType):
             9,
             Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
         )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            9,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
-        )
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
             9,
             Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag,
@@ -459,10 +447,6 @@ class Su_57(PlaneType):
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
             11,
             Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
-            11,
-            Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP,
         )
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
             11,

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
-git+https://github.com/pydcs/dcs@97cc0a28941fac32bac66884f29461fd8a5fdfde#egg=pydcs
+git+https://github.com/pydcs/dcs@8fdeda106ba7e847a5d0a1ed358a1463636b513d#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
Support for DCS 2.8.5.40170, including laser hellfire, pylon 5 for the apache, and a more tolerant livery scanner (not all liveries will be discovered, but Liberation at least won't crash).

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2880.