### PR TITLE
Pre-allocate laser codes for FLOTs and flight members, add UI.

### DIFF
--- a/game/ato/flightmember.py
+++ b/game/ato/flightmember.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from game.ato.loadouts import Loadout
+from game.lasercodes import LaserCode
+from game.savecompat import has_save_compat_for
 
 if TYPE_CHECKING:
     from game.squadrons import Pilot
@@ -13,7 +15,29 @@ class FlightMember:
         self.pilot = pilot
         self.loadout = loadout
         self.use_custom_loadout = False
+        self.tgp_laser_code: LaserCode | None = None
         self.properties: dict[str, bool | float | int] = {}
+
+    @has_save_compat_for(9)
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        if "tgp_laser_code" not in state:
+            state["tgp_laser_code"] = None
+        self.__dict__.update(state)
+
+    def assign_tgp_laser_code(self, code: LaserCode) -> None:
+        if self.tgp_laser_code is not None:
+            raise RuntimeError(
+                f"{self.pilot} already has already been assigned laser code "
+                f"{self.tgp_laser_code}"
+            )
+        self.tgp_laser_code = code
+
+    def release_tgp_laser_code(self) -> None:
+        if self.tgp_laser_code is None:
+            raise RuntimeError(f"{self.pilot} has no assigned laser code")
+
+        self.tgp_laser_code.release()
+        self.tgp_laser_code = None
 
     @property
     def is_player(self) -> bool:

--- a/game/ato/flightmembers.py
+++ b/game/ato/flightmembers.py
@@ -46,9 +46,11 @@ class FlightMembers(IFlightRoster):
 
     def resize(self, new_size: int) -> None:
         if self.max_size > new_size:
-            self.flight.squadron.return_pilots(
-                [m.pilot for m in self.members[new_size:] if m.pilot is not None]
-            )
+            for member in self.members[new_size:]:
+                if (pilot := member.pilot) is not None:
+                    self.flight.squadron.return_pilot(pilot)
+                if (code := member.tgp_laser_code) is not None:
+                    code.release()
             self.members = self.members[:new_size]
             return
         if self.max_size:
@@ -71,6 +73,9 @@ class FlightMembers(IFlightRoster):
         self.flight.squadron.return_pilots(
             [p for p in self.iter_pilots() if p is not None]
         )
+        for member in self.members:
+            if (code := member.tgp_laser_code) is not None:
+                code.release()
 
     def use_same_loadout_for_all_members(self) -> None:
         if not self.members:

--- a/game/coalition.py
+++ b/game/coalition.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from .data.doctrine import Doctrine
     from .factions.faction import Faction
     from .game import Game
+    from .lasercodes import LaserCodeRegistry
     from .sim import GameUpdateEvents
 
 
@@ -89,6 +90,10 @@ class Coalition:
     def nav_mesh(self) -> NavMesh:
         assert self._navmesh is not None
         return self._navmesh
+
+    @property
+    def laser_code_registry(self) -> LaserCodeRegistry:
+        return self.game.laser_code_registry
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()

--- a/game/commander/packagebuilder.py
+++ b/game/commander/packagebuilder.py
@@ -10,9 +10,10 @@ from ..ato.starttype import StartType
 from ..db.database import Database
 
 if TYPE_CHECKING:
-    from game.dcs.aircrafttype import AircraftType
-    from game.squadrons.airwing import AirWing
     from game.ato.closestairfields import ClosestAirfields
+    from game.dcs.aircrafttype import AircraftType
+    from game.lasercodes import LaserCodeRegistry
+    from game.squadrons.airwing import AirWing
     from .missionproposals import ProposedFlight
 
 
@@ -24,6 +25,7 @@ class PackageBuilder:
         location: MissionTarget,
         closest_airfields: ClosestAirfields,
         air_wing: AirWing,
+        laser_code_registry: LaserCodeRegistry,
         flight_db: Database[Flight],
         is_player: bool,
         package_country: str,
@@ -35,6 +37,7 @@ class PackageBuilder:
         self.package_country = package_country
         self.package = Package(location, flight_db, auto_asap=asap)
         self.air_wing = air_wing
