### PR TITLE
Adds F-15E Suite 4+ to Allied Sword's custom faction

### DIFF
--- a/resources/campaigns/operation_allied_sword.yaml
+++ b/resources/campaigns/operation_allied_sword.yaml
@@ -15,6 +15,7 @@ recommended_player_faction:
     - F-4E Phantom II
     - F-15C Eagle
     - F-15E Strike Eagle
+    - F-15E Strike Eagle (Suite 4+)
     - F-16CM Fighting Falcon (Block 50)
     - F-14B Tomcat
     - F/A-18C Hornet (Lot 20)


### PR DESCRIPTION
Fuzzle's Allied Sword campaign has a custom faction in the campaign yaml, and it wasn't updated when Razbam's Mudhen was released. I've added it in.