### PR TITLE
Configure target points for F-15E S4+.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Flight Planning]** Improved IP selection for targets that are near the center of a threat zone.
 * **[Flight Planning]** Loadouts and aircraft properties can now be set per-flight member. Warning: AI flights should not use mixed loadouts.
 * **[Flight Planning]** Laser codes that are pre-assigned to weapons at mission start can now be chosen from a list in the loadout UI. This does not affect the aircraft's TGP, just the weapons. Currently only implemented for the F-15E S4+ and F-16C.
+* **[Mission Generation]** Configured target and initial points for F-15E S4+.
 * **[Modding]** Factions can now specify the ship type to be used for cargo shipping. The Handy Wind will be used by default, but WW2 factions can pick something more appropriate.
 * **[UI]** An error will be displayed when invalid fast-forward options are selected rather than beginning a never ending simulation.
 * **[UI]** Added cheats for instantly repairing and destroying runways.

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -208,6 +208,8 @@ class AircraftType(UnitType[Type[FlyingType]]):
 
     laser_code_configs: list[LaserCodeConfig]
 
+    use_f15e_waypoint_names: bool
+
     _by_name: ClassVar[dict[str, AircraftType]] = {}
     _by_unit_type: ClassVar[dict[type[FlyingType], list[AircraftType]]] = defaultdict(
         list
@@ -502,6 +504,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
                 laser_code_configs=[
                     LaserCodeConfig.from_yaml(d) for d in data.get("laser_codes", [])
                 ],
+                use_f15e_waypoint_names=data.get("use_f15e_waypoint_names", False),
             )
 
     def __hash__(self) -> int:

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -43,11 +43,14 @@ class PydcsWaypointBuilder:
         self.unit_map = unit_map
         self.generated_waypoint_idx = generated_waypoint_idx
 
+    def dcs_name_for_waypoint(self) -> str:
+        return self.waypoint.name
+
     def build(self) -> MovingPoint:
         waypoint = self.group.add_waypoint(
             self.waypoint.position,
             self.waypoint.alt.meters,
-            name=self.waypoint.name,
+            name=self.dcs_name_for_waypoint(),
         )
 
         if self.waypoint.flyover:

--- a/game/missiongenerator/aircraft/waypoints/target.py
+++ b/game/missiongenerator/aircraft/waypoints/target.py
@@ -1,0 +1,14 @@
+from .pydcswaypointbuilder import PydcsWaypointBuilder
+
+
+class TargetBuilder(PydcsWaypointBuilder):
+    """Waypoint builder for target waypoint types.
+
+    This handles both precise target locations (TARGET_POINT) and target areas
+    (TARGET_GROUP_LOC).
+    """
+
+    def dcs_name_for_waypoint(self) -> str:
+        if self.flight.unit_type.use_f15e_waypoint_names:
+            return f"#T {self.waypoint.name}"
+        return super().dcs_name_for_waypoint()

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -43,6 +43,7 @@ from .seadingress import SeadIngressBuilder
 from .splitpoint import SplitPointBuilder
 from .strikeingress import StrikeIngressBuilder
 from .sweepingress import SweepIngressBuilder
+from .target import TargetBuilder
 
 
 class WaypointGenerator:
@@ -128,6 +129,8 @@ class WaypointGenerator:
         self, waypoint: FlightWaypoint, generated_waypoint_index: int
     ) -> PydcsWaypointBuilder:
         builders = {
+            FlightWaypointType.CARGO_STOP: CargoStopBuilder,
+            FlightWaypointType.DROPOFF_ZONE: LandingZoneBuilder,
             FlightWaypointType.INGRESS_ANTI_SHIP: AntiShipIngressBuilder,
             FlightWaypointType.INGRESS_BAI: BaiIngressBuilder,
             FlightWaypointType.INGRESS_CAS: CasIngressBuilder,
@@ -138,16 +141,16 @@ class WaypointGenerator:
             FlightWaypointType.INGRESS_STRIKE: StrikeIngressBuilder,
             FlightWaypointType.INGRESS_SWEEP: SweepIngressBuilder,
             FlightWaypointType.JOIN: JoinPointBuilder,
-            FlightWaypointType.SPLIT: SplitPointBuilder,
             FlightWaypointType.LANDING_POINT: LandingPointBuilder,
             FlightWaypointType.LOITER: HoldPointBuilder,
             FlightWaypointType.PATROL: RaceTrackEndBuilder,
             FlightWaypointType.PATROL_TRACK: RaceTrackBuilder,
             FlightWaypointType.PICKUP_ZONE: LandingZoneBuilder,
-            FlightWaypointType.DROPOFF_ZONE: LandingZoneBuilder,
-            FlightWaypointType.REFUEL: RefuelPointBuilder,
             FlightWaypointType.RECOVERY_TANKER: RecoveryTankerBuilder,
-            FlightWaypointType.CARGO_STOP: CargoStopBuilder,
+            FlightWaypointType.REFUEL: RefuelPointBuilder,
+            FlightWaypointType.SPLIT: SplitPointBuilder,
+            FlightWaypointType.TARGET_GROUP_LOC: TargetBuilder,
+            FlightWaypointType.TARGET_POINT: TargetBuilder,
         }
         builder = builders.get(waypoint.waypoint_type, DefaultWaypointBuilder)
         return builder(

--- a/resources/units/aircraft/F-15ESE.yaml
+++ b/resources/units/aircraft/F-15ESE.yaml
@@ -9,6 +9,7 @@ origin: USA
 price: 24
 role: Multirole Strike Fighter
 max_range: 300
+use_f15e_waypoint_names: true
 variants:
   F-15E Strike Eagle (Suite 4+): {}
 radios:


### PR DESCRIPTION
We don't need explicit configuration of initial points. The plane automatically configures any steerpoint immediately before a target point as an initial point.

Target offset points and aim points have not been implemented because I can't find any information the describes their intent.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3088.