### PR TITLE
Fix waypoint drag and drop.

### DIFF
--- a/game/server/waypoints/routes.py
+++ b/game/server/waypoints/routes.py
@@ -50,7 +50,7 @@ def set_position(
     if waypoint_idx == 0:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
-    waypoint = flight.flight_plan.waypoints[waypoint_idx - 1]
+    waypoint = flight.flight_plan.waypoints[waypoint_idx]
     waypoint.position = Point.from_latlng(
         LatLng(position.lat, position.lng), game.theater.terrain
     )


### PR DESCRIPTION
The fix for https://github.com/dcs-liberation/dcs_liberation/issues/3037 wasn't complete. It seems this `- 1` was here to work around the UI wrongly having two takeoff points... Now that we fixed that, this also needs to go.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3059.