### PR TITLE
Add UI for selecting weapon laser codes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Saves from 8.x are not compatible with 9.0.0.
 
 * **[Flight Planning]** Improved IP selection for targets that are near the center of a threat zone.
 * **[Flight Planning]** Loadouts and aircraft properties can now be set per-flight member. Warning: AI flights should not use mixed loadouts.
+* **[Flight Planning]** Laser codes that are pre-assigned to weapons at mission start can now be chosen from a list in the loadout UI. This does not affect the aircraft's TGP, just the weapons. Currently only implemented for the F-15E S4+.
 * **[Modding]** Factions can now specify the ship type to be used for cargo shipping. The Handy Wind will be used by default, but WW2 factions can pick something more appropriate.
 * **[UI]** An error will be displayed when invalid fast-forward options are selected rather than beginning a never ending simulation.
 * **[UI]** Added cheats for instantly repairing and destroying runways.

--- a/game/ato/flightmember.py
+++ b/game/ato/flightmember.py
@@ -16,12 +16,15 @@ class FlightMember:
         self.loadout = loadout
         self.use_custom_loadout = False
         self.tgp_laser_code: LaserCode | None = None
+        self.weapon_laser_code: LaserCode | None = None
         self.properties: dict[str, bool | float | int] = {}
 
     @has_save_compat_for(9)
     def __setstate__(self, state: dict[str, Any]) -> None:
         if "tgp_laser_code" not in state:
             state["tgp_laser_code"] = None
+        if "weapon_laser_code" not in state:
+            state["weapon_laser_code"] = None
         self.__dict__.update(state)
 
     def assign_tgp_laser_code(self, code: LaserCode) -> None:
@@ -36,6 +39,8 @@ class FlightMember:
         if self.tgp_laser_code is None:
             raise RuntimeError(f"{self.pilot} has no assigned laser code")
 
+        if self.weapon_laser_code == self.tgp_laser_code:
+            self.weapon_laser_code = None
         self.tgp_laser_code.release()
         self.tgp_laser_code = None
 

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -14,6 +14,7 @@ from dcs.unitpropertydescription import UnitPropertyDescription
 from dcs.unittype import FlyingType
 
 from game.data.units import UnitClass
+from game.dcs.lasercodeconfig import LaserCodeConfig
 from game.dcs.unittype import UnitType
 from game.radio.channels import (
     ApacheChannelNamer,
@@ -204,6 +205,8 @@ class AircraftType(UnitType[Type[FlyingType]]):
     # not take up a weapons station. If True, do not replace LGBs with dumb bombs
     # when no TGP is mounted on any station.
     has_built_in_target_pod: bool
+
+    laser_code_configs: list[LaserCodeConfig]
 
     _by_name: ClassVar[dict[str, AircraftType]] = {}
     _by_unit_type: ClassVar[dict[type[FlyingType], list[AircraftType]]] = defaultdict(
@@ -486,6 +489,9 @@ class AircraftType(UnitType[Type[FlyingType]]):
                 can_carry_crates=data.get("can_carry_crates", aircraft.helicopter),
                 task_priorities=task_priorities,
                 has_built_in_target_pod=data.get("has_built_in_target_pod", False),
+                laser_code_configs=[
+                    LaserCodeConfig.from_yaml(d) for d in data.get("laser_codes", [])
+                ],
             )
 
     def __hash__(self) -> int:

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -325,8 +325,18 @@ class AircraftType(UnitType[Type[FlyingType]]):
     def channel_name(self, radio_id: int, channel_id: int) -> str:
         return self.channel_namer.channel_name(radio_id, channel_id)
 
+    @cached_property
+    def laser_code_prop_ids(self) -> set[str]:
+        laser_code_props: set[str] = set()
+        for laser_code_config in self.laser_code_configs:
+            laser_code_props.update(laser_code_config.iter_prop_ids())
+        return laser_code_props
+
     def iter_props(self) -> Iterator[UnitPropertyDescription]:
         yield from self.dcs_unit_type.properties.values()
+
+    def should_show_prop(self, prop_id: str) -> bool:
+        return prop_id not in self.laser_code_prop_ids
 
     def capable_of(self, task: FlightType) -> bool:
         return task in self.task_priorities

--- a/game/dcs/lasercodeconfig.py
+++ b/game/dcs/lasercodeconfig.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from typing import Any
 
 
@@ -20,6 +21,10 @@ class LaserCodeConfig(ABC):
         )
 
     @abstractmethod
