### PR TITLE
Make patch coverage task informational.

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,7 +2,7 @@ coverage:
   status:
     patch:
       default:
-        informational: false
+        informational: true
     project:
       default:
         informational: true


### PR DESCRIPTION
Not reasonable to require all PRs to avoid regressing coverage yet...