### PR TITLE
In NewUnitTransferDialog, only list reachable control points

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.
 * **[UI]** Fixed deleting waypoints in custom flight plans deleting the wrong waypoint.
 * **[UI]** Fixed flight properties UI to support F-15E S4+ laser codes.
+* **[UI]** In unit transfer dialog, only list control points that are reachable from the control point units are being transferred from.
 
 # 8.1.0
 

--- a/qt_ui/windows/basemenu/NewUnitTransferDialog.py
+++ b/qt_ui/windows/basemenu/NewUnitTransferDialog.py
@@ -36,13 +36,8 @@ class TransferDestinationComboBox(QComboBox):
         self.game = game
         self.origin = origin
 
-        for cp in self.game.theater.controlpoints:
-            if (
-                cp != self.origin
-                and cp.is_friendly(to_player=True)
-                and cp.can_deploy_ground_units
-            ):
-                self.addItem(cp.name, cp)
+        for cp in self.game.blue.transit_network.connections_from(origin):
+            self.addItem(cp.name, cp)
         self.model().sort(0)
         self.setCurrentIndex(0)
 

--- a/qt_ui/windows/basemenu/NewUnitTransferDialog.py
+++ b/qt_ui/windows/basemenu/NewUnitTransferDialog.py
@@ -36,7 +36,11 @@ class TransferDestinationComboBox(QComboBox):
         self.game = game
         self.origin = origin
 
-        for cp in self.game.blue.transit_network.connections_from(origin):
+        for cp in self.game.blue.transit_network.nodes:
+            if cp == origin:
+                continue
+            if not self.game.blue.transit_network.has_path_between(origin, cp):
+                continue
             self.addItem(cp.name, cp)
         self.model().sort(0)
         self.setCurrentIndex(0)


### PR DESCRIPTION
This PR addresses #3066 by restricting the list of control points in the new unit transfer dialog to control points reachable from the origin. This change centralizes the logic for reachable nodes to the TransitNetworkBuilder class. 

This PR was tested by:

1. Loading save from #3066 
2. Using cheat menu to destroy runway at Wadi al Jandali
3. Purchasing units at any of the other control points
4. Pass the turn to allow the purchase to complete
5. Initiating a unit transfer from the other control point and confirming that Wadi al Jandali does not show up in the list

Steps 2-4 are needed as no ground units show up at Melez when loading the save directly from the latest dev build.