### PR TITLE
Fix UI waypoint numbering.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@ Saves from 8.0.0 are compatible with 8.1.0
 
 ## Fixes
 
+* **[UI]** Fixed numbering of waypoints in the map and flight dialog (first waypoint is now 0 rather than 1).
+
 # 8.0.0
 
 Saves from 7.x are not compatible with 8.0.

--- a/game/server/waypoints/routes.py
+++ b/game/server/waypoints/routes.py
@@ -6,30 +6,16 @@ from starlette.responses import Response
 
 from game import Game
 from game.ato import Flight
-from game.ato.flightwaypoint import FlightWaypoint
-from game.ato.flightwaypointtype import FlightWaypointType
 from game.server import GameContext
 from game.server.leaflet import LeafletPoint
 from game.server.waypoints.models import FlightWaypointJs
 from game.sim import GameUpdateEvents
-from game.utils import meters
 
 router: APIRouter = APIRouter(prefix="/waypoints")
 
 
 def waypoints_for_flight(flight: Flight) -> list[FlightWaypointJs]:
-    departure = FlightWaypointJs.for_waypoint(
-        FlightWaypoint(
-            "TAKEOFF",
-            FlightWaypointType.TAKEOFF,
-            flight.departure.position,
-            meters(0),
-            "RADIO",
-        ),
-        flight,
-        0,
-    )
-    return [departure] + [
+    return [
         FlightWaypointJs.for_waypoint(w, flight, i)
         for i, w in enumerate(flight.flight_plan.waypoints, 1)
     ]

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
@@ -64,7 +64,23 @@ class QFlightWaypointList(QTableView):
             self.model.setHorizontalHeaderLabels(HEADER_LABELS)
 
             waypoints = self.flight.flight_plan.waypoints
-            for row, waypoint in enumerate(waypoints):
+            # Why [1:]? Qt starts indexing at 1 rather than 0, whereas DCS numbers
+            # waypoints starting with 0, and for whatever reason Qt crashes whenever I
+            # set the vertical labels manually.
+            #
+            # Starting with the second waypoint is a bit of a hack, but it's also the
+            # historical behavior anyway. This view used to have waypoints starting at 1
+            # and just didn't show the departure waypoint because the departure waypoint
+            # wasn't actually part of the flight plan tracked by Liberation. That
+            # changed at some point, so now we need to skip it manually to preserve that
+            # behavior.
+            #
+            # It really ought to show the departure waypoint and start indexing at 0,
+            # but since this all pending a move to React anyway, it's not worth fighting
+            # the Qt crashes for now.
+            #
+            # https://github.com/dcs-liberation/dcs_liberation/issues/3037
+            for row, waypoint in enumerate(waypoints[1:]):
                 self._add_waypoint_row(row, self.flight, waypoint)
             self.selectionModel().setCurrentIndex(
                 self.model.index(current_index, 0), QItemSelectionModel.Select


### PR DESCRIPTION
The flight plan used to not include a waypoint for departure, so a few places would create one for the sake of the UI, or were built to assume there was a missing waypoint that was okay to ignore. At some point we added them to the flight plan, but never updated the UI, so the waypoint list in the flight dialog started counting from 1 instead of 0, and the openapi endpoint wrongly reported two departure waypoints to the front- end.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3037.