### PR TITLE
Fix Python coverage reporting.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: run tests
         run: |
           ./venv/scripts/activate
-          pytest --cov-report=xml tests
+          pytest --cov --cov-report=xml tests
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv
 .vscode/settings.json
 dist/**
 /.coverage
+/coverage.xml
 # User-specific stuff
 .idea/
 .env


### PR DESCRIPTION
Apparently the fact that I want the coverage report to be XML isn't enough of a hint that I want coverage.