### PR TITLE
Add Sinai terrain info and beacon exports.

### DIFF
--- a/game/theater/theaterloader.py
+++ b/game/theater/theaterloader.py
@@ -14,6 +14,7 @@ from dcs.terrain import (
     Nevada,
     Normandy,
     PersianGulf,
+    Sinai,
     Syria,
     TheChannel,
 )
@@ -31,6 +32,7 @@ ALL_TERRAINS = [
     MarianaIslands(),
     Nevada(),
     TheChannel(),
+    Sinai(),
     Syria(),
 ]
 

--- a/resources/dcs/beacons/sinai.json
+++ b/resources/dcs/beacons/sinai.json
@@ -1,0 +1,1045 @@
+{
+ "world_0": {
+  "name": "Banias",
+  "callsign": "BAN",
+  "beacon_type": 8,
+  "hertz": 304000,
+  "channel": 0
+ },
+ "world_1": {
+  "name": "QueenAlia",
+  "callsign": "MDB",
+  "beacon_type": 8,
+  "hertz": 399000,
+  "channel": 0
+ },
+ "world_2": {
+  "name": "QueenAlia",
+  "callsign": "QAA",
+  "beacon_type": 3,
+  "hertz": 115200000,
+  "channel": 99
+ },
+ "world_3": {
+  "name": "Damascus",
+  "callsign": "DAM",
+  "beacon_type": 3,
+  "hertz": 116000000,
+  "channel": 107
+ },
+ "world_4": {
+  "name": "Beirut",
+  "callsign": "BOD",
+  "beacon_type": 8,
+  "hertz": 351000,
+  "channel": 0
+ },
+ "world_5": {
+  "name": "Asyut",
+  "callsign": "AST",
+  "beacon_type": 3,
+  "hertz": 117700000,
+  "channel": 124
+ },
+ "world_6": {
+  "name": "Aqaba",
+  "callsign": "AQC",
+  "beacon_type": 8,
+  "hertz": 326000,
+  "channel": 0
+ },
+ "world_7": {
+  "name": "Mezze",
+  "callsign": "MEZ",
+  "beacon_type": 8,
+  "hertz": 358000,
+  "channel": 0
+ },
+ "world_8": {
+  "name": "Kariatain",
+  "callsign": "KTN",
+  "beacon_type": 8,
+  "hertz": 373000,
+  "channel": 0
+ },
+ "world_9": {
+  "name": "BasselAlAssad",
+  "callsign": "LTK",
+  "beacon_type": 3,
+  "hertz": 114800000,
+  "channel": 95
+ },
+ "world_10": {
+  "name": "Taba",
+  "callsign": "TBA",
+  "beacon_type": 3,
+  "hertz": 114500000,
+  "channel": 92
+ },
+ "world_11": {
+  "name": "Nuweibaa",
+  "callsign": "NWB",
+  "beacon_type": 8,
+  "hertz": 288000,
+  "channel": 0
+ },
+ "world_12": {
+  "name": "Jerusalem",
+  "callsign": "IRM",
+  "beacon_type": 8,
+  "hertz": 336000,
+  "channel": 0
+ },
+ "world_13": {
+  "name": "Almaza",
+  "callsign": "A",
+  "beacon_type": 8,
+  "hertz": 490000,
+  "channel": 0
+ },
+ "world_14": {
+  "name": "Amman",
+  "callsign": "AMN",
+  "beacon_type": 3,
+  "hertz": 116300000,
+  "channel": 110
+ },
+ "world_15": {
+  "name": "BenGurion",
+  "callsign": "BGN",
+  "beacon_type": 5,
+  "hertz": 113500000,
+  "channel": 82
+ },
+ "world_16": {
+  "name": "Almaza",
+  "callsign": "MXR",
+  "beacon_type": 4,
+  "hertz": 116300000,
+  "channel": 110
+ },
+ "world_17": {
+  "name": "Ovda",
+  "callsign": "OVD",
+  "beacon_type": 8,
+  "hertz": 353000,
+  "channel": 0
+ },
+ "world_18": {
+  "name": "Haifa",
+  "callsign": "HFA",
+  "beacon_type": 8,
+  "hertz": 323000,
+  "channel": 0
+ },
+ "world_19": {
+  "name": "Aqaba",
+  "callsign": "AQ",
+  "beacon_type": 8,
+  "hertz": 404000,
+  "channel": 0
+ },
+ "world_20": {
+  "name": "Alexandria",
+  "callsign": "AXD",
+  "beacon_type": 8,
+  "hertz": 403000,
+  "channel": 0
+ },
+ "world_21": {
+  "name": "Baltim",
+  "callsign": "BLT",
+  "beacon_type": 3,
+  "hertz": 116900000,
+  "channel": 116
+ },
+ "world_22": {
+  "name": "Turaif",
+  "callsign": "TRF",
+  "beacon_type": 3,
+  "hertz": 116100000,
+  "channel": 108
+ },
+ "world_23": {
+  "name": "Wejh",
+  "callsign": "WEJ",
+  "beacon_type": 5,
+  "hertz": 113900000,
+  "channel": 86
+ },
+ "world_24": {
+  "name": "Metzada",
+  "callsign": "MZD",
+  "beacon_type": 5,
+  "hertz": 115000000,
+  "channel": 97
+ },
+ "world_25": {
+  "name": "RoshPina",
+  "callsign": "RPN",
+  "beacon_type": 8,
+  "hertz": 243000,
+  "channel": 0
+ },
+ "world_26": {
+  "name": "Hurghada",
+  "callsign": "HGD",
+  "beacon_type": 3,
+  "hertz": 116500000,
+  "channel": 112
+ },
+ "world_27": {
+  "name": "Chekka",
+  "callsign": "CAK",
+  "beacon_type": 3,
+  "hertz": 116200000,
+  "channel": 109
+ },
+ "world_28": {
+  "name": "QueenAlia",
+  "callsign": "QA",
+  "beacon_type": 8,
+  "hertz": 410000,
+  "channel": 0
+ },
+ "world_29": {
+  "name": "October",
+  "callsign": "OCT",
+  "beacon_type": 8,
+  "hertz": 340000,
+  "channel": 0
+ },
+ "world_30": {
+  "name": "PortSaid",
+  "callsign": "PSD",
+  "beacon_type": 3,
+  "hertz": 112700000,
+  "channel": 74
+ },
+ "world_31": {
+  "name": "Alexandria",
+  "callsign": "NOZ",
+  "beacon_type": 3,
+  "hertz": 115900000,
+  "channel": 106
+ },
+ "world_32": {
+  "name": "DeirZzor",
+  "callsign": "DRZ",
+  "beacon_type": 8,
+  "hertz": 295000,
+  "channel": 0
+ },
+ "world_33": {
+  "name": "DeirZzor",
+  "callsign": "DRZ",
+  "beacon_type": 3,
+  "hertz": 117000000,
+  "channel": 117
+ },
+ "world_34": {
+  "name": "Cairo",
+  "callsign": "ALI",
+  "beacon_type": 8,
+  "hertz": 310000,
+  "channel": 0
+ },
+ "world_35": {
+  "name": "Al-Shigar",
+  "callsign": "ASH",
+  "beacon_type": 3,
+  "hertz": 112300000,
+  "channel": 70
+ },
+ "world_36": {
+  "name": "Cairo",
+  "callsign": "MKT",
+  "beacon_type": 8,
+  "hertz": 317000,
+  "channel": 0
+ },
+ "world_37": {
+  "name": "MarsaAlam",
+  "callsign": "MAK",
+  "beacon_type": 3,
+  "hertz": 115500000,
+  "channel": 102
+ },
+ "world_38": {
+  "name": "Taba",
+  "callsign": "TBA",
+  "beacon_type": 8,
+  "hertz": 316000,
+  "channel": 0
+ },
+ "world_39": {
+  "name": "Zofar",
+  "callsign": "ZFR",
+  "beacon_type": 3,
+  "hertz": 115600000,
+  "channel": 103
+ },
+ "world_40": {
+  "name": "Natania",
+  "callsign": "NAT",
+  "beacon_type": 5,
+  "hertz": 112400000,
+  "channel": 71
+ },
+ "world_41": {
+  "name": "Kariatain",
+  "callsign": "KTN",
+  "beacon_type": 3,
+  "hertz": 117700000,
+  "channel": 124
+ },
+ "world_42": {
+  "name": "Herzlia",
+  "callsign": "HRZ",
+  "beacon_type": 8,
+  "hertz": 273000,
+  "channel": 0
+ },
+ "world_43": {
+  "name": "Guriat",
+  "callsign": "GRY",
+  "beacon_type": 5,
+  "hertz": 114700000,
+  "channel": 94
+ },
+ "world_44": {
+  "name": "Gaza",
+  "callsign": "GZA",
+  "beacon_type": 3,
+  "hertz": 113350000,
+  "channel": 80
+ },
+ "world_45": {
+  "name": "Cairo",
+  "callsign": "CVO",
+  "beacon_type": 3,
+  "hertz": 115200000,
+  "channel": 99
+ },
+ "world_46": {
+  "name": "ReneMouawad",
+  "callsign": "RA",
+  "beacon_type": 8,
+  "hertz": 450000,
+  "channel": 0
+ },
+ "world_47": {
+  "name": "Amman",
+  "callsign": "JYO",
+  "beacon_type": 8,
+  "hertz": 391000,
+  "channel": 0
+ },
+ "world_48": {
+  "name": "Aqaba",
+  "callsign": "AQA",
+  "beacon_type": 8,
+  "hertz": 418000,
+  "channel": 0
+ },
+ "world_49": {
+  "name": "Cairo",
+  "callsign": "CAI",
+  "beacon_type": 3,
+  "hertz": 112500000,
+  "channel": 72
+ },
+ "world_50": {
+  "name": "BasselAlAssad",
+  "callsign": "LTK",
+  "beacon_type": 8,
+  "hertz": 414000,
+  "channel": 0
+ },
+ "world_51": {
+  "name": "SharmElSheikh",
+  "callsign": "SHM",
+  "beacon_type": 3,
+  "hertz": 114200000,
+  "channel": 89
+ },
+ "world_52": {
+  "name": "QueenAlia(Locator)",
+  "callsign": "QL",
+  "beacon_type": 8,
+  "hertz": 307000,
+  "channel": 0
+ },
+ "world_53": {
+  "name": "Khaldeh",
+  "callsign": "KAD",
+  "beacon_type": 3,
+  "hertz": 112600000,
+  "channel": 73
+ },
+ "world_54": {
+  "name": "ElDaba",
+  "callsign": "DBA",
+  "beacon_type": 3,
+  "hertz": 115700000,
+  "channel": 104
+ },
+ "world_55": {
+  "name": "InnerBeacon",
+  "callsign": "D",
+  "beacon_type": 8,
+  "hertz": 273000,
+  "channel": 0
+ },
+ "world_56": {
+  "name": "CairoWest",
+  "callsign": "BLA",
+  "beacon_type": 4,
+  "hertz": 116700000,
+  "channel": 114
+ },
+ "world_57": {
+  "name": "Gaza",
+  "callsign": "RFH",
+  "beacon_type": 8,
+  "hertz": 380000,
+  "channel": 0
+ },
+ "world_58": {
+  "name": "Palmyra",
+  "callsign": "PAL",
+  "beacon_type": 8,
+  "hertz": 337000,
+  "channel": 0
+ },
+ "world_59": {
+  "name": "ElKharga",
+  "callsign": "KHG",
+  "beacon_type": 3,
+  "hertz": 113800000,
+  "channel": 85
+ },
+ "world_60": {
+  "name": "Halaifa",
+  "callsign": "HLF",
+  "beacon_type": 3,
+  "hertz": 116700000,
+  "channel": 114
+ },
+ "world_61": {
+  "name": "Aqaba",
+  "callsign": "AQB",
+  "beacon_type": 3,
+  "hertz": 113100000,
+  "channel": 78
+ },
+ "world_62": {
+  "name": "Beirut",
+  "callsign": "BAB",
+  "beacon_type": 8,
+  "hertz": 312000,
+  "channel": 0
+ },
+ "world_63": {
+  "name": "SidiBarrani",
+  "callsign": "BRN",
+  "beacon_type": 3,
+  "hertz": 116200000,
+  "channel": 109
+ },
+ "world_64": {
+  "name": "Luxor",
+  "callsign": "LXR",
+  "beacon_type": 3,
+  "hertz": 114400000,
+  "channel": 91
+ },
+ "world_65": {
+  "name": "Luxor",
+  "callsign": "LO",
+  "beacon_type": 8,
+  "hertz": 364000,
+  "channel": 0
+ },
+ "world_66": {
+  "name": "Tabuk",
+  "callsign": "TBK",
+  "beacon_type": 5,
+  "hertz": 115700000,
+  "channel": 104
+ },
+ "world_67": {
+  "name": "Tanf",
+  "callsign": "TAN",
+  "beacon_type": 3,
+  "hertz": 114000000,
+  "channel": 87
+ },
+ "world_68": {
+  "name": "Qatraneh",
+  "callsign": "JYT",
+  "beacon_type": 8,
+  "hertz": 302000,
+  "channel": 0
+ },
+ "world_69": {
+  "name": "BorgElArab",
+  "callsign": "DJ",
+  "beacon_type": 8,
+  "hertz": 563000,
+  "channel": 0
+ },
+ "world_70": {
+  "name": "Abyad",
+  "callsign": "ABD",
+  "beacon_type": 8,
+  "hertz": 264000,
+  "channel": 0
+ },
+ "world_71": {
+  "name": "Otaebe",
+  "callsign": "DAL",
+  "beacon_type": 8,
+  "hertz": 342000,
+  "channel": 0
+ },
+ "world_72": {
+  "name": "Beer-Sheba",
+  "callsign": "BSA",
+  "beacon_type": 5,
+  "hertz": 114300000,
+  "channel": 90
+ },
+ "world_73": {
+  "name": "Dakhla",
+  "callsign": "MB",
+  "beacon_type": 8,
+  "hertz": 387000,
+  "channel": 0
+ },
+ "world_74": {
+  "name": "Eilot",
+  "callsign": "LOT",
+  "beacon_type": 3,
+  "hertz": 112000000,
+  "channel": 57
+ },
+ "world_75": {
+  "name": "SharmElSheikh",
+  "callsign": "SKH",
+  "beacon_type": 8,
+  "hertz": 335000,
+  "channel": 0
+ },
+ "world_76": {
+  "name": "RoshPina",
+  "callsign": "ROP",
+  "beacon_type": 3,
+  "hertz": 115300000,
+  "channel": 100
+ },
+ "world_77": {
+  "name": "Ovda",
+  "callsign": "OVD",
+  "beacon_type": 3,
+  "hertz": 114100000,
+  "channel": 88
+ },
+ "world_78": {
+  "name": "Qatraneh",
+  "callsign": "QTR",
+  "beacon_type": 3,
+  "hertz": 112900000,
+  "channel": 76
+ },
+ "world_79": {
+  "name": "Fayoum",
+  "callsign": "FYM",
+  "beacon_type": 3,
+  "hertz": 117300000,
+  "channel": 120
+ },
+ "airfield2_0": {
+  "name": "",
+  "callsign": "WAYR",
+  "beacon_type": 13,
+  "hertz": 119700000,
+  "channel": null
+ },
+ "airfield2_1": {
+  "name": "",
+  "callsign": "WAYR",
+  "beacon_type": 14,
+  "hertz": 119700000,
+  "channel": null
+ },
+ "airfield2_2": {
+  "name": "AbuSuwayr",
+  "callsign": "ZYT",
+  "beacon_type": 4,
+  "hertz": 109200000,
+  "channel": 29
+ },
+ "airfield4_0": {
+  "name": "Ismailiyah",
+  "callsign": "ISA",
+  "beacon_type": 13,
+  "hertz": 110300000,
+  "channel": null
+ },
+ "airfield4_1": {
+  "name": "Ismailiyah",
+  "callsign": "ISA",
+  "beacon_type": 14,
+  "hertz": 110300000,
+  "channel": null
+ },
+ "airfield14_0": {
+  "name": "AlMansurah",
+  "callsign": "MRN",
+  "beacon_type": 4,
+  "hertz": 111600000,
+  "channel": 53
+ },
+ "airfield3_0": {
+  "name": "AsSalihiyah",
+  "callsign": "SAI",
+  "beacon_type": 13,
+  "hertz": 110700000,
+  "channel": null
+ },
+ "airfield3_1": {
+  "name": "AsSalihiyah",
+  "callsign": "SAI",
+  "beacon_type": 14,
+  "hertz": 110700000,
+  "channel": null
+ },
+ "airfield3_2": {
+  "name": "AsSalihiyah",
+  "callsign": "ASL",
+  "beacon_type": 4,
+  "hertz": 111200000,
+  "channel": 26
+ },
+ "airfield15_0": {
+  "name": "AzZaqaziq",
+  "callsign": "AMB",
+  "beacon_type": 4,
+  "hertz": 114700000,
+  "channel": 94
+ },
+ "airfield24_0": {
+  "name": "BenGurion",
+  "callsign": "BC",
+  "beacon_type": 13,
+  "hertz": 110900000,
+  "channel": null
+ },
+ "airfield24_1": {
+  "name": "BenGurion",
+  "callsign": "BC",
+  "beacon_type": 14,
+  "hertz": 110900000,
+  "channel": null
+ },
+ "airfield24_2": {
+  "name": "BenGurion",
+  "callsign": "BG",
+  "beacon_type": 14,
+  "hertz": 110300000,
+  "channel": null
+ },
+ "airfield24_3": {
+  "name": "BenGurion",
+  "callsign": "BN",
+  "beacon_type": 13,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield24_4": {
+  "name": "BenGurion",
+  "callsign": "BN",
+  "beacon_type": 14,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield24_5": {
+  "name": "BenGurion",
+  "callsign": "BA",
+  "beacon_type": 14,
+  "hertz": 108700000,
+  "channel": null
+ },
+ "airfield24_6": {
+  "name": "BenGurion",
+  "callsign": "BA",
+  "beacon_type": 13,
+  "hertz": 108700000,
+  "channel": null
+ },
+ "airfield24_7": {
+  "name": "BenGurion",
+  "callsign": "BD",
+  "beacon_type": 14,
+  "hertz": 111900000,
+  "channel": null
+ },
+ "airfield24_8": {
+  "name": "BenGurion",
+  "callsign": "BG",
+  "beacon_type": 13,
+  "hertz": 110300000,
+  "channel": null
+ },
+ "airfield24_9": {
+  "name": "BenGurion",
+  "callsign": "BD",
+  "beacon_type": 13,
+  "hertz": 111900000,
+  "channel": null
+ },
+ "airfield16_0": {
+  "name": "BilbeisAirBase",
+  "callsign": "BA",
+  "beacon_type": 14,
+  "hertz": 108600000,
+  "channel": null
+ },
+ "airfield16_1": {
+  "name": "BilbeisAirBase",
+  "callsign": "ARF",
+  "beacon_type": 4,
+  "hertz": 113900000,
+  "channel": 86
+ },
+ "airfield16_2": {
+  "name": "BilbeisAirBase",
+  "callsign": "BA",
+  "beacon_type": 13,
+  "hertz": 108600000,
+  "channel": null
+ },
+ "airfield5_0": {
+  "name": "Melez",
+  "callsign": "MLZ",
+  "beacon_type": 3,
+  "hertz": 110100000,
+  "channel": 38
+ },
+ "airfield17_0": {
+  "name": "CairoInternationalAirport",
+  "callsign": "IZFL",
+  "beacon_type": 14,
+  "hertz": 110900000,
+  "channel": null
+ },
+ "airfield17_1": {
+  "name": "CairoInternationalAirport",
+  "callsign": "IZFCs",
+  "beacon_type": 14,
+  "hertz": 109900000,
+  "channel": null
+ },
+ "airfield17_2": {
+  "name": "CairoInternationalAirport",
+  "callsign": "IZFR",
+  "beacon_type": 14,
+  "hertz": 108900000,
+  "channel": null
+ },
+ "airfield17_3": {
+  "name": "CairoInternationalAirport",
+  "callsign": "IZFR",
+  "beacon_type": 13,
+  "hertz": 108900000,
+  "channel": null
+ },
+ "airfield17_4": {
+  "name": "CairoInternationalAirport",
+  "callsign": "ITTL",
+  "beacon_type": 14,
+  "hertz": 108700000,
+  "channel": null
+ },
+ "airfield17_5": {
+  "name": "CairoInternationalAirport",
+  "callsign": "ITTC",
+  "beacon_type": 14,
+  "hertz": 109500000,
+  "channel": null
+ },
+ "airfield17_6": {
+  "name": "CairoInternationalAirport",
+  "callsign": "ITTR",
+  "beacon_type": 14,
+  "hertz": 110300000,
+  "channel": null
+ },
+ "airfield17_7": {
+  "name": "CairoInternationalAirportd",
+  "callsign": "ITTL",
+  "beacon_type": 13,
+  "hertz": 108700000,
+  "channel": null
+ },
+ "airfield17_8": {
+  "name": "CairoInternationalAirport",
+  "callsign": "ITTC",
+  "beacon_type": 13,
+  "hertz": 109500000,
+  "channel": null
+ },
+ "airfield17_9": {
+  "name": "CairoInternationalAirport",
+  "callsign": "IZFC",
+  "beacon_type": 13,
+  "hertz": 109900000,
+  "channel": null
+ },
+ "airfield17_10": {
+  "name": "CairoInternationalAirport",
+  "callsign": "IZFL",
+  "beacon_type": 13,
+  "hertz": 110900000,
+  "channel": null
+ },
+ "airfield17_11": {
+  "name": "CairoInternationalAirport",
+  "callsign": "ITTR",
+  "beacon_type": 13,
+  "hertz": 110300000,
+  "channel": null
+ },
+ "airfield18_0": {
+  "name": "",
+  "callsign": "SPX",
+  "beacon_type": 5,
+  "hertz": 0,
+  "channel": null
+ },
+ "airfield18_1": {
+  "name": "CairoWest",
+  "callsign": "IPSX",
+  "beacon_type": 14,
+  "hertz": 111500000,
+  "channel": null
+ },
+ "airfield18_2": {
+  "name": "CairoWest",
+  "callsign": "IPSX",
+  "beacon_type": 13,
+  "hertz": 111500000,
+  "channel": null
+ },
+ "airfield29_0": {
+  "name": "ElArish",
+  "callsign": "ARH",
+  "beacon_type": 3,
+  "hertz": 113600000,
+  "channel": 83
+ },
+ "airfield6_0": {
+  "name": "Faid",
+  "callsign": "FAID",
+  "beacon_type": 13,
+  "hertz": 110150000,
+  "channel": 0
+ },
+ "airfield6_1": {
+  "name": "Faid",
+  "callsign": "FAD",
+  "beacon_type": 14,
+  "hertz": 110150000,
+  "channel": 0
+ },
+ "airfield6_2": {
+  "name": "Faid",
+  "callsign": "GIO",
+  "beacon_type": 4,
+  "hertz": 117800000,
+  "channel": 125
+ },
+ "airfield7_0": {
+  "name": "Hatzerim",
+  "callsign": "BRA",
+  "beacon_type": 5,
+  "hertz": 114900000,
+  "channel": 96
+ },
+ "airfield7_1": {
+  "name": "Hatzerim",
+  "callsign": "BRA",
+  "beacon_type": 13,
+  "hertz": 111300000,
+  "channel": null
+ },
+ "airfield7_2": {
+  "name": "Hatzerim",
+  "callsign": "BRA",
+  "beacon_type": 14,
+  "hertz": 111300000,
+  "channel": null
+ },
+ "airfield20_1": {
+  "name": "Hatzor",
+  "callsign": "HZR",
+  "beacon_type": 5,
+  "hertz": 115900000,
+  "channel": 106
+ },
+ "airfield20_2": {
+  "name": "Hatzor",
+  "callsign": "HZR",
+  "beacon_type": 14,
+  "hertz": 108500000,
+  "channel": null
+ },
+ "airfield20_3": {
+  "name": "Hatzor",
+  "callsign": "HZR",
+  "beacon_type": 13,
+  "hertz": 108500000,
+  "channel": null
+ },
+ "airfield19_0": {
+  "name": "InshasAirbase",
+  "callsign": "ISH",
+  "beacon_type": 14,
+  "hertz": 116900000,
+  "channel": null
+ },
+ "airfield19_1": {
+  "name": "InshasAirbase",
+  "callsign": "IHA",
+  "beacon_type": 4,
+  "hertz": 115100000,
+  "channel": 98
+ },
+ "airfield19_2": {
+  "name": "InshasAirbase",
+  "callsign": "ISH",
+  "beacon_type": 13,
+  "hertz": 116900000,
+  "channel": null
+ },
+ "airfield11_0": {
+  "name": "Kibrit",
+  "callsign": "KBR",
+  "beacon_type": 4,
+  "hertz": 113700000,
+  "channel": 55
+ },
+ "airfield8_0": {
+  "name": "Nevatim",
+  "callsign": "NEV",
+  "beacon_type": 13,
+  "hertz": 108300000,
+  "channel": null
+ },
+ "airfield8_1": {
+  "name": "Nevatim",
+  "callsign": "NEV",
+  "beacon_type": 14,
+  "hertz": 108300000,
+  "channel": null
+ },
+ "airfield8_2": {
+  "name": "Nevatim",
+  "callsign": "NGV",
+  "beacon_type": 14,
+  "hertz": 111500000,
+  "channel": null
+ },
+ "airfield8_3": {
+  "name": "Nevatim",
+  "callsign": "NGV",
+  "beacon_type": 13,
+  "hertz": 111500000,
+  "channel": null
+ },
+ "airfield10_0": {
+  "name": "Ovda",
+  "callsign": "VA",
+  "beacon_type": 14,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield10_1": {
+  "name": "Ovda",
+  "callsign": "OVD",
+  "beacon_type": 4,
+  "hertz": 133600000,
+  "channel": 63
+ },
+ "airfield10_2": {
+  "name": "Ovda",
+  "callsign": "VA",
+  "beacon_type": 13,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield9_0": {
+  "name": "Ramon",
+  "callsign": "RMN",
+  "beacon_type": 13,
+  "hertz": 110700000,
+  "channel": null
+ },
+ "airfield9_1": {
+  "name": "Ramon",
+  "callsign": "RMN",
+  "beacon_type": 14,
+  "hertz": 110700000,
+  "channel": null
+ },
+ "airfield9_2": {
+  "name": "Ramon",
+  "callsign": "RMN",
+  "beacon_type": 5,
+  "hertz": 115800000,
+  "channel": 105
+ },
+ "airfield23_0": {
+  "name": "TelNof",
+  "callsign": "AKR",
+  "beacon_type": 4,
+  "hertz": 113700000,
+  "channel": 87
+ },
+ "airfield23_1": {
+  "name": "TelNof",
+  "callsign": "AKR",
+  "beacon_type": 13,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield23_2": {
+  "name": "TelNof",
+  "callsign": "AKR",
+  "beacon_type": 13,
+  "hertz": 109100000,
+  "channel": null
+ },
+ "airfield13_0": {
+  "name": "WadiAlJandali",
+  "callsign": "ICTM",
+  "beacon_type": 13,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield13_1": {
+  "name": "WadiAlJandali",
+  "callsign": "IKTM",
+  "beacon_type": 14,
+  "hertz": 109700000,
+  "channel": null
+ },
+ "airfield13_2": {
+  "name": "WadialJandali",
+  "callsign": "WAJ",
+  "beacon_type": 4,
+  "hertz": 114900000,
+  "channel": 96
+ }
+}

