### PR TITLE
Undo addition of "(AI)" F-15E variant.

### DIFF
--- a/resources/factions/NATO_Desert_Storm.yaml
+++ b/resources/factions/NATO_Desert_Storm.yaml
@@ -17,7 +17,7 @@ aircrafts:
   - F-14A Tomcat (Block 135-GR Late)
   - F-14B Tomcat
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F-4E Phantom II

--- a/resources/factions/NATO_OIF.yaml
+++ b/resources/factions/NATO_OIF.yaml
@@ -18,7 +18,7 @@ aircrafts:
   - F-14A Tomcat (Block 135-GR Late)
   - F-14B Tomcat
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F-22A Raptor

--- a/resources/factions/bluefor_modern.yaml
+++ b/resources/factions/bluefor_modern.yaml
@@ -23,7 +23,7 @@ aircrafts:
   - F-117A Nighthawk
   - F-14B Tomcat
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F-22A Raptor

--- a/resources/factions/israel_2000.yaml
+++ b/resources/factions/israel_2000.yaml
@@ -12,7 +12,7 @@ aircrafts:
   - C-130
   - C-130J-30 Super Hercules
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F-4E Phantom II

--- a/resources/factions/israel_2012.yaml
+++ b/resources/factions/israel_2012.yaml
@@ -12,7 +12,7 @@ aircrafts:
   - C-130
   - C-130J-30 Super Hercules
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F/A-18C Hornet (Lot 20)

--- a/resources/factions/us_aggressors.yaml
+++ b/resources/factions/us_aggressors.yaml
@@ -19,7 +19,7 @@ aircrafts:
   - F-117A Nighthawk
   - F-14B Tomcat
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F/A-18C Hornet (Lot 20)

--- a/resources/factions/usa_1990.yaml
+++ b/resources/factions/usa_1990.yaml
@@ -19,7 +19,7 @@ aircrafts:
   - F-14A Tomcat (Block 135-GR Late)
   - F-14B Tomcat
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F/A-18C Hornet (Lot 20)

--- a/resources/factions/usa_2005.yaml
+++ b/resources/factions/usa_2005.yaml
@@ -21,7 +21,7 @@ aircrafts:
   - F-117A Nighthawk
   - F-14B Tomcat
   - F-15C Eagle
-  - F-15E Strike Eagle (AI)
+  - F-15E Strike Eagle
   - F-15E Strike Eagle (Suite 4+)
   - F-16CM Fighting Falcon (Block 50)
   - F-22A Raptor

--- a/resources/units/aircraft/F-15E.yaml
+++ b/resources/units/aircraft/F-15E.yaml
@@ -11,7 +11,6 @@ role: Multirole Strike Fighter
 max_range: 300
 variants:
   F-15E Strike Eagle: {}
-  F-15E Strike Eagle (AI): {}
 tasks:
   BAI: 760
   BARCAP: 240


### PR DESCRIPTION
This interacts badly with the built-in squadrons:
https://github.com/dcs-liberation/dcs_liberation/issues/3033. Better to split the display name and "ID" (which is effectively how the key here is treated), but that's a more invasive change than I'd like to tackle in this release.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3033.