### PR TITLE
Update pydcs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,12 @@ Saves from 7.x are not compatible with 8.0.
 
 ## Features/Improvements
 
+* **[Engine]** Support for DCS 2.8.6.41066.
 * **[UI]** Limited size of overfull airbase display and added scrollbar.
 
 ## Fixes
+
+* **[Mission Generation]** Fix crash during mission generation caused by out of date DCS data for the Gazelle.
 
 # 7.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
-git+https://github.com/pydcs/dcs@e74c3885a55affda09b36907aa7afe5588b0702f#egg=pydcs
+git+https://github.com/pydcs/dcs@55d15b95cbc61655f9bef835ba77947540543a4a#egg=pydcs
 pyinstaller==5.7.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1


### PR DESCRIPTION
Includes the updates needed to fix the Gazelle, and a terrain export for Normandy for the new airfields added in the latest update.

No Sinai support yet.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2984.