+        self.laser_code_registry = laser_code_registry
         self.start_type = start_type
 
     def plan_flight(self, plan: ProposedFlight) -> bool:
@@ -63,6 +66,11 @@ class PackageBuilder:
             start_type,
             divert=self.find_divert_field(squadron.aircraft, squadron.location),
         )
+        for member in flight.iter_members():
+            if member.is_player:
+                member.assign_tgp_laser_code(
+                    self.laser_code_registry.alloc_laser_code()
+                )
         self.package.add_flight(flight)
         return True
 

--- a/game/commander/packagefulfiller.py
+++ b/game/commander/packagefulfiller.py
@@ -141,6 +141,7 @@ class PackageFulfiller:
             mission.location,
             ObjectiveDistanceCache.get_closest_airfields(mission.location),
             self.air_wing,
+            self.coalition.laser_code_registry,
             self.flight_db,
             self.is_player,
             self.coalition.country_name,

--- a/game/lasercodes/__init__.py
+++ b/game/lasercodes/__init__.py
@@ -1,1 +1,3 @@
+from .ilasercoderegistry import ILaserCodeRegistry
+from .lasercode import LaserCode
 from .lasercoderegistry import LaserCodeRegistry

--- a/game/lasercodes/ilasercoderegistry.py
+++ b/game/lasercodes/ilasercoderegistry.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .lasercode import LaserCode
+
+
+class ILaserCodeRegistry(ABC):
+    @abstractmethod
+    def alloc_laser_code(self) -> LaserCode:
+        ...
+
+    @abstractmethod
+    def release_code(self, code: LaserCode) -> None:
+        ...

--- a/game/lasercodes/lasercode.py
+++ b/game/lasercodes/lasercode.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .ilasercoderegistry import ILaserCodeRegistry
+
+
+class LaserCode:
+    def __init__(self, code: int, registry: ILaserCodeRegistry) -> None:
+        self.verify_laser_code(code)
+        self.code = code
+        self.registry = registry
+
+    def release(self) -> None:
+        self.registry.release_code(self)
+
+    @staticmethod
+    def verify_laser_code(code: int) -> None:
+        # https://forum.dcs.world/topic/211574-valid-laser-codes/
+        # Valid laser codes are as follows
+        # First digit is always 1
+        # Second digit is 5-7
+        # Third and fourth digits are 1 - 8
+        # We iterate backward (reversed()) so that 1687 follows 1688
+
+        # Special case used by FC3 aircraft like the A-10A that is not valid for other
+        # aircraft.
+        if code == 1113:
+            return
+
+        # Must be 4 digits with no leading 0
+        if code < 1000 or code >= 2000:
+            raise ValueError
+
+        # The first digit was already verified above. Isolate the remaining three
+        # digits. The resulting list is ordered by significance, not printed position.
+        digits = [code // 10**i % 10 for i in range(3)]
+
+        if digits[0] < 1 or digits[0] > 8:
+            raise ValueError
+        if digits[1] < 1 or digits[1] > 8:
+            raise ValueError
+        if digits[2] < 5 or digits[2] > 7:
+            raise ValueError
+
+    def __str__(self) -> str:
+        return f"{self.code}"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LaserCode):
+            return False
+        return self.code == other.code
+
+    def __hash__(self) -> int:
+        return hash(self.code)

--- a/game/lasercodes/lasercoderegistry.py
+++ b/game/lasercodes/lasercoderegistry.py
@@ -1,18 +1,32 @@
+import logging
 from collections import deque
 
+from .ilasercoderegistry import ILaserCodeRegistry
+from .lasercode import LaserCode
 
-class LaserCodeRegistry:
+
+class LaserCodeRegistry(ILaserCodeRegistry):
     def __init__(self) -> None:
         self.allocated_codes: set[int] = set()
         self.available_codes = LaserCodeRegistry._all_valid_laser_codes()
+        self.fc3_code = LaserCode(1113, self)
 
