### PR TITLE
Issue 1491

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Data]** Allow CH-47D, CH-53E and UH-60A to operate from carriers and LHAs.
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
 * **[Mission Generation]** Fix generation of OCA Runway missions to allow LGBs to be used.
+* **[New Game Wizard]** Factions are reset to default after clicking "Back" to Theater Configuration screen.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.
 * **[UI]** Fixed deleting waypoints in custom flight plans deleting the wrong waypoint.
 * **[UI]** Fixed flight properties UI to support F-15E S4+ laser codes.

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -518,7 +518,6 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
                 self.advanced_iads.setToolTip("Enable Advanced IADS")
 
             self.campaign_selected.emit(campaign)
-            self.completeChanged.emit()
 
         self.campaignList.selectionModel().setCurrentIndex(
             self.campaignList.indexAt(QPoint(1, 1)), QItemSelectionModel.Rows

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -361,6 +361,10 @@ class FactionSelection(QtWidgets.QWizardPage):
 
         self.updateUnitRecap()
 
+    def cleanupPage(self):
+        """When clicking Back button, reset factions to campaign defaults"""
+        self.setDefaultFactions(self.field("selectedCampaign"))
+
     def updateUnitRecap(self):
         red_faction = self.factions.get_by_name(self.redFactionSelect.currentText())
         blue_faction = self.factions.get_by_name(self.blueFactionSelect.currentText())
@@ -514,6 +518,7 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
                 self.advanced_iads.setToolTip("Enable Advanced IADS")
 
             self.campaign_selected.emit(campaign)
+            self.completeChanged.emit()
 
         self.campaignList.selectionModel().setCurrentIndex(
             self.campaignList.indexAt(QPoint(1, 1)), QItemSelectionModel.Rows
@@ -556,6 +561,11 @@ class TheaterConfiguration(QtWidgets.QWizardPage):
         layout.addWidget(mapSettingsGroup, 2, 1, 1, 1)
         layout.addWidget(timeGroup, 3, 1, 3, 1)
         self.setLayout(layout)
+
+    def initializePage(self):
+        """Ensure that selectCampaign field is set after user clicks Back to previous page and Next back onto this page"""
+        campaign = self.campaignList.selected_campaign
+        self.setField("selectedCampaign", campaign)
 
 
 class BudgetInputs(QtWidgets.QGridLayout):


### PR DESCRIPTION
This PR addresses issue #1491 by resetting factions to default when clicking back from the faction selection page in the NGW.

An additional change is required to handle the scenario where user clicks back from the theater configuration page.