### PR TITLE
Added and updated weapons files

### DIFF
--- a/pydcs_extensions/ov10a/ov10a.py
+++ b/pydcs_extensions/ov10a/ov10a.py
@@ -41,12 +41,18 @@ class Bronco_OV_10A(PlaneType):
     }
 
     livery_name = "BRONCO-OV-10A"  # from type
+    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
             1,
             Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
         )
+        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
+            1,
+            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+        )
+        LAU_33A = (1, Weapons.LAU_33A)
 
     # ERRR {MK-81}
 
@@ -61,6 +67,7 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (2, Weapons.LAU3_HE5)
         LAU3_HE151 = (2, Weapons.LAU3_HE151)
         M260_HYDRA = (2, Weapons.M260_HYDRA)
+        M260_HYDRA_WP = (2, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             2,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -68,6 +75,62 @@ class Bronco_OV_10A(PlaneType):
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             2,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            2,
+            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            2,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            2,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+            2,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
         )
 
     # ERRR {MK-81}
@@ -83,6 +146,7 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (3, Weapons.LAU3_HE5)
         LAU3_HE151 = (3, Weapons.LAU3_HE151)
         M260_HYDRA = (3, Weapons.M260_HYDRA)
+        M260_HYDRA_WP = (3, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             3,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -90,6 +154,62 @@ class Bronco_OV_10A(PlaneType):
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             3,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            3,
+            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            3,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            3,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+            3,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
         )
 
     class Pylon4:
@@ -99,6 +219,7 @@ class Bronco_OV_10A(PlaneType):
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         M117___750lb_GP_Bomb_LD = (4, Weapons.M117___750lb_GP_Bomb_LD)
+        Mk4_mod_0 = (4, Weapons.Mk4_mod_0)
 
     # ERRR {MK-81}
 
@@ -113,6 +234,7 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (5, Weapons.LAU3_HE5)
         LAU3_HE151 = (5, Weapons.LAU3_HE151)
         M260_HYDRA = (5, Weapons.M260_HYDRA)
+        M260_HYDRA_WP = (5, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             5,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -120,6 +242,62 @@ class Bronco_OV_10A(PlaneType):
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             5,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            5,
+            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            5,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            5,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+            5,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
         )
 
     # ERRR {MK-81}
@@ -135,6 +313,7 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (6, Weapons.LAU3_HE5)
         LAU3_HE151 = (6, Weapons.LAU3_HE151)
         M260_HYDRA = (6, Weapons.M260_HYDRA)
+        M260_HYDRA_WP = (6, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             6,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -143,15 +322,76 @@ class Bronco_OV_10A(PlaneType):
             6,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
         )
+        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            6,
+            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            6,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            6,
+            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
+        )
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+        )
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+            6,
+            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
+        )
 
     class Pylon7:
         LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
             7,
             Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
         )
+        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
+            7,
+            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+        )
+        LAU_33A = (7, Weapons.LAU_33A)
 
     class Pylon8:
-        ParaTrooper = (8, Weapons.ParaTrooper)
+        OV10_Paratrooper = (8, Weapons.OV10_Paratrooper)
 
     class Pylon9:
         OV10_SMOKE = (9, Weapons.OV10_SMOKE)

--- a/pydcs_extensions/ov10a/ov10a.py
+++ b/pydcs_extensions/ov10a/ov10a.py
@@ -41,18 +41,12 @@ class Bronco_OV_10A(PlaneType):
     }
 
     livery_name = "BRONCO-OV-10A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
             1,
             Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
         )
-        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
-            1,
-            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
-        )
-        LAU_33A = (1, Weapons.LAU_33A)
 
     # ERRR {MK-81}
 
@@ -67,7 +61,6 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (2, Weapons.LAU3_HE5)
         LAU3_HE151 = (2, Weapons.LAU3_HE151)
         M260_HYDRA = (2, Weapons.M260_HYDRA)
-        M260_HYDRA_WP = (2, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             2,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -75,62 +68,6 @@ class Bronco_OV_10A(PlaneType):
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             2,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            2,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
-            2,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
         )
 
     # ERRR {MK-81}
@@ -146,7 +83,6 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (3, Weapons.LAU3_HE5)
         LAU3_HE151 = (3, Weapons.LAU3_HE151)
         M260_HYDRA = (3, Weapons.M260_HYDRA)