-    def alloc_laser_code(self) -> int:
+    def alloc_laser_code(self) -> LaserCode:
         try:
             code = self.available_codes.popleft()
             self.allocated_codes.add(code)
-            return code
+            return LaserCode(code, self)
         except IndexError:
             raise RuntimeError("All laser codes have been allocated")
+
+    def release_code(self, code: LaserCode) -> None:
+        if code.code in self.allocated_codes:
+            self.allocated_codes.remove(code.code)
+            self.available_codes.appendleft(code.code)
+        else:
+            logging.error(
+                "attempted to release laser code %d which was not allocated", code.code
+            )
 
     @staticmethod
     def _all_valid_laser_codes() -> deque[int]:

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -18,7 +18,6 @@ from game.ato.package import Package
 from game.ato.starttype import StartType
 from game.factions.faction import Faction
 from game.missiongenerator.missiondata import MissionData
-from game.lasercodes import LaserCodeRegistry
 from game.radio.radios import RadioRegistry
 from game.radio.tacan import TacanRegistry
 from game.runways import RunwayData
@@ -48,7 +47,6 @@ class AircraftGenerator:
         time: datetime,
         radio_registry: RadioRegistry,
         tacan_registry: TacanRegistry,
-        laser_code_registry: LaserCodeRegistry,
         unit_map: UnitMap,
         mission_data: MissionData,
         helipads: dict[ControlPoint, StaticGroup],
@@ -59,7 +57,6 @@ class AircraftGenerator:
         self.time = time
         self.radio_registry = radio_registry
         self.tacan_registy = tacan_registry
-        self.laser_code_registry = laser_code_registry
         self.unit_map = unit_map
         self.flights: List[FlightData] = []
         self.mission_data = mission_data
@@ -174,7 +171,6 @@ class AircraftGenerator:
                 self.time,
                 self.radio_registry,
                 self.tacan_registy,
-                self.laser_code_registry,
                 self.mission_data,
                 dynamic_runways,
                 self.use_client,

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -133,7 +133,7 @@ class FlightGroupConfigurator:
     ) -> None:
         self.set_skill(unit, member)
         if member.loadout.has_weapon_of_type(WeaponTypeEnum.TGP) and member.is_player:
-            laser_codes.append(self.laser_code_registry.alloc_laser_code())
+            laser_codes.append(self.laser_code_registry.alloc_laser_code().code)
         else:
             laser_codes.append(None)
 

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -11,8 +11,7 @@ from dcs.unitgroup import FlyingGroup
 
 from game.ato import Flight, FlightType
 from game.callsigns import callsign_for_support_unit
-from game.data.weapons import Pylon, WeaponType as WeaponTypeEnum
-from game.lasercodes import LaserCodeRegistry
+from game.data.weapons import Pylon
 from game.missiongenerator.logisticsgenerator import LogisticsGenerator
 from game.missiongenerator.missiondata import AwacsInfo, MissionData, TankerInfo
 from game.radio.radios import RadioFrequency, RadioRegistry
@@ -40,7 +39,6 @@ class FlightGroupConfigurator:
         time: datetime,
         radio_registry: RadioRegistry,
         tacan_registry: TacanRegistry,
-        laser_code_registry: LaserCodeRegistry,
         mission_data: MissionData,
         dynamic_runways: dict[str, RunwayData],
         use_client: bool,
@@ -53,7 +51,6 @@ class FlightGroupConfigurator:
         self.time = time
         self.radio_registry = radio_registry
         self.tacan_registry = tacan_registry
-        self.laser_code_registry = laser_code_registry
         self.mission_data = mission_data
         self.dynamic_runways = dynamic_runways
         self.use_client = use_client
@@ -132,8 +129,8 @@ class FlightGroupConfigurator:
         self, unit: FlyingUnit, member: FlightMember, laser_codes: list[Optional[int]]
     ) -> None:
         self.set_skill(unit, member)
