### PR TITLE
Make loadout/properties tab scrollable.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Saves from 8.0.0 are compatible with 8.1.0
 ## Features/Improvements
 
 * **[Engine]** Support for DCS 2.8.6.41363, including F-15E support.
+* **[UI]** Flight loadout/properties tab is now scrollable.
 
 ## Fixes
 

--- a/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
+++ b/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
@@ -4,6 +4,8 @@ from PySide6.QtWidgets import (
     QFrame,
     QLabel,
     QVBoxLayout,
+    QScrollArea,
+    QWidget,
 )
 
 from game import Game
@@ -35,6 +37,16 @@ class QFlightPayloadTab(QFrame):
 
         layout = QVBoxLayout()
 
+        scroll_content = QWidget()
+        scrolling_layout = QVBoxLayout()
+        scroll_content.setLayout(scrolling_layout)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(scroll_content)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        layout.addWidget(scroll)
+
         # Docs Link
         docsText = QLabel(
             '<a href="https://github.com/dcs-liberation/dcs_liberation/wiki/Custom-Loadouts"><span style="color:#FFFFFF;">How to create your own default loadout</span></a>'
@@ -42,12 +54,12 @@ class QFlightPayloadTab(QFrame):
         docsText.setAlignment(Qt.AlignCenter)
         docsText.setOpenExternalLinks(True)
 
-        layout.addLayout(PropertyEditor(self.flight))
+        scrolling_layout.addLayout(PropertyEditor(self.flight))
         self.loadout_selector = DcsLoadoutSelector(flight)
         self.loadout_selector.currentIndexChanged.connect(self.on_new_loadout)
-        layout.addWidget(self.loadout_selector)
-        layout.addWidget(self.payload_editor)
-        layout.addWidget(docsText)
+        scrolling_layout.addWidget(self.loadout_selector)
+        scrolling_layout.addWidget(self.payload_editor)
+        scrolling_layout.addWidget(docsText)
 
         self.setLayout(layout)
 


### PR DESCRIPTION
Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3044.

(cherry picked from commit d54d90659340c9c2607612e8ed65a770e1996b05)