### PR TITLE
Enforces Topgun: Maverick Rogue Nation livery for Iranian Tomcat

### DIFF
--- a/resources/factions/iran_2015.yaml
+++ b/resources/factions/iran_2015.yaml
@@ -74,3 +74,6 @@ missiles:
   - SSM SS-1C Scud-B
 has_jtac: true
 jtac_unit: MQ-9 Reaper
+liveries_overrides:
+  F-14A Tomcat (Block 135-GR Late):
+    - Rogue Nation(Top Gun - Maverick)


### PR DESCRIPTION
Enforces Topgun: Maverick Rogue Nation livery for Iranian Tomcat...while fictional it's the only non-American livery there is.