-        if member.loadout.has_weapon_of_type(WeaponTypeEnum.TGP) and member.is_player:
-            laser_codes.append(self.laser_code_registry.alloc_laser_code().code)
+        if (code := member.tgp_laser_code) is not None:
+            laser_codes.append(code.code)
         else:
             laser_codes.append(None)
 

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -37,13 +37,13 @@ from game.ground_forces.ai_ground_planner import (
     DISTANCE_FROM_FRONTLINE,
 )
 from game.ground_forces.combat_stance import CombatStance
+from game.lasercodes import LaserCodeRegistry
 from game.naming import namegen
 from game.radio.radios import RadioRegistry
 from game.theater.controlpoint import ControlPoint
 from game.unitmap import UnitMap
 from game.utils import Heading
 from .frontlineconflictdescription import FrontLineConflictDescription
-from game.lasercodes import LaserCodeRegistry
 from .missiondata import JtacInfo, MissionData
 
 if TYPE_CHECKING:
@@ -136,13 +136,12 @@ class FlotGenerator:
 
         # Add JTAC
         if self.game.blue.faction.has_jtac:
-            code: int
             freq = self.radio_registry.alloc_uhf()
             # If the option fc3LaserCode is enabled, force all JTAC
             # laser codes to 1113 to allow lasing for Su-25 Frogfoots and A-10A Warthogs.
             # Otherwise use 1688 for the first JTAC, 1687 for the second etc.
             if self.game.lua_plugin_manager.is_option_enabled("ctld", "fc3LaserCode"):
-                code = 1113
+                code = self.laser_code_registry.fc3_code
             else:
                 code = self.laser_code_registry.alloc_laser_code()
 

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -37,7 +37,6 @@ from game.ground_forces.ai_ground_planner import (
     DISTANCE_FROM_FRONTLINE,
 )
 from game.ground_forces.combat_stance import CombatStance
-from game.lasercodes import LaserCodeRegistry
 from game.naming import namegen
 from game.radio.radios import RadioRegistry
 from game.theater.controlpoint import ControlPoint
@@ -80,7 +79,6 @@ class FlotGenerator:
         unit_map: UnitMap,
         radio_registry: RadioRegistry,
         mission_data: MissionData,
-        laser_code_registry: LaserCodeRegistry,
     ) -> None:
         self.mission = mission
         self.conflict = conflict
@@ -92,7 +90,6 @@ class FlotGenerator:
         self.unit_map = unit_map
         self.radio_registry = radio_registry
         self.mission_data = mission_data
-        self.laser_code_registry = laser_code_registry
 
     def generate(self) -> None:
         position = FrontLineConflictDescription.frontline_position(
@@ -141,9 +138,9 @@ class FlotGenerator:
             # laser codes to 1113 to allow lasing for Su-25 Frogfoots and A-10A Warthogs.
             # Otherwise use 1688 for the first JTAC, 1687 for the second etc.
             if self.game.lua_plugin_manager.is_option_enabled("ctld", "fc3LaserCode"):
-                code = self.laser_code_registry.fc3_code
+                code = self.game.laser_code_registry.fc3_code
             else:
-                code = self.laser_code_registry.alloc_laser_code()
+                code = self.conflict.front_line.laser_code
 
             utype = self.game.blue.faction.jtac_unit
             if utype is None:

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -34,7 +34,6 @@ from .flotgenerator import FlotGenerator
 from .forcedoptionsgenerator import ForcedOptionsGenerator
 from .frontlineconflictdescription import FrontLineConflictDescription
 from .kneeboard import KneeboardGenerator
-from game.lasercodes import LaserCodeRegistry
 from .luagenerator import LuaGenerator
 from .missiondata import MissionData
 from .tgogenerator import TgoGenerator
@@ -65,7 +64,6 @@ class MissionGenerator:
 
         self.mission_data = MissionData()
 
-        self.laser_code_registry = LaserCodeRegistry()
         self.radio_registry = RadioRegistry()
         self.tacan_registry = TacanRegistry()
 
@@ -236,7 +234,6 @@ class MissionGenerator:
                 self.unit_map,
                 self.radio_registry,
                 self.mission_data,
-                self.laser_code_registry,
             )
             ground_conflict_gen.generate()
 