--- a/resources/theaters/sinai/info.yaml
+++ b/resources/theaters/sinai/info.yaml
@@ -1,0 +1,44 @@
+---
+name: Sinai
+timezone: +3 # TODO
+daytime:
+  dawn: [6, 8]
+  day: [8, 16]
+  dusk: [16, 18]
+  night: [0, 5]
+climate:
+  day_night_temperature_difference: 8.0
+  seasons:
+    winter:
+      average_pressure: 29.86 # TODO: Find real-world data
+      average_temperature: 10.0
+      weather:
+        thunderstorm: 1
+        raining: 25
+        cloudy: 35
+        clear: 40
+    spring:
+      weather:
+        thunderstorm: 1
+        raining: 10
+        cloudy: 30
+        clear: 60
+    summer:
+      average_pressure: 29.98 # TODO: Find real-world data
+      average_temperature: 28.5
+      weather:
+        thunderstorm: 1
+        raining: 5
+        cloudy: 30
+        clear: 65
+    fall:
+      weather:
+        thunderstorm: 1
+        raining: 15
+        cloudy: 35
+        clear: 50
+  turbulence:
+    high_avg_yearly_turbulence_per_10cm: 9
+    low_avg_yearly_turbulence_per_10cm: 3.5
+    solar_noon_turbulence_per_10cm: 3.5
+    midnight_turbulence_per_10cm: -3


### PR DESCRIPTION
Not usable for play, but useable enough for campaign authors to try the basics (no landmap, so frontlines will happily go right into the sea).