### PR TITLE
Stop gap fix for AI speed to nav points.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Flight Planning]** Patrolling flight plans (CAS, CAP, refueling, etc) now handle TOT offsets.
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
 * **[Mission Generation]** Fix generation of OCA Runway missions to allow LGBs to be used.
+* **[Mission Generation]** Fixed AI flights flying far too slowly toward NAV points.
 * **[New Game Wizard]** Factions are reset to default after clicking "Back" to Theater Configuration screen.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.
 * **[UI]** Fixed deleting waypoints in custom flight plans deleting the wrong waypoint.

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -10,6 +10,7 @@ from dcs.unitgroup import FlyingGroup
 
 from game.ato import Flight, FlightWaypoint
 from game.ato.flightwaypointtype import FlightWaypointType
+from game.ato.traveltime import GroundSpeed
 from game.missiongenerator.missiondata import MissionData
 from game.theater import MissionTarget, TheaterUnit
 from game.unitmap import UnitMap
@@ -50,6 +51,20 @@ class PydcsWaypointBuilder:
         waypoint = self.group.add_waypoint(
             self.waypoint.position,
             self.waypoint.alt.meters,
+            # The speed we pass will be overridden for most waypoints because we'll set
+            # a TOT and leave the speed up to the AI, but for the few types of waypoints
+            # that don't have TOTs (e.g. nav points), we set a reasonable cruise speed
+            # to pydcs doesn't assign the default of 600kph ground speed (which is very
+            # slow at most altitudes).
+            #
+            # Calling GroundSpeed.for_flight isn't really a correct fix here. We ought
+            # to be using FlightPlan.speed_between_waypoints, but the way the waypoint
+            # builder is called makes it difficult to track the previous waypoint. This
+            # is probably good enough for a stop gap, and most of the flight planning
+            # code is hopefully being rewritten soon anyway.
+            #
+            # https://github.com/dcs-liberation/dcs_liberation/issues/3113
+            speed=GroundSpeed.for_flight(self.flight, self.waypoint.alt).kph,
             name=self.dcs_name_for_waypoint(),
         )
 


### PR DESCRIPTION
This isn't a great fix for the reason I mention in the comment, but it's quick and actually is accurate since it looks like we don't actually handle formation speeds correctly in most cases...

This is probably as "fixed" as this is going to get for now since most of the flight planning code is in the process of being rewritten.

https://github.com/dcs-liberation/dcs_liberation/issues/3113