@@ -262,7 +259,6 @@ class MissionGenerator:
             self.time,
             self.radio_registry,
             self.tacan_registry,
-            self.laser_code_registry,
             self.unit_map,
             mission_data=air_support_generator.mission_data,
             helipads=tgo_generator.helipads,

--- a/game/theater/frontline.py
+++ b/game/theater/frontline.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator, List, TYPE_CHECKING, Tuple
 from dcs.mapping import Point
 
 from .missiontarget import MissionTarget
+from ..lasercodes.lasercode import LaserCode
 from ..utils import Heading, pairwise
 
 if TYPE_CHECKING:
@@ -49,10 +50,12 @@ class FrontLine(MissionTarget):
         self,
         blue_point: ControlPoint,
         red_point: ControlPoint,
+        laser_code: LaserCode,
     ) -> None:
         self.id = uuid.uuid4()
         self.blue_cp = blue_point
         self.red_cp = red_point
+        self.laser_code = laser_code
         try:
             route = list(blue_point.convoy_route_to(red_point))
         except KeyError:

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -196,6 +196,12 @@ class QFlightCreator(QDialog):
             roster=roster,
         )
 
+        for member in flight.iter_members():
+            if member.is_player:
+                member.assign_tgp_laser_code(
+                    self.game.laser_code_registry.alloc_laser_code()
+                )
+
         # noinspection PyUnresolvedReferences
         self.created.emit(flight)
         self.accept()

--- a/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
+++ b/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
@@ -16,6 +16,7 @@ from game.ato.flightmember import FlightMember
 from game.ato.loadouts import Loadout
 from qt_ui.widgets.QLabeledWidget import QLabeledWidget
 from .QLoadoutEditor import QLoadoutEditor
+from .ownlasercodeinfo import OwnLaserCodeInfo
 from .propertyeditor import PropertyEditor
 
 
@@ -89,6 +90,11 @@ class QFlightPayloadTab(QFrame):
         docsText.setAlignment(Qt.AlignCenter)
         docsText.setOpenExternalLinks(True)
 
+        self.own_laser_code_info = OwnLaserCodeInfo(
+            game, self.member_selector.selected_member
+        )
+        scrolling_layout.addLayout(self.own_laser_code_info)
+
         self.property_editor = PropertyEditor(
             self.flight, self.member_selector.selected_member
         )
@@ -117,6 +123,7 @@ class QFlightPayloadTab(QFrame):
         self.loadout_selector.setCurrentText(member.loadout.name)
         self.loadout_selector.setDisabled(member.loadout.is_custom)
         self.payload_editor.set_flight_member(member)