-        M260_HYDRA_WP = (3, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             3,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -154,62 +90,6 @@ class Bronco_OV_10A(PlaneType):
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             3,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            3,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
-            3,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
         )
 
     class Pylon4:
@@ -219,7 +99,6 @@ class Bronco_OV_10A(PlaneType):
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         M117___750lb_GP_Bomb_LD = (4, Weapons.M117___750lb_GP_Bomb_LD)
-        Mk4_mod_0 = (4, Weapons.Mk4_mod_0)
 
     # ERRR {MK-81}
 
@@ -234,7 +113,6 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (5, Weapons.LAU3_HE5)
         LAU3_HE151 = (5, Weapons.LAU3_HE151)
         M260_HYDRA = (5, Weapons.M260_HYDRA)
-        M260_HYDRA_WP = (5, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             5,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -242,62 +120,6 @@ class Bronco_OV_10A(PlaneType):
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             5,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
-        )
-        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            5,
-            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            5,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            5,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
-            5,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
         )
 
     # ERRR {MK-81}
@@ -313,7 +135,6 @@ class Bronco_OV_10A(PlaneType):
         LAU3_HE5 = (6, Weapons.LAU3_HE5)
         LAU3_HE151 = (6, Weapons.LAU3_HE151)
         M260_HYDRA = (6, Weapons.M260_HYDRA)
-        M260_HYDRA_WP = (6, Weapons.M260_HYDRA_WP)
         LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
             6,
             Weapons.LAU_10R_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
@@ -322,76 +143,15 @@ class Bronco_OV_10A(PlaneType):
             6,
             Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
         )
-        LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            6,
-            Weapons.LAU_61R_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            6,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            6,
-            Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE,
-        )
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
-        )
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
-            6,
-            Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
-        )
 
     class Pylon7:
         LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
             7,
             Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
         )
-        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
-            7,
-            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
-        )
-        LAU_33A = (7, Weapons.LAU_33A)
 
     class Pylon8:
-        OV10_Paratrooper = (8, Weapons.OV10_Paratrooper)
+        ParaTrooper = (8, Weapons.ParaTrooper)
 
     class Pylon9:
         OV10_SMOKE = (9, Weapons.OV10_SMOKE)

--- a/resources/weapons/pods/OH-58D_Brauning.yaml
+++ b/resources/weapons/pods/OH-58D_Brauning.yaml
@@ -1,0 +1,4 @@
+name: Brauning Gun Pod
+fallback: M261 - 19 x UnGd Rkts, 70 mm Hydra 70 M151 HE
+clsids:
+  - "oh-58-brauning"

--- a/resources/weapons/pods/alq-131.yaml
+++ b/resources/weapons/pods/alq-131.yaml
@@ -1,0 +1,6 @@
+name: AN/ALQ-131 ECM
+# Hard to find information on initial iteration - 74 military budget mentions development, FAS.org suggests late 70s, and DCS usage is allowed on or after 1973
+year: 1977
+fallback: 2xAIM-120C
+clsids:
+  - "{6D21ECEA-F85B-4E8D-9D51-31DC9B8AA4EF}"

--- a/resources/weapons/pods/alq-184 Long.yaml
+++ b/resources/weapons/pods/alq-184 Long.yaml
@@ -1,6 +1,6 @@
-name: AN/ALQ-184 ECM
+name: AN/ALQ-184 Long ECM
 # https://www.deagel.com/Protection%20Systems/ANALQ-184/a001666
 year: 1987
-fallback: AN/ALQ-131 ECM
+fallback: AN/ALQ-184 ECM
 clsids:
-  - "ALQ_184"
+  - "ALQ_184_Long"

--- a/resources/weapons/rockets/M260 Mk5 HEAT.yaml
+++ b/resources/weapons/rockets/M260 Mk5 HEAT.yaml
@@ -1,0 +1,4 @@
+name: M260 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT
+fallback: LAU-61 pod - 19 x 2.75\" Hydra, UnGd Rkts M151, HE
+clsids:
+  - "M260_HYDRA"

--- a/resources/weapons/rockets/M261  MK151.yaml
+++ b/resources/weapons/rockets/M261  MK151.yaml
@@ -1,0 +1,4 @@
+name: M261 - 19 x UnGd Rkts, 70 mm Hydra 70 M151 HE
+fallback: M260 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT
+clsids:
+  - "M261_MK151"

