### PR TITLE
Add S-300 SAM to Egypt 2000

### DIFF
--- a/resources/factions/egypt_2000.yaml
+++ b/resources/factions/egypt_2000.yaml
@@ -57,6 +57,7 @@ preset_groups:
   - SA-2/S-75
   - SA-6
   - SA-17
+  - SA-10/S-300PS
   - SA-23/S-300VM
   - Patriot
   - Hawk


### PR DESCRIPTION
Adds S-300 as an alternative to Egypt's S-300VM for those who are not using the High Digits SAM mod.