### PR TITLE
issue 2922: make BAI plannable against missile and costal sites

### DIFF
--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -434,6 +434,14 @@ class MissileSiteGroundObject(TheaterGroundObject):
     def should_head_to_conflict(self) -> bool:
         return True
 
+    def mission_types(self, for_player: bool) -> Iterator[FlightType]:
+        from game.ato import FlightType
+
+        if not self.is_friendly(for_player):
+            yield FlightType.BAI
+        for mission_type in super().mission_types(for_player):
+            yield mission_type
+
 
 class CoastalSiteGroundObject(TheaterGroundObject):
     def __init__(
@@ -465,6 +473,14 @@ class CoastalSiteGroundObject(TheaterGroundObject):
     @property
     def should_head_to_conflict(self) -> bool:
         return True
+
+    def mission_types(self, for_player: bool) -> Iterator[FlightType]:
+        from game.ato import FlightType
+
+        if not self.is_friendly(for_player):
+            yield FlightType.BAI
+        for mission_type in super().mission_types(for_player):
+            yield mission_type
 
 
 class IadsGroundObject(TheaterGroundObject, ABC):

--- a/tests/theater/test_theatergroundobject.py
+++ b/tests/theater/test_theatergroundobject.py
@@ -180,7 +180,8 @@ def test_mission_types_enemy(mocker: Any) -> None:
             control_point=dummy_control_point,
         )
         mission_types = list(ground_object.mission_types(for_player=False))
-        assert len(mission_types) == 6
+        assert len(mission_types) == 7
+        assert FlightType.BAI in mission_types
         assert FlightType.STRIKE in mission_types
         assert FlightType.REFUELING in mission_types
         assert FlightType.ESCORT in mission_types


### PR DESCRIPTION
This PR addresses  #2922 by making BAI plannable against Coastal Sites and Missile Sites.