--- a/resources/weapons/standoff/AGM-114K-1X.yaml
+++ b/resources/weapons/standoff/AGM-114K-1X.yaml
@@ -1,0 +1,7 @@
+name: AGM-114K * 1
+year: 1993
+fallback: 4 x BGM-71D TOW ATGM
+clsids:
+  - "{M299_1xAGM_114K_OUTBOARD_PORT}"
+  - "{M299_1xAGM_114K_OUTBOARD_STARBOARD}"
+  - "{ee368869-c35a-486a-afe7-284beb7c5d52}"

--- a/resources/weapons/standoff/AGM-114K-2X.yaml
+++ b/resources/weapons/standoff/AGM-114K-2X.yaml
@@ -1,0 +1,6 @@
+name: AGM-114K * 2
+year: 1993
+fallback: 4 x BGM-71D TOW ATGM
+clsids:
+  - "{M299_2xAGM_114K}"
+  - "AGM114x2_OH_58"

--- a/resources/weapons/standoff/AGM-114K-3X.yaml
+++ b/resources/weapons/standoff/AGM-114K-3X.yaml
@@ -1,0 +1,6 @@
+name: AGM-114K * 3
+year: 1993
+fallback: 4 x BGM-71D TOW ATGM
+clsids:
+  - "{M299_3xAGM_114K_OUTBOARD_PORT}"
+  - "{M299_3xAGM_114K_OUTBOARD_STARBOARD}"

--- a/resources/weapons/standoff/AGM-114L-1X.yaml
+++ b/resources/weapons/standoff/AGM-114L-1X.yaml
@@ -1,0 +1,7 @@
+name: AGM-114L * 1
+year: 2000
+fallback: AGM-114K * 1
+clsids:
+  - "{M299_1xAGM_114L_OUTBOARD_PORT}"
+  - "{M299_1xAGM_114L_OUTBOARD_STARBOARD}"
+  - "{AGM_114L}"

--- a/resources/weapons/standoff/AGM-114L-2X.yaml
+++ b/resources/weapons/standoff/AGM-114L-2X.yaml
@@ -1,0 +1,5 @@
+name: AGM-114L * 2
+year: 2000
+fallback: AGM-114K * 2
+clsids:
+  - "{M299_2xAGM_114L}"

--- a/resources/weapons/standoff/AGM-114L-3X.yaml
+++ b/resources/weapons/standoff/AGM-114L-3X.yaml
@@ -1,0 +1,6 @@
+name: AGM-114L * 3
+year: 2000
+fallback: AGM-114K * 3
+clsids:
+  - "{M299_3xAGM_114L_OUTBOARD_PORT}"
+  - "{M299_3xAGM_114L_OUTBOARD_STARBOARD}"

--- a/resources/weapons/standoff/AGM-45A.yaml
+++ b/resources/weapons/standoff/AGM-45A.yaml
@@ -1,4 +1,5 @@
 name: AGM-45A Shrike ARM
 type: ARM
+year: 1965
 clsids:
   - "{AGM_45A}"

--- a/resources/weapons/standoff/AGM-45B.yaml
+++ b/resources/weapons/standoff/AGM-45B.yaml
@@ -1,4 +1,6 @@
 name: AGM-45B Shrike ARM (Imp)
 type: ARM
+year: 1972
+fallback: AGM-45A Shrike ARM
 clsids:
   - "{3E6B632D-65EB-44D2-9501-1C2D04515404}"

--- a/resources/weapons/standoff/BGM-71D-4X.yaml
+++ b/resources/weapons/standoff/BGM-71D-4X.yaml
@@ -1,6 +1,6 @@
 name: 4 x BGM-71D TOW ATGM
 year: 1985
 # BGM-71A IOC in  1970 can be used as a stand-in until earlier variants are added to DCS. BGM-71D true IOC is 1985
-fallback: LAU-61 pod - 19 x 2.75\" Hydra, UnGd Rkts M151, HE
+fallback: Brauning Gun Pod
 clsids:
   - "{3EA17AB0-A805-4D9E-8732-4CE00CB00F17}"


### PR DESCRIPTION
Added or updated weapons files including 

The various Hellfire II iterations - this covers fallbacks to rockets for all 3 Apache variants, the Supercobra, and the Kiowa.  
This also adds the 184 Long and 131 pods. 
Lastly, this adds date and fallback information to the shrikes in advance of the AGM-45B being added to the A-4E mod.