### PR TITLE
Always initialize IADS coalition lua tables.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Saves from 8.x are not compatible with 9.0.0.
 
 * **[Data]** Fixed the class of the Samuel Chase so it can't be picked for a AAA or SHORAD site.
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
+* **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.
 
 # 8.1.0
 

--- a/game/missiongenerator/luagenerator.py
+++ b/game/missiongenerator/luagenerator.py
@@ -188,6 +188,11 @@ class LuaGenerator:
 
         # Generate IADS Lua Item
         iads_object = lua_data.add_item("IADS")
+        # These should always be created even if they are empty.
+        iads_object.get_or_create_item("BLUE")
+        iads_object.get_or_create_item("RED")
+        # Should probably do the same with all the roles... but the script is already
+        # tolerant of those being empty.
         for node in self.game.theater.iads_network.skynet_nodes(self.game):
             coalition = iads_object.get_or_create_item("BLUE" if node.player else "RED")
             iads_type = coalition.get_or_create_item(node.iads_role.value)


### PR DESCRIPTION
These are read unconditionally, but were only initialized when the coalition had nodes. When a coalition had no nodes, this caused a nil access. It's unclear if that had any symptoms, but I expect at the very least it would break the remainder of the script (so a non-functioning blue IADS if the red IADS had no nodes).

There's a very small chance this is the culprit behind https://github.com/dcs-liberation/dcs_liberation/issues/3073.