+    def iter_prop_ids(self) -> Iterator[str]:
+        ...
+
+    @abstractmethod
     def property_dict_for_code(self, code: int) -> dict[str, int]:
         ...
 
@@ -29,6 +34,9 @@ class SinglePropertyLaserCodeConfig(LaserCodeConfig):
         super().__init__(pylon)
         self.property_id = property_id
         self.digits = digits
+
+    def iter_prop_ids(self) -> Iterator[str]:
+        yield self.property_id
 
     def property_dict_for_code(self, code: int) -> dict[str, int]:
         return {self.property_id: code % 10**self.digits}
@@ -40,6 +48,9 @@ class MultiplePropertyLaserCodeConfig(LaserCodeConfig):
     ) -> None:
         super().__init__(pylon)
         self.property_digit_mappings = property_digit_mappings
+
+    def iter_prop_ids(self) -> Iterator[str]:
+        yield from (i for i, p in self.property_digit_mappings)
 
     def property_dict_for_code(self, code: int) -> dict[str, int]:
         d = {}

--- a/game/dcs/lasercodeconfig.py
+++ b/game/dcs/lasercodeconfig.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class LaserCodeConfig(ABC):
+    def __init__(self, pylon: int) -> None:
+        self.pylon = pylon
+
+    @staticmethod
+    def from_yaml(data: dict[str, Any]) -> LaserCodeConfig:
+        pylon = data["pylon"]
+        if (property_def := data.get("property")) is not None:
+            return SinglePropertyLaserCodeConfig(
+                pylon, property_def["id"], int(property_def["digits"])
+            )
+        return MultiplePropertyLaserCodeConfig(
+            pylon, [(d["id"], d["digit"]) for d in data["properties"]]
+        )
+
+    @abstractmethod
+    def property_dict_for_code(self, code: int) -> dict[str, int]:
+        ...
+
+
+class SinglePropertyLaserCodeConfig(LaserCodeConfig):
+    def __init__(self, pylon: int, property_id: str, digits: int) -> None:
+        super().__init__(pylon)
+        self.property_id = property_id
+        self.digits = digits
+
+    def property_dict_for_code(self, code: int) -> dict[str, int]:
+        return {self.property_id: code % 10**self.digits}
+
+
+class MultiplePropertyLaserCodeConfig(LaserCodeConfig):
+    def __init__(
+        self, pylon: int, property_digit_mappings: list[tuple[str, int]]
+    ) -> None:
+        super().__init__(pylon)
+        self.property_digit_mappings = property_digit_mappings
+
+    def property_dict_for_code(self, code: int) -> dict[str, int]:
+        d = {}
+        for prop_id, idx in self.property_digit_mappings:
+            d[prop_id] = code // 10**idx % 10
+        return d

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -213,7 +213,11 @@ class FlightGroupConfigurator:
 
     def setup_props(self) -> None:
         for unit, member in zip(self.group.units, self.flight.iter_members()):
-            for prop_id, value in member.properties.items():
+            props = dict(member.properties)
+            if (code := member.weapon_laser_code) is not None:
+                for laser_code_config in self.flight.unit_type.laser_code_configs:
+                    props.update(laser_code_config.property_dict_for_code(code.code))
+            for prop_id, value in props.items():
                 unit.set_property(prop_id, value)
 
     def setup_payloads(self) -> None:

--- a/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
+++ b/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
@@ -18,6 +18,7 @@ from qt_ui.widgets.QLabeledWidget import QLabeledWidget
 from .QLoadoutEditor import QLoadoutEditor
 from .ownlasercodeinfo import OwnLaserCodeInfo
 from .propertyeditor import PropertyEditor
