### PR TITLE
Disallow air wing generation with overfull bases.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,8 @@ Saves from 7.0.0 are compatible with 7.1.0
 * **[Mission Generation]** Added option to prevent scud and V2 sites from firing at the start of the mission.
 * **[Mission Generation]** Added settings for controlling number of tactical commander, observer, JTAC, and game master slots.
 * **[Mission Planning]** Per-flight TOT offsets can now be set in the flight details UI. This allows individual flights to be scheduled ahead of or behind the rest of the package.
+* **[New Game Wizard]** The air wing configuration dialog will check for and reject overfull airbases before continuing when the new squadron rules are used.
+* **[New Game Wizard]** Closing the air wing configuration dialog will now cancel and return to the new game wizard rather than reverting changes and continuing.
 * **[UI]** Parking capacity of each squadron's base is now shown during air wing configuration to avoid overcrowding bases when beginning the game with full squadrons.
 
 ## Fixes

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -13,7 +13,7 @@ import yaml
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QApplication, QCheckBox, QSplashScreen
+from PySide6.QtWidgets import QApplication, QCheckBox, QSplashScreen, QDialog
 from dcs.payloads import PayloadDirectories
 
 from game import Game, VERSION, logging_config, persistence
@@ -357,7 +357,8 @@ def create_game(params: CreateGameParams) -> Game:
     )
     game = generator.generate()
     if params.show_air_wing_config:
-        AirWingConfigurationDialog(game, None).exec_()
+        if AirWingConfigurationDialog(game, None).exec() == QDialog.DialogCode.Rejected:
+            sys.exit("Aborted air wing configuration")
     game.begin_turn_0(squadrons_start_full=params.use_new_squadron_rules)
     return game
 

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QDialog,
 )
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -223,7 +224,12 @@ class NewGameWizard(QtWidgets.QWizard):
         )
         self.generatedGame = generator.generate()
 
-        AirWingConfigurationDialog(self.generatedGame, self).exec_()
+        if (
+            AirWingConfigurationDialog(self.generatedGame, self).exec()
+            == QDialog.DialogCode.Rejected
+        ):
+            logging.info("Aborted air wing configuration")
+            return
 
         self.generatedGame.begin_turn_0(squadrons_start_full=use_new_squadron_rules)
 


### PR DESCRIPTION
This also changes the window close button of the air wing configuration dialog to cancel rather than revert and continue, because otherwise there's no way for the user to back out of the dialog without fixing all the overfull bases first.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2910.