### PR TITLE
Fix syntax error in bluefor_modern.yaml.

### DIFF
--- a/resources/factions/bluefor_modern.yaml
+++ b/resources/factions/bluefor_modern.yaml
@@ -107,7 +107,7 @@ liveries_overrides:
   J-11A Flanker-L:
     - USN Aggressor VFC-13 'Ferris' (Fictional)
   JF-17 Thunder:
-    - 'Chips' Camo for Blue Side (Fictional)
+    - "'Chips' Camo for Blue Side (Fictional)"
   Ka-50 Hokum:
     - georgia camo
   Ka-50 Hokum (Blackshark 3):


### PR DESCRIPTION
(cherry picked from commit 7a2e8279cd2c4dcf0d6bd1bdc93aa10ad135f51c)