### PR TITLE
Allow NGW to be called from anywhere.

### DIFF
--- a/qt_ui/windows/GameUpdateSignal.py
+++ b/qt_ui/windows/GameUpdateSignal.py
@@ -16,6 +16,7 @@ class GameUpdateSignal(QObject):
     debriefingReceived = Signal(Debriefing)
 
     game_loaded = Signal(Game)
+    game_generated = Signal(Game)
 
     def __init__(self):
         super(GameUpdateSignal, self).__init__()

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -152,6 +152,7 @@ class QLiberationWindow(QMainWindow):
     def connectSignals(self):
         GameUpdateSignal.get_instance().gameupdated.connect(self.setGame)
         GameUpdateSignal.get_instance().debriefingReceived.connect(self.onDebriefing)
+        GameUpdateSignal.get_instance().game_generated.connect(self.onGameGenerated)
 
     def initActions(self):
         self.newGameAction = QAction("&New Game", self)
@@ -332,7 +333,6 @@ class QLiberationWindow(QMainWindow):
     def newGame(self):
         wizard = NewGameWizard(self)
         wizard.show()
-        wizard.accepted.connect(lambda: self.onGameGenerated(wizard.generatedGame))
 
     def openFile(self):
         if (

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -28,6 +28,7 @@ from game.theater.start_generator import GameGenerator, GeneratorSettings, ModSe
 from qt_ui.widgets.QLiberationCalendar import QLiberationCalendar
 from qt_ui.widgets.spinsliders import CurrencySpinner, FloatSpinSlider, TimeInputs
 from qt_ui.windows.AirWingConfigurationDialog import AirWingConfigurationDialog
+from qt_ui.windows.GameUpdateSignal import GameUpdateSignal
 from qt_ui.windows.newgame.QCampaignList import QCampaignList
 
 jinja_env = Environment(
@@ -139,7 +140,6 @@ class NewGameWizard(QtWidgets.QWizard):
         self.setWizardStyle(QtWidgets.QWizard.ModernStyle)
 
         self.setWindowTitle("New Game")
-        self.generatedGame = None
 
     def accept(self):
         logging.info("New Game Wizard accept")
@@ -228,16 +228,14 @@ class NewGameWizard(QtWidgets.QWizard):
             mod_settings,
             self.lua_plugin_manager,
         )
-        self.generatedGame = generator.generate()
+        game = generator.generate()
 
-        if (
-            AirWingConfigurationDialog(self.generatedGame, self).exec()
-            == QDialog.DialogCode.Rejected
-        ):
+        if AirWingConfigurationDialog(game, self).exec() == QDialog.DialogCode.Rejected:
             logging.info("Aborted air wing configuration")
             return
 
-        self.generatedGame.begin_turn_0(squadrons_start_full=use_new_squadron_rules)
+        game.begin_turn_0(squadrons_start_full=use_new_squadron_rules)
+        GameUpdateSignal.get_instance().game_generated.emit(game)
 
         super(NewGameWizard, self).accept()
 


### PR DESCRIPTION
Any real end game dialog needs a "new game" button. If only the main window can usefully call the NGW we'd have to plumb that object through and call into it from that dialog, which is gross. Just make it easier to call the wizard.

https://github.com/dcs-liberation/dcs_liberation/issues/978