+from .weaponlasercodeselector import WeaponLaserCodeSelector
 
 
 class DcsLoadoutSelector(QComboBox):
@@ -95,6 +96,24 @@ class QFlightPayloadTab(QFrame):
         )
         scrolling_layout.addLayout(self.own_laser_code_info)
 
+        self.weapon_laser_code_selector = WeaponLaserCodeSelector(
+            game, self.member_selector.selected_member, self
+        )
+        self.own_laser_code_info.assigned_laser_code_changed.connect(
+            self.weapon_laser_code_selector.rebuild
+        )
+        scrolling_layout.addLayout(
+            QLabeledWidget(
+                "Preset laser code for weapons:", self.weapon_laser_code_selector
+            )
+        )
+        scrolling_layout.addWidget(
+            QLabel(
+                "Equipped weapons will be pre-configured to the selected laser code at "
+                "mission start."
+            )
+        )
+
         self.property_editor = PropertyEditor(
             self.flight, self.member_selector.selected_member
         )
@@ -123,6 +142,7 @@ class QFlightPayloadTab(QFrame):
         self.loadout_selector.setCurrentText(member.loadout.name)
         self.loadout_selector.setDisabled(member.loadout.is_custom)
         self.payload_editor.set_flight_member(member)
+        self.weapon_laser_code_selector.set_flight_member(member)
         self.own_laser_code_info.set_flight_member(member)
         if self.member_selector.value() != 0:
             self.loadout_selector.setDisabled(

--- a/qt_ui/windows/mission/flight/payload/propertyeditor.py
+++ b/qt_ui/windows/mission/flight/payload/propertyeditor.py
@@ -37,6 +37,9 @@ class PropertyEditor(QGridLayout):
             if prop.player_only and not flight.client_count:
                 continue
 
+            if not flight.unit_type.should_show_prop(prop.identifier):
+                continue
+
             try:
                 widget = self.control_for_property(prop)
             except (MissingPropertyDataError, UnhandledControlTypeError):

--- a/qt_ui/windows/mission/flight/payload/weaponlasercodeselector.py
+++ b/qt_ui/windows/mission/flight/payload/weaponlasercodeselector.py
@@ -1,0 +1,51 @@
+from PySide6.QtWidgets import QComboBox, QWidget
+
+from game import Game
+from game.ato.flightmember import FlightMember
+from qt_ui.blocksignals import block_signals
+
+
+class WeaponLaserCodeSelector(QComboBox):
+    def __init__(
+        self, game: Game, flight_member: FlightMember, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.game = game
+        self.flight_member = flight_member
+        self.currentIndexChanged.connect(self.on_index_changed)
+
+        self.rebuild()
+
+    def set_flight_member(self, flight_member: FlightMember) -> None:
+        self.flight_member = flight_member
+        self.rebuild()
+
+    def on_index_changed(self) -> None:
+        self.flight_member.weapon_laser_code = self.currentData()
+
+    def rebuild(self) -> None:
+        with block_signals(self):
+            self.clear()
+            if not self.flight_member.is_player:
+                self.setDisabled(True)
+                self.addItem("AI does not use laser codes", None)
+
+            self.setEnabled(True)
+
+            self.addItem("Default (1688)", None)
+            selected_index: int | None = None
+            idx = 1
+            if (own := self.flight_member.tgp_laser_code) is not None:
+                self.addItem(f"Use own code ({own})", own)
+                if own == self.flight_member.weapon_laser_code:
+                    selected_index = idx
+                idx += 1
+            for idx, front in enumerate(self.game.theater.conflicts(), idx):
+                self.addItem(
+                    f"JTAC {front.name} ({front.laser_code})", front.laser_code
+                )
+                if front.laser_code == self.flight_member.weapon_laser_code:
+                    selected_index = idx
+
+            if selected_index is not None:
+                self.setCurrentIndex(selected_index)

--- a/resources/units/aircraft/F-15ESE.yaml
+++ b/resources/units/aircraft/F-15ESE.yaml
@@ -34,3 +34,24 @@ tasks:
   OCA/Runway: 630
   Strike: 640
   TARCAP: 240
+laser_codes:
+  - pylon: 2
+    property:
+      id: Sta2LaserCode
+      digits: 3
+  - pylon: 4
+    property:
+      id: LCFTLaserCode
+      digits: 3
+  - pylon: 5
+    property:
+      id: Sta5LaserCode
+      digits: 3
+  - pylon: 12
+    property:
+      id: RCFTLaserCode
+      digits: 3
+  - pylon: 14
+    property:
+      id: Sta8LaserCode
+      digits: 3

--- a/tests/dcs/test_lasercodeconfig.py
+++ b/tests/dcs/test_lasercodeconfig.py
@@ -1,0 +1,65 @@
+from game.dcs.lasercodeconfig import (
+    SinglePropertyLaserCodeConfig,
+    MultiplePropertyLaserCodeConfig,
+    LaserCodeConfig,
+)
+
+
+def test_singlepropertylasercodeproperty() -> None:
+    config = SinglePropertyLaserCodeConfig(0, "code", 3)
+    assert config.property_dict_for_code(1688) == {"code": 688}
+    assert config.property_dict_for_code(1000) == {"code": 0}
+    assert config.property_dict_for_code(1234) == {"code": 234}
+    assert config.property_dict_for_code(1) == {"code": 1}
+
+
+def test_multiplepropertylasercodeproperty() -> None:
+    config = MultiplePropertyLaserCodeConfig(
+        0,
+        [
+            ("digit0", 0),
+            ("digit1", 1),
+            ("digit2", 2),
+        ],
+    )
+    assert config.property_dict_for_code(1688) == {
+        "digit0": 8,
+        "digit1": 8,
+        "digit2": 6,
+    }
+    assert config.property_dict_for_code(1000) == {
+        "digit0": 0,
+        "digit1": 0,
+        "digit2": 0,
+    }
+    assert config.property_dict_for_code(1234) == {
+        "digit0": 4,
+        "digit1": 3,
+        "digit2": 2,
+    }
+    assert config.property_dict_for_code(1) == {"digit0": 1, "digit1": 0, "digit2": 0}
+
+
+def test_lasercodeconfig_from_yaml() -> None:
+    config = LaserCodeConfig.from_yaml(
+        {"pylon": 0, "property": {"id": "code", "digits": 3}}
+    )
+    assert config.pylon == 0
+    assert config.property_dict_for_code(1688) == {"code": 688}
+
+    config = LaserCodeConfig.from_yaml(
+        {
+            "pylon": 1,
+            "properties": [
+                {"id": "digit0", "digit": 0},
+                {"id": "digit1", "digit": 1},
+                {"id": "digit2", "digit": 2},
+            ],
+        }
+    )
+    assert config.pylon == 1
+    assert config.property_dict_for_code(1688) == {
+        "digit0": 8,
+        "digit1": 8,
+        "digit2": 6,
+    }

--- a/tests/dcs/test_lasercodeconfig.py
+++ b/tests/dcs/test_lasercodeconfig.py
@@ -7,6 +7,7 @@ from game.dcs.lasercodeconfig import (
 
 def test_singlepropertylasercodeproperty() -> None:
     config = SinglePropertyLaserCodeConfig(0, "code", 3)
+    assert list(config.iter_prop_ids()) == ["code"]
     assert config.property_dict_for_code(1688) == {"code": 688}
     assert config.property_dict_for_code(1000) == {"code": 0}
     assert config.property_dict_for_code(1234) == {"code": 234}
@@ -22,6 +23,7 @@ def test_multiplepropertylasercodeproperty() -> None:
             ("digit2", 2),
         ],
     )
+    assert list(config.iter_prop_ids()) == ["digit0", "digit1", "digit2"]
     assert config.property_dict_for_code(1688) == {
         "digit0": 8,
         "digit1": 8,


### PR DESCRIPTION
This makes it possible to have the right laser code set for hot start aircraft that (typically) do not allow changing laser codes when the engine is on.

![image](https://github.com/dcs-liberation/dcs_liberation/assets/315852/0274f156-9dd5-495b-ad5b-05dcef87d8b9)
