### PR TITLE
Make the flight details menu modal.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ Saves from 7.x are not compatible with 8.0.
 
 ## Fixes
 
+# 7.1.0
+
+## Features/Improvements
+
+## Fixes
+
 # 7.0.0
 
 Saves from 6.x are not compatible with 7.0.

--- a/qt_ui/windows/mission/QEditFlightDialog.py
+++ b/qt_ui/windows/mission/QEditFlightDialog.py
@@ -29,6 +29,7 @@ class QEditFlightDialog(QDialog):
 
         self.setWindowTitle("Edit flight")
         self.setWindowIcon(EVENT_ICONS["strike"])
+        self.setModal(True)
 
         layout = QVBoxLayout()
 


### PR DESCRIPTION
Prevents players from accidentally deleting flights they're currently viewing, which would cause an error.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2911.