### PR TITLE
Move WW2 factions to WW2 transports.

### DIFF
--- a/resources/factions/allies_1940.yaml
+++ b/resources/factions/allies_1940.yaml
@@ -38,3 +38,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II

--- a/resources/factions/allies_1944.yaml
+++ b/resources/factions/allies_1944.yaml
@@ -51,3 +51,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II

--- a/resources/factions/dprk_1950_fictional.yaml
+++ b/resources/factions/dprk_1950_fictional.yaml
@@ -3,8 +3,8 @@ country: North Korea
 name: North Korea 1950, fictional
 authors: BenBenBeartrax
 description:
-  <p>Fictional DPRK (North Korea) army around 1955, during the Korean War,
-  with some WW2 planes added in place of their post-war counterparts.</p>
+  <p>Fictional DPRK (North Korea) army around 1955, during the Korean War, with
+  some WW2 planes added in place of their post-war counterparts.</p>
 aircrafts:
   - "Bf 109 K-4 Kurf\xFCrst"
   - Fw 190 A-8 Anton
@@ -40,3 +40,4 @@ requirements:
 carrier_names: []
 has_jtac: false
 doctrine: ww2
+cargo_ship: LST Mk.II

--- a/resources/factions/germany_1940.yaml
+++ b/resources/factions/germany_1940.yaml
@@ -3,8 +3,8 @@ country: Third Reich
 name: Germany 1940
 authors: Khopa
 description:
-  <p>Germany 1940, Early german faction for Battle of France, or Battle
-  of England.</p>
+  <p>Germany 1940, Early german faction for Battle of France, or Battle of
+  England.</p>
 locales:
   - de_DE
 aircrafts:
@@ -37,3 +37,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2germany
+cargo_ship: LST Mk.II

--- a/resources/factions/germany_1942.yaml
+++ b/resources/factions/germany_1942.yaml
@@ -3,8 +3,8 @@ country: Third Reich
 name: Germany 1942
 authors: Khopa
 description:
-  <p>Germany 1942, is a faction that does not use the late war german units
-  such as the Tiger tank, so it's a bit easier to perform CAS against them.</p>
+  <p>Germany 1942, is a faction that does not use the late war german units such
+  as the Tiger tank, so it's a bit easier to perform CAS against them.</p>
 locales:
   - de_DE
 aircrafts:
@@ -40,3 +40,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2germany
+cargo_ship: LST Mk.II

--- a/resources/factions/germany_1944.yaml
+++ b/resources/factions/germany_1944.yaml
@@ -3,8 +3,8 @@ country: Third Reich
 name: Germany 1944
 authors: Khopa
 description:
-  <p>Late war Germany with access to all the late-war ground units such
-  as the Tiger and Tiger II tanks.</p>
+  <p>Late war Germany with access to all the late-war ground units such as the
+  Tiger and Tiger II tanks.</p>
 locales:
   - de_DE
 aircrafts:
@@ -50,3 +50,4 @@ missiles:
 has_jtac: false
 doctrine: ww2
 building_set: ww2germany
+cargo_ship: LST Mk.II

--- a/resources/factions/israel_1948.yaml
+++ b/resources/factions/israel_1948.yaml
@@ -35,3 +35,4 @@ carrier_names: []
 helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
+cargo_ship: LST Mk.II

--- a/resources/factions/japan_1944.yaml
+++ b/resources/factions/japan_1944.yaml
@@ -29,6 +29,7 @@ missiles: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2free
+cargo_ship: LST Mk.II
 liveries_overrides:
   Fw 190 A-8 Anton:
     - Fictional IJN 256th Kokutai Rai-153

--- a/resources/factions/soviet_union_1943.yaml
+++ b/resources/factions/soviet_union_1943.yaml
@@ -3,8 +3,8 @@ country: USSR
 name: Soviet Union 1943
 authors: Khopa
 description:
-  <p>Soviet Union in 1943. Featuring the I16, and using some allies units
-  to represent either lend leased vehicles or soviet equivalent vehicles. BM-21 is
+  <p>Soviet Union in 1943. Featuring the I16, and using some allies units to
+  represent either lend leased vehicles or soviet equivalent vehicles. BM-21 is
   used to represent BM-13</p>
 locales:
   - ru_RU
@@ -37,3 +37,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II

--- a/resources/factions/syria_1948.yaml
+++ b/resources/factions/syria_1948.yaml
@@ -29,3 +29,4 @@ carrier_names: []
 requirements:
   WW2 Asset Pack: https://www.digitalcombatsimulator.com/en/products/other/wwii_assets_pack/
 doctrine: ww2
+cargo_ship: LST Mk.II

--- a/resources/factions/uk_1944.yaml
+++ b/resources/factions/uk_1944.yaml
@@ -46,3 +46,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II

--- a/resources/factions/unc_1950_fictional.yaml
+++ b/resources/factions/unc_1950_fictional.yaml
@@ -3,8 +3,8 @@ country: USA
 name: United Nations Command 1950, fictional
 authors: BenBenBeartrax
 description:
-  <p>Fictional United Nations Command around 1955 during the Korean War,
-  with some WW2 planes added in place of their post-war counterparts.</p>
+  <p>Fictional United Nations Command around 1955 during the Korean War, with
+  some WW2 planes added in place of their post-war counterparts.</p>
 aircrafts:
   - A-20G Havoc
   - B-17G Flying Fortress
@@ -34,5 +34,6 @@ naval_units: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II
 requirements:
   WW2 Asset Pack: https://www.digitalcombatsimulator.com/en/products/other/wwii_assets_pack/

--- a/resources/factions/usa_1944.yaml
+++ b/resources/factions/usa_1944.yaml
@@ -42,3 +42,4 @@ helicopter_carrier_names: []
 has_jtac: false
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II

--- a/resources/factions/usa_1955.yaml
+++ b/resources/factions/usa_1955.yaml
@@ -30,5 +30,6 @@ preset_groups:
 naval_units: []
 doctrine: ww2
 building_set: ww2ally
+cargo_ship: LST Mk.II
 requirements:
   WW2 Asset Pack: https://www.digitalcombatsimulator.com/en/products/other/wwii_assets_pack/


### PR DESCRIPTION
Only for those that require the WW2 asset pack. There don't appear to be any free WW2 transports.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3039.