### PR TITLE
Updated F-15E Suite 4+ loadouts as the AI cannot currently use GBUs

### DIFF
--- a/resources/customized_payloads/F-15ESE.lua
+++ b/resources/customized_payloads/F-15ESE.lua
@@ -2,7 +2,8 @@ local unitPayloads = {
 	["name"] = "F-15ESE",
 	["payloads"] = {
 		[1] = {
-			["name"] = "Liberation BAI",
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
@@ -13,40 +14,45 @@ local unitPayloads = {
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[4] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
-				},
-				[5] = {
 					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
 					["num"] = 13,
 				},
-				[6] = {
+				[4] = {
 					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
 					["num"] = 3,
 				},
-				[7] = {
-					["CLSID"] = "{CFT_R_GBU_12_x_4}",
+				[5] = {
+					["CLSID"] = "{CFT_R_MK84LD_x_2}",
 					["num"] = 12,
 				},
-				[8] = {
+				[6] = {
 					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
 					["num"] = 9,
 				},
-				[9] = {
-					["CLSID"] = "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}",
+				[7] = {
+					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
 					["num"] = 8,
+					["settings"] = {
+						["GUI_fuze_type"] = 1,
+						["arm_delay_ctrl_FMU139CB_LD"] = 1,
+						["function_delay_ctrl_FMU139CB_LD"] = 0,
+					},
 				},
-				[10] = {
+				[8] = {
 					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
 					["num"] = 7,
 				},
-				[11] = {
-					["CLSID"] = "{CFT_L_GBU_12_x_4}",
+				[9] = {
+					["CLSID"] = "{CFT_L_MK84LD_x_2}",
 					["num"] = 4,
+				},
+				[10] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 14,
+				},
+				[11] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
@@ -54,6 +60,50 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[6] = {
+					["CLSID"] = "{CFT_L_CBU_97_x_6}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{CFT_R_CBU_97_x_6}",
+					["num"] = 12,
+				},
+				[8] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[3] = {
 			["name"] = "Liberation BARCAP",
 			["pylons"] = {
 				[1] = {
@@ -81,68 +131,7 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 8,
-				},
-				[8] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 6,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
-				},
-				[12] = {
 					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[13] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[3] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
-				},
-				[2] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
-				},
-				[3] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[4] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 11,
-				},
-				[5] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 10,
-				},
-				[6] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
 					["num"] = 8,
 				},
 				[8] = {
@@ -203,7 +192,7 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[7] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "{F15E_EXTTANK}",
 					["num"] = 8,
 				},
 				[8] = {
@@ -236,157 +225,6 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["displayName"] = "Liberation Fighter Sweep",
-			["name"] = "Liberation Fighter Sweep",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
-				},
-				[2] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
-				},
-				[3] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[4] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 11,
-				},
-				[5] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 10,
-				},
-				[6] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 8,
-				},
-				[8] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 6,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
-				},
-				[12] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[13] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[6] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[4] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
-				},
-				[5] = {
-					["CLSID"] = "{CFT_R_CBU_100_x_6}",
-					["num"] = 12,
-				},
-				[6] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[7] = {
-					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
-					["num"] = 8,
-				},
-				[8] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[9] = {
-					["CLSID"] = "{CFT_L_CBU_100_x_6}",
-					["num"] = 4,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[7] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[4] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
-				},
-				[5] = {
-					["CLSID"] = "{CFT_R_GBU_10_x_2}",
-					["num"] = 12,
-				},
-				[6] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[7] = {
-					["CLSID"] = "{51F9AAE5-964F-4D21-83FB-502E3BFE5F8A}",
-					["num"] = 8,
-				},
-				[8] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[9] = {
-					["CLSID"] = "{CFT_L_GBU_10_x_2}",
-					["num"] = 4,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[8] = {
 			["displayName"] = "Liberation OCA/Runway",
 			["name"] = "Liberation OCA/Runway",
 			["pylons"] = {
@@ -407,7 +245,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[5] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["CLSID"] = "{CFT_R_MK84LD_x_2}",
 					["num"] = 12,
 				},
 				[6] = {
@@ -415,23 +253,36 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[7] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
 					["num"] = 8,
+					["settings"] = {
+						["GUI_fuze_type"] = 1,
+						["arm_delay_ctrl_FMU139CB_LD"] = 1,
+						["function_delay_ctrl_FMU139CB_LD"] = 0,
+					},
 				},
 				[8] = {
 					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
 					["num"] = 7,
 				},
 				[9] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["CLSID"] = "{CFT_L_MK84LD_x_2}",
 					["num"] = 4,
+				},
+				[10] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 14,
+				},
+				[11] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
 				[1] = 32,
 			},
 		},
-		[9] = {
+		[6] = {
 			["displayName"] = "Liberation OCA/Aircraft",
 			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
@@ -476,14 +327,189 @@ local unitPayloads = {
 					["CLSID"] = "{CFT_L_MK82LD_x_6}",
 					["num"] = 4,
 				},
+				[10] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 14,
+				},
+				[11] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation Fighter Sweep",
+			["name"] = "Liberation Fighter Sweep",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+				[2] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 14,
+				},
+				[3] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[4] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 11,
+				},
+				[5] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 10,
+				},
+				[6] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[7] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[8] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[12] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 2,
+				},
+				[13] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[8] = {
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[4] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{CFT_L_CBU_97_x_6}",
+					["num"] = 4,
+				},
+				[9] = {
+					["CLSID"] = "{CFT_R_CBU_97_x_6}",
+					["num"] = 12,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[9] = {
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+				[2] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 14,
+				},
+				[3] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[4] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 11,
+				},
+				[5] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 10,
+				},
+				[6] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[7] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[8] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[12] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 2,
+				},
+				[13] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
 			},
 			["tasks"] = {
 				[1] = 32,
 			},
 		},
 		[10] = {
-			["displayName"] = "Liberation DEAD",
-			["name"] = "Liberation DEAD",
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
@@ -510,7 +536,7 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[7] = {
-					["CLSID"] = "{5335D97A-35A5-4643-9D9B-026C75961E52}",
+					["CLSID"] = "{F15E_EXTTANK}",
 					["num"] = 8,
 				},
 				[8] = {


### PR DESCRIPTION
A2G loadouts for anti-unit have been switched to CBU-97s, which appear to be the most effective weapon type.
A2G loadouts against static targets (OCA/aircraft, OCA/runway, strike) have been change to Mk82s and Mk84s.