### PR TITLE
Add support for ARA Veinticinco de Mayo

### DIFF
--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -27,7 +27,7 @@ from uuid import UUID
 
 from dcs.mapping import Point
 from dcs.ships import (
-    ara_vdm,
+    Ara_vdm,
     CVN_71,
     CVN_72,
     CVN_73,
@@ -1247,7 +1247,7 @@ class NavalControlPoint(ControlPoint, ABC):
         for group in self.find_main_tgo().groups:
             for u in group.units:
                 if u.alive and u.type in [
-                    ara_vdm,
+                    Ara_vdm,
                     Forrestal,
                     Hms_invincible,
                     KUZNECOW,

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -27,6 +27,7 @@ from uuid import UUID
 
 from dcs.mapping import Point
 from dcs.ships import (
+    ara_vdm,
     CVN_71,
     CVN_72,
     CVN_73,
@@ -1246,6 +1247,7 @@ class NavalControlPoint(ControlPoint, ABC):
         for group in self.find_main_tgo().groups:
             for u in group.units:
                 if u.alive and u.type in [
+                    ara_vdm,
                     Forrestal,
                     Hms_invincible,
                     KUZNECOW,

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
-git+https://github.com/pydcs/dcs@fe541426f36889d7e0275b71656f5c2db2c617ce#egg=pydcs
+git+https://github.com/pydcs/dcs@074064171cff71ea0bfb7b62fc27f89f0e6aee77#egg=pydcs
 pyinstaller==5.12.0
 pyinstaller-hooks-contrib==2022.14
 pyproj==3.4.1

--- a/resources/factions/argentina_1982.yaml
+++ b/resources/factions/argentina_1982.yaml
@@ -2,7 +2,7 @@
 country: Argentina
 name: Argentina 1982
 authors: Nosaj
-description: <p>Starter Argentina faction during falklands war for testing the ARA Vienticinco de Mayo. Using the Castle Class as a stand-in for the rest of the Argentine Navy. </p>
+description: <p>Starter Argentina faction during falklands war for testing the ARA Veinticinco de Mayo. Using the Castle Class as a stand-in for the rest of the Argentine Navy. </p>
 locales:
   - es_ES
 aircrafts:
@@ -30,7 +30,7 @@ infantry_units:
 preset_groups:
   - Roland
 naval_units:
-  - ARA Vienticinco de Mayo
+  - ARA Veinticinco de Mayo
   - Castle Class
 missiles: []
 air_defense_units:

--- a/resources/factions/argentina_1982.yaml
+++ b/resources/factions/argentina_1982.yaml
@@ -1,0 +1,40 @@
+---
+country: Argentina
+name: Argentina 1982
+authors: Nosaj
+description: <p>Starter Argentina faction during falklands war for testing the ARA Vienticinco de Mayo. Using the Castle Class as a stand-in for the rest of the Argentine Navy. </p>
+locales:
+  - es_ES
+aircrafts:
+  - A-4E Skyhawk
+  - C-130
+  - C-130J-30 Super Hercules
+  - CH-47D
+  - MB-339A
+  - UH-1H Iroquois
+awacs: []
+tankers:
+  - KC-130
+frontline_units:
+  - AAVP-7A1 'Amtrac'
+  - Scout LC with DSHK 12.7mm
+  - Scout LC with KORD 12.7mm
+artillery_units:
+  - MLRS LC with B8M1 80mm
+logistics_units:
+  - Truck M818 6x6
+infantry_units:
+  - Infantry M249
+  - Infantry M4
+  - Mortar 2B11 120mm
+preset_groups:
+  - Roland
+naval_units:
+  - ARA Vienticinco de Mayo
+  - Castle Class
+missiles: []
+air_defense_units:
+  - Bofors 40 mm Gun
+requirements: {}
+carrier_names:
+  - ARA Vienticinco de Mayo

--- a/resources/factions/argentina_1982.yaml
+++ b/resources/factions/argentina_1982.yaml
@@ -37,4 +37,4 @@ air_defense_units:
   - Bofors 40 mm Gun
 requirements: {}
 carrier_names:
-  - ARA Vienticinco de Mayo
+  - ARA Veinticinco de Mayo

--- a/resources/units/ships/ara_vdm.yaml
+++ b/resources/units/ships/ara_vdm.yaml
@@ -1,0 +1,4 @@
+class: AircraftCarrier
+price: 0
+variants:
+  ARA Vienticinco de Mayo: null

--- a/resources/units/ships/ara_vdm.yaml
+++ b/resources/units/ships/ara_vdm.yaml
@@ -1,4 +1,6 @@
 class: AircraftCarrier
 price: 0
 variants:
-  ARA Vienticinco de Mayo: null
+  ARA Vienticinco de Mayo: {}
+  ARA Veinticinco de Mayo: {}
+  HMAS Melbourne: {}


### PR DESCRIPTION
Add support for ARA Veinticinco de Mayo

Includes an Argentina 1982 faction for testing purposes, although it's sparse because of a lack of assets in DCS.

-Update - pydcs ships needs to be updated to unclude ara_vdm, once that occurs I'll try this again. Also note that the carrier is mispelled as the Vienticinco in the game.