### PR TITLE
Fix a handful of TOT offset bugs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[UI]** Fixed flight properties UI to support F-15E S4+ laser codes.
 * **[UI]** In unit transfer dialog, only list control points that are reachable from the control point units are being transferred from.
 * **[UI]** Fixed UI bug where altering an "ahead of package" TOT offset would change the offset back to a "behind pacakge" offset.
+* **[UI]** Fixed bug where changing TOT offsets could result in flight startup times that are in the past.
 
 # 8.1.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[UI]** Fixed deleting waypoints in custom flight plans deleting the wrong waypoint.
 * **[UI]** Fixed flight properties UI to support F-15E S4+ laser codes.
 * **[UI]** In unit transfer dialog, only list control points that are reachable from the control point units are being transferred from.
+* **[UI]** Fixed UI bug where altering an "ahead of package" TOT offset would change the offset back to a "behind pacakge" offset.
 
 # 8.1.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Data]** Fixed the class of the Samuel Chase so it can't be picked for a AAA or SHORAD site.
 * **[Data]** Allow CH-47D, CH-53E and UH-60A to operate from carriers and LHAs.
 * **[Data]** Added the F-15E's LANTIRN to the list of known targeting pods. Player F-15E flight with TGPs will now be assigned laser codes.
+* **[Flight Planning]** Patrolling flight plans (CAS, CAP, refueling, etc) now handle TOT offsets.
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
 * **[Mission Generation]** Fix generation of OCA Runway missions to allow LGBs to be used.
 * **[New Game Wizard]** Factions are reset to default after clicking "Back" to Theater Configuration screen.

--- a/game/ato/flightplans/patrolling.py
+++ b/game/ato/flightplans/patrolling.py
@@ -62,7 +62,7 @@ class PatrollingFlightPlan(StandardFlightPlan[LayoutT], UiZoneDisplay, ABC):
 
     @property
     def patrol_start_time(self) -> datetime:
-        return self.package.time_over_target
+        return self.tot
 
     @property
     def patrol_end_time(self) -> datetime:

--- a/qt_ui/windows/mission/flight/settings/FlightPlanPropertiesGroup.py
+++ b/qt_ui/windows/mission/flight/settings/FlightPlanPropertiesGroup.py
@@ -51,10 +51,10 @@ class FlightPlanPropertiesGroup(QGroupBox):
 
         tot_offset_layout.addWidget(QLabel("TOT Offset (minutes:seconds)"))
         tot_offset_layout.addStretch()
-        negative_offset_checkbox = QCheckBox("Ahead of package")
-        negative_offset_checkbox.setChecked(negative)
-        negative_offset_checkbox.toggled.connect(self.toggle_negative_offset)
-        tot_offset_layout.addWidget(negative_offset_checkbox)
+        self.negative_offset_checkbox = QCheckBox("Ahead of package")
+        self.negative_offset_checkbox.setChecked(negative)
+        self.negative_offset_checkbox.toggled.connect(self.toggle_negative_offset)
+        tot_offset_layout.addWidget(self.negative_offset_checkbox)
 
         self.tot_offset_spinner = QTimeEdit(QTime(hours, minutes, seconds))
         self.tot_offset_spinner.setMaximumTime(QTime(59, 0))
@@ -113,9 +113,12 @@ class FlightPlanPropertiesGroup(QGroupBox):
             )
 
     def set_tot_offset(self, offset: QTime) -> None:
-        self.flight.flight_plan.tot_offset = timedelta(
+        offset = timedelta(
             hours=offset.hour(), minutes=offset.minute(), seconds=offset.second()
         )
+        if self.negative_offset_checkbox.isChecked():
+            offset = -offset
+        self.flight.flight_plan.tot_offset = offset
         self.update_departure_time()
 
     def toggle_negative_offset(self) -> None:

--- a/qt_ui/windows/mission/flight/settings/FlightPlanPropertiesGroup.py
+++ b/qt_ui/windows/mission/flight/settings/FlightPlanPropertiesGroup.py
@@ -119,8 +119,10 @@ class FlightPlanPropertiesGroup(QGroupBox):
         if self.negative_offset_checkbox.isChecked():
             offset = -offset
         self.flight.flight_plan.tot_offset = offset
+        self.package_model.update_tot()
         self.update_departure_time()
 
     def toggle_negative_offset(self) -> None:
         self.flight.flight_plan.tot_offset = -self.flight.flight_plan.tot_offset
+        self.package_model.update_tot()
         self.update_departure_time()


### PR DESCRIPTION
1. The TOT offset spinner didn't account for the state of the "ahead of package" checkbox on change.
2. Changing TOT offsets didn't update the package's TOT, so could result in a negative startup time.
3. Patrolling flight plans didn't use the offset TOT when determining their patrol start time, but did for their takeoff time.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3107.