### PR TITLE
address issue 3072 by allowing ch47d, ch53e and uh60a to operate from…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Saves from 8.x are not compatible with 9.0.0.
 ## Fixes
 
 * **[Data]** Fixed the class of the Samuel Chase so it can't be picked for a AAA or SHORAD site.
+* **[Data]** Allow CH-47D, CH-53E and UH-60A to operate from carriers and LHAs.
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.
 

--- a/resources/units/aircraft/CH-47D.yaml
+++ b/resources/units/aircraft/CH-47D.yaml
@@ -1,4 +1,6 @@
 class: Helicopter
+carrier_capable: true
+lha_capable: true
 cabin_size: 24 # It should have 33 but we do not want so much for CTLD to be possible
 can_carry_crates: true
 description: The CH-47D is a transport helicopter.

--- a/resources/units/aircraft/CH-53E.yaml
+++ b/resources/units/aircraft/CH-53E.yaml
@@ -1,4 +1,6 @@
 class: Helicopter
+carrier_capable: true
+lha_capable: true
 cabin_size: 24 # It should have 37 but we do not want so much for CTLD to be possible
 can_carry_crates: true
 description: The CH-53 is a military transport helicopter.

--- a/resources/units/aircraft/UH-60A.yaml
+++ b/resources/units/aircraft/UH-60A.yaml
@@ -1,4 +1,6 @@
 class: Helicopter
+carrier_capable: true
+lha_capable: true
 price: 4
 cabin_size: 10
 can_carry_crates: true


### PR DESCRIPTION
… carriers and lhas

This PR addresses #3072 by updating the data for CH47D, CH53E and UH60A to allow them to operate from carriers and LHAs.

This PR was tested by:
- Creating a new campaign 
- Confirming that NGW Squadron setup allows the above aircraft types to be based off a CVN and LHA
- Generating a mission and running to ensure that aircraft take off successfully in an air assault mission.
