### PR TITLE
Add Chengdu J-7B to Egypt_2000

### DIFF
--- a/resources/factions/egypt_2000.yaml
+++ b/resources/factions/egypt_2000.yaml
@@ -7,6 +7,7 @@ locales:
   - ar_SA
 aircrafts:
   - MiG-29S Fulcrum-C
+  - J-7B
   - Mirage 2000C
   - F-16CM Fighting Falcon (Block 50)
   - IL-76MD


### PR DESCRIPTION
Adding the Chengdu J-7B to Egypt 2000 as it is still in service.