+        self.own_laser_code_info.set_flight_member(member)
         if self.member_selector.value() != 0:
             self.loadout_selector.setDisabled(
                 self.flight.use_same_loadout_for_all_members

--- a/qt_ui/windows/mission/flight/payload/ownlasercodeinfo.py
+++ b/qt_ui/windows/mission/flight/payload/ownlasercodeinfo.py
@@ -1,0 +1,56 @@
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton
+
+from game import Game
+from game.ato.flightmember import FlightMember
+
+
+class OwnLaserCodeInfo(QHBoxLayout):
+    assigned_laser_code_changed = Signal()
+
+    def __init__(
+        self, game: Game, flight_member: FlightMember, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.game = game
+        self.flight_member = flight_member
+
+        self.addWidget(QLabel("Assigned laser code:"))
+        self.addStretch()
+
+        self.code_display = QLabel()
+        self.addWidget(self.code_display)
+
+        self.alloc_dealloc_button = QPushButton()
+        self.alloc_dealloc_button.clicked.connect(self.on_alloc_dealloc_clicked)
+        self.addWidget(self.alloc_dealloc_button)
+
+        self.bind_to_selected_member()
+
+    def set_flight_member(self, flight_member: FlightMember) -> None:
+        self.flight_member = flight_member
+        self.bind_to_selected_member()
+
+    def bind_to_selected_member(self) -> None:
+        if (code := self.flight_member.tgp_laser_code) is not None:
+            self.alloc_dealloc_button.setEnabled(True)
+            self.alloc_dealloc_button.setText("Release")
+            self.code_display.setText(f"{code}")
+        elif self.flight_member.is_player:
+            self.alloc_dealloc_button.setText("Assign")
+            self.alloc_dealloc_button.setEnabled(True)
+            self.code_display.setText("Not assigned")
+        else:
+            self.alloc_dealloc_button.setText("Assign")
+            self.alloc_dealloc_button.setEnabled(False)
+            self.code_display.setText("AI does not use laser codes")
+
+    def on_alloc_dealloc_clicked(self) -> None:
+        if self.flight_member.tgp_laser_code is not None:
+            self.flight_member.release_tgp_laser_code()
+        else:
+            self.flight_member.assign_tgp_laser_code(
+                self.game.laser_code_registry.alloc_laser_code()
+            )
+        self.bind_to_selected_member()
+        self.assigned_laser_code_changed.emit()

--- a/tests/lasercodes/test_lasercode.py
+++ b/tests/lasercodes/test_lasercode.py
@@ -1,0 +1,75 @@
+import pytest
+
+from game.lasercodes import ILaserCodeRegistry
+from game.lasercodes.lasercode import LaserCode
+
+
+class MockRegistry(ILaserCodeRegistry):
+    def __init__(self) -> None:
+        self.release_count = 0
+
+    def alloc_laser_code(self) -> LaserCode:
+        raise NotImplementedError
+
+    def release_code(self, code: LaserCode) -> None:
+        self.release_count += 1
+
+
+@pytest.fixture(name="registry")
+def mock_registry() -> MockRegistry:
+    return MockRegistry()
+
+
+def test_lasercode_code(registry: ILaserCodeRegistry) -> None:
+
+    assert LaserCode(1688, registry).code == 1688
+
+    # 1113 doesn't comply to the rules, but is the only code valid for FC3 aircraft like
+    # the A-10A.
+    assert LaserCode(1113, registry).code == 1113
+
+    # The first digit must be 1
+    with pytest.raises(ValueError):
+        # And be exactly 4 digits
+        LaserCode(2688, registry)
+
+    # The code must be exactly 4 digits
+    with pytest.raises(ValueError):
+        LaserCode(888, registry)
+    with pytest.raises(ValueError):
+        LaserCode(18888, registry)
+
+    # 0 and 9 are invalid digits
+    with pytest.raises(ValueError):
+        LaserCode(1088, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1608, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1680, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1988, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1698, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1689, registry)
+
+    # The second digit is further constrained to be 5, 6, or 7.
+    with pytest.raises(ValueError):
+        LaserCode(1188, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1288, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1388, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1488, registry)
+    with pytest.raises(ValueError):
+        LaserCode(1888, registry)
+
+
+def test_lasercode_release(registry: MockRegistry) -> None:
+    code = LaserCode(1688, registry)
+    assert registry.release_count == 0
+    code.release()
+    assert registry.release_count == 1
+    code.release()
+    assert registry.release_count == 2

--- a/tests/lasercodes/test_lasercoderegistry.py
+++ b/tests/lasercodes/test_lasercoderegistry.py
@@ -10,6 +10,16 @@ def test_initial_laser_codes() -> None:
 
 def test_alloc_laser_code() -> None:
     reg = LaserCodeRegistry()
-    assert reg.alloc_laser_code() == 1688
+    assert reg.alloc_laser_code().code == 1688
     assert 1688 not in reg.available_codes
     assert len(reg.available_codes) == 191
+
+
+def test_release_code() -> None:
+    reg = LaserCodeRegistry()
+    code = reg.alloc_laser_code()
+    code.release()
+    assert code.code in reg.available_codes
+    assert len(reg.available_codes) == 192
+    code.release()
+    assert len(reg.available_codes) == 192


### PR DESCRIPTION
Alone this isn't very useful yet. I'm still working on the interesting part: the selector that will allow players to pick which laser code their weapons come pre-assigned to (which is important for a variety of aircraft that do not allow changing laser codes when the engine is on, or sometimes at all).