### PR TITLE
Add a real CAS ingress point.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Data]** Added support for the ARA Veinticinco de Mayo.
 * **[Data]** Changed display name of the AI-only F-15E Strike Eagle for clarity.
 * **[Flight Planning]** Improved IP selection for targets that are near the center of a threat zone.
+* **[Flight Planning]** Moved CAS ingress point off the front line so that the AI begins their target search earlier.
 * **[Flight Planning]** Loadouts and aircraft properties can now be set per-flight member. Warning: AI flights should not use mixed loadouts.
 * **[Flight Planning]** Laser codes that are pre-assigned to weapons at mission start can now be chosen from a list in the loadout UI. This does not affect the aircraft's TGP, just the weapons. Currently only implemented for the F-15E S4+ and F-16C.
 * **[Mission Generation]** Configured target and initial points for F-15E S4+.

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -12,7 +12,6 @@ from .flightmembers import FlightMembers
 from .flightroster import FlightRoster
 from .flightstate import FlightState, Navigating, Uninitialized
 from .flightstate.killed import Killed
-from ..savecompat import has_save_compat_for
 from ..sidc import (
     Entity,
     SidcDescribable,
@@ -108,14 +107,9 @@ class Flight(SidcDescribable):
         del state["state"]
         return state
 
-    @has_save_compat_for(9)
     def __setstate__(self, state: dict[str, Any]) -> None:
         state["state"] = Uninitialized(self, state["squadron"].settings)
-        if "use_same_loadout_for_all_members" not in state:
-            state["use_same_loadout_for_all_members"] = True
         self.__dict__.update(state)
-        if isinstance(self.roster, FlightRoster):
-            self.roster = FlightMembers.from_roster(self, self.roster)
 
     @property
     def blue(self) -> bool:

--- a/game/ato/flightmember.py
+++ b/game/ato/flightmember.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from game.ato.loadouts import Loadout
 from game.lasercodes import LaserCode
-from game.savecompat import has_save_compat_for
 
 if TYPE_CHECKING:
     from game.squadrons import Pilot
@@ -18,14 +17,6 @@ class FlightMember:
         self.tgp_laser_code: LaserCode | None = None
         self.weapon_laser_code: LaserCode | None = None
         self.properties: dict[str, bool | float | int] = {}
-
-    @has_save_compat_for(9)
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        if "tgp_laser_code" not in state:
-            state["tgp_laser_code"] = None
-        if "weapon_laser_code" not in state:
-            state["weapon_laser_code"] = None
-        self.__dict__.update(state)
 
     def assign_tgp_laser_code(self, code: LaserCode) -> None:
         if self.tgp_laser_code is not None:

--- a/game/ato/flightplans/aewc.py
+++ b/game/ato/flightplans/aewc.py
@@ -90,5 +90,5 @@ class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> AewcFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> AewcFlightPlan:
         return AewcFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -152,5 +152,5 @@ class Builder(IBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> AirAssaultFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> AirAssaultFlightPlan:
         return AirAssaultFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/airlift.py
+++ b/game/ato/flightplans/airlift.py
@@ -155,5 +155,5 @@ class Builder(IBuilder[AirliftFlightPlan, AirliftLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> AirliftFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> AirliftFlightPlan:
         return AirliftFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/antiship.py
+++ b/game/ato/flightplans/antiship.py
@@ -41,5 +41,5 @@ class Builder(FormationAttackBuilder[AntiShipFlightPlan, FormationAttackLayout])
     def anti_ship_targets_for_tgo(tgo: NavalGroundObject) -> list[StrikeTarget]:
         return [StrikeTarget(f"{g.group_name} at {tgo.name}", g) for g in tgo.groups]
 
-    def build(self) -> AntiShipFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> AntiShipFlightPlan:
         return AntiShipFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/bai.py
+++ b/game/ato/flightplans/bai.py
@@ -39,5 +39,5 @@ class Builder(FormationAttackBuilder[BaiFlightPlan, FormationAttackLayout]):
 
         return self._build(FlightWaypointType.INGRESS_BAI, targets)
 
-    def build(self) -> BaiFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> BaiFlightPlan:
         return BaiFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/barcap.py
+++ b/game/ato/flightplans/barcap.py
@@ -66,5 +66,5 @@ class Builder(CapBuilder[BarCapFlightPlan, PatrollingLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> BarCapFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> BarCapFlightPlan:
         return BarCapFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/custom.py
+++ b/game/ato/flightplans/custom.py
@@ -72,5 +72,5 @@ class Builder(IBuilder[CustomFlightPlan, CustomLayout]):
         builder = WaypointBuilder(self.flight, self.coalition)
         return CustomLayout(builder.takeoff(self.flight.departure), self.waypoints)
 
-    def build(self) -> CustomFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> CustomFlightPlan:
         return CustomFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/dead.py
+++ b/game/ato/flightplans/dead.py
@@ -37,5 +37,5 @@ class Builder(FormationAttackBuilder[DeadFlightPlan, FormationAttackLayout]):
 
         return self._build(FlightWaypointType.INGRESS_DEAD)
 
-    def build(self) -> DeadFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> DeadFlightPlan:
         return DeadFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/escort.py
+++ b/game/ato/flightplans/escort.py
@@ -50,5 +50,5 @@ class Builder(FormationAttackBuilder[EscortFlightPlan, FormationAttackLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> EscortFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> EscortFlightPlan:
         return EscortFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/ferry.py
+++ b/game/ato/flightplans/ferry.py
@@ -83,5 +83,5 @@ class Builder(IBuilder[FerryFlightPlan, FerryLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> FerryFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> FerryFlightPlan:
         return FerryFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/ibuilder.py
+++ b/game/ato/flightplans/ibuilder.py
@@ -35,7 +35,7 @@ class IBuilder(ABC, Generic[FlightPlanT, LayoutT]):
     def regenerate(self, dump_debug_info: bool = False) -> None:
         try:
             self._generate_package_waypoints_if_needed(dump_debug_info)
-            self._flight_plan = self.build()
+            self._flight_plan = self.build(dump_debug_info)
         except NavMeshError as ex:
             color = "blue" if self.flight.squadron.player else "red"
             raise PlanningError(
@@ -59,11 +59,7 @@ class IBuilder(ABC, Generic[FlightPlanT, LayoutT]):
         return self.flight.departure.theater
 
     @abstractmethod
-    def layout(self) -> LayoutT:
-        ...
-
-    @abstractmethod
-    def build(self) -> FlightPlanT:
+    def build(self, dump_debug_info: bool = False) -> FlightPlanT:
         ...
 
     @property

--- a/game/ato/flightplans/ocaaircraft.py
+++ b/game/ato/flightplans/ocaaircraft.py
@@ -32,5 +32,5 @@ class Builder(FormationAttackBuilder[OcaAircraftFlightPlan, FormationAttackLayou
 
         return self._build(FlightWaypointType.INGRESS_OCA_AIRCRAFT)
 
-    def build(self) -> OcaAircraftFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> OcaAircraftFlightPlan:
         return OcaAircraftFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/ocarunway.py
+++ b/game/ato/flightplans/ocarunway.py
@@ -32,5 +32,5 @@ class Builder(FormationAttackBuilder[OcaRunwayFlightPlan, FormationAttackLayout]
 
         return self._build(FlightWaypointType.INGRESS_OCA_RUNWAY)
 
-    def build(self) -> OcaRunwayFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> OcaRunwayFlightPlan:
         return OcaRunwayFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/packagerefueling.py
+++ b/game/ato/flightplans/packagerefueling.py
@@ -121,5 +121,5 @@ class Builder(IBuilder[PackageRefuelingFlightPlan, PatrollingLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> PackageRefuelingFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> PackageRefuelingFlightPlan:
         return PackageRefuelingFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/rtb.py
+++ b/game/ato/flightplans/rtb.py
@@ -93,5 +93,5 @@ class Builder(IBuilder[RtbFlightPlan, RtbLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> RtbFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> RtbFlightPlan:
         return RtbFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/sead.py
+++ b/game/ato/flightplans/sead.py
@@ -24,5 +24,5 @@ class Builder(FormationAttackBuilder[SeadFlightPlan, FormationAttackLayout]):
     def layout(self) -> FormationAttackLayout:
         return self._build(FlightWaypointType.INGRESS_SEAD)
 
-    def build(self) -> SeadFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> SeadFlightPlan:
         return SeadFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/shiprecoverytanker.py
+++ b/game/ato/flightplans/shiprecoverytanker.py
@@ -91,5 +91,5 @@ class Builder(IBuilder[RecoveryTankerFlightPlan, RecoveryTankerLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> RecoveryTankerFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> RecoveryTankerFlightPlan:
         return RecoveryTankerFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/strike.py
+++ b/game/ato/flightplans/strike.py
@@ -32,5 +32,5 @@ class Builder(FormationAttackBuilder[StrikeFlightPlan, FormationAttackLayout]):
 
         return self._build(FlightWaypointType.INGRESS_STRIKE, targets)
 
-    def build(self) -> StrikeFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> StrikeFlightPlan:
         return StrikeFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/sweep.py
+++ b/game/ato/flightplans/sweep.py
@@ -137,5 +137,5 @@ class Builder(IBuilder[SweepFlightPlan, SweepLayout]):
             target, origin, ip, join, self.coalition, self.theater
         ).find_best_hold_point()
 
-    def build(self) -> SweepFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> SweepFlightPlan:
         return SweepFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/tarcap.py
+++ b/game/ato/flightplans/tarcap.py
@@ -122,5 +122,5 @@ class Builder(CapBuilder[TarCapFlightPlan, TarCapLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> TarCapFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> TarCapFlightPlan:
         return TarCapFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -79,5 +79,5 @@ class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):
             bullseye=builder.bullseye(),
         )
 
-    def build(self) -> TheaterRefuelingFlightPlan:
+    def build(self, dump_debug_info: bool = False) -> TheaterRefuelingFlightPlan:
         return TheaterRefuelingFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -253,21 +253,6 @@ class WaypointBuilder:
             targets=objective.strike_targets,
         )
 
-    def egress(self, position: Point, target: MissionTarget) -> FlightWaypoint:
-        alt_type: AltitudeReference = "BARO"
-        if self.is_helo:
-            alt_type = "RADIO"
-
-        return FlightWaypoint(
-            "EGRESS",
-            FlightWaypointType.EGRESS,
-            position,
-            meters(60) if self.is_helo else self.doctrine.ingress_altitude,
-            alt_type,
-            description=f"EGRESS from {target.name}",
-            pretty_name=f"EGRESS from {target.name}",
-        )
-
     def bai_group(self, target: StrikeTarget) -> FlightWaypoint:
         return self._target_point(target, f"ATTACK {target.name}")
 
@@ -356,17 +341,6 @@ class WaypointBuilder:
         else:
             waypoint.only_for_player = True
         return waypoint
-
-    def cas(self, position: Point) -> FlightWaypoint:
-        return FlightWaypoint(
-            "CAS",
-            FlightWaypointType.CAS,
-            position,
-            meters(60) if self.is_helo else meters(1000),
-            "RADIO",
-            description="Provide CAS",
-            pretty_name="CAS",
-        )
 
     @staticmethod
     def race_track_start(position: Point, altitude: Distance) -> FlightWaypoint:

--- a/game/ato/flightwaypointtype.py
+++ b/game/ato/flightwaypointtype.py
@@ -25,7 +25,7 @@ class FlightWaypointType(IntEnum):
     INGRESS_STRIKE = 5  # Ingress strike (For generator, means that this should have bombing on next TARGET_POINT points)
     INGRESS_SEAD = 6  # Ingress sead (For generator, means that this should attack groups on TARGET_GROUP_LOC points)
     INGRESS_CAS = 7  # Ingress cas (should start CAS task)
-    CAS = 8  # Should do CAS there
+    CAS = 8  # Unused.
     EGRESS = 9  # Should stop attack
     DESCENT_POINT = 10  # Should start descending to pattern alt
     LANDING_POINT = 11  # Should land there

--- a/game/ato/packagewaypoints.py
+++ b/game/ato/packagewaypoints.py
@@ -9,7 +9,7 @@ from game.ato.flightplans.waypointbuilder import WaypointBuilder
 from game.flightplan import JoinZoneGeometry
 from game.flightplan.ipsolver import IpSolver
 from game.flightplan.refuelzonegeometry import RefuelZoneGeometry
-from game.persistence.paths import liberation_user_dir
+from game.persistence.paths import waypoint_debug_directory
 from game.utils import dcs_to_shapely_point
 
 if TYPE_CHECKING:
@@ -30,8 +30,6 @@ class PackageWaypoints:
     ) -> PackageWaypoints:
         origin = package.departure_closest_to_target()
 
-        waypoint_debug_directory = liberation_user_dir() / "Debug/Waypoints"
-
         # Start by picking the best IP for the attack.
         ip_solver = IpSolver(
             dcs_to_shapely_point(origin.position),
@@ -40,7 +38,7 @@ class PackageWaypoints:
             coalition.opponent.threat_zone.all,
         )
         ip_solver.set_debug_properties(
-            waypoint_debug_directory / "IP", coalition.game.theater.terrain
+            waypoint_debug_directory() / "IP", coalition.game.theater.terrain
         )
         ingress_point_shapely = ip_solver.solve()
         if dump_debug_info:

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -35,7 +35,6 @@ from game.radio.channels import (
     ViperChannelNamer,
     WarthogChannelNamer,
 )
-from game.savecompat import has_save_compat_for
 from game.utils import (
     Distance,
     ImperialUnits,
@@ -348,12 +347,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
     def task_priority(self, task: FlightType) -> int:
         return self.task_priorities[task]
 
-    @has_save_compat_for(9)
     def __setstate__(self, state: dict[str, Any]) -> None:
-        # Save compat: the `name` field has been renamed `variant_id`.
-        if "name" in state:
-            state["variant_id"] = state.pop("name")
-
         # Update any existing models with new data on load.
         updated = AircraftType.named(state["variant_id"])
         state.update(updated.__dict__)

--- a/game/dcs/groundunittype.py
+++ b/game/dcs/groundunittype.py
@@ -11,7 +11,6 @@ from dcs.vehicles import vehicle_map
 
 from game.data.units import UnitClass
 from game.dcs.unittype import UnitType
-from game.savecompat import has_save_compat_for
 
 
 @dataclass
@@ -65,12 +64,7 @@ class GroundUnitType(UnitType[Type[VehicleType]]):
         dict[type[VehicleType], list[GroundUnitType]]
     ] = defaultdict(list)
 
-    @has_save_compat_for(9)
     def __setstate__(self, state: dict[str, Any]) -> None:
-        # Save compat: the `name` field has been renamed `variant_id`.
-        if "name" in state:
-            state["variant_id"] = state.pop("name")
-
         # Update any existing models with new data on load.
         updated = GroundUnitType.named(state["variant_id"])
         state.update(updated.__dict__)

--- a/game/dcs/shipunittype.py
+++ b/game/dcs/shipunittype.py
@@ -10,7 +10,6 @@ from dcs.unittype import ShipType
 
 from game.data.units import UnitClass
 from game.dcs.unittype import UnitType
-from game.savecompat import has_save_compat_for
 
 
 @dataclass(frozen=True)
@@ -20,12 +19,7 @@ class ShipUnitType(UnitType[Type[ShipType]]):
         list
     )
 
-    @has_save_compat_for(9)
     def __setstate__(self, state: dict[str, Any]) -> None:
-        # Save compat: the `name` field has been renamed `variant_id`.
-        if "name" in state:
-            state["variant_id"] = state.pop("name")
-
         # Update any existing models with new data on load.
         updated = ShipUnitType.named(state["variant_id"])
         state.update(updated.__dict__)

--- a/game/game.py
+++ b/game/game.py
@@ -27,7 +27,6 @@ from .infos.information import Information
 from .lasercodes.lasercoderegistry import LaserCodeRegistry
 from .persistence import SaveManager
 from .profiling import logged_duration
-from .savecompat import has_save_compat_for
 from .settings import Settings
 from .theater import ConflictTheater
 from .theater.bullseye import Bullseye
@@ -142,13 +141,8 @@ class Game:
 
         self.on_load(game_still_initializing=True)
 
-    @has_save_compat_for(9)
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
-        if not hasattr(self, "laser_code_registry"):
-            self.laser_code_registry = LaserCodeRegistry()
-            for front_line in self.theater.conflicts():
-                front_line.laser_code = self.laser_code_registry.alloc_laser_code()
         # Regenerate any state that was not persisted.
         self.on_load()
 

--- a/game/missiongenerator/aircraft/waypoints/casingress.py
+++ b/game/missiongenerator/aircraft/waypoints/casingress.py
@@ -11,9 +11,13 @@ from .pydcswaypointbuilder import PydcsWaypointBuilder
 class CasIngressBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
         if isinstance(self.flight.flight_plan, CasFlightPlan):
+            patrol_center = (
+                self.flight.flight_plan.layout.patrol_start.position
+                + self.flight.flight_plan.layout.patrol_end.position
+            ) / 2
             waypoint.add_task(
                 EngageTargetsInZone(
-                    position=self.flight.flight_plan.layout.target.position,
+                    position=patrol_center,
                     radius=int(self.flight.flight_plan.engagement_distance.meters),
                     targets=[
                         Targets.All.GroundUnits.GroundVehicles,

--- a/game/persistence/paths.py
+++ b/game/persistence/paths.py
@@ -29,3 +29,7 @@ def save_dir() -> Path:
 
 def mission_path_for(name: str) -> Path:
     return Path(base_path()) / "Missions" / name
+
+
+def waypoint_debug_directory() -> Path:
+    return liberation_user_dir() / "Debug/Waypoints"


### PR DESCRIPTION
Putting the ingress point directly on one end of the FLOT means that AI flights won't start searching and engaging targets until they reach that point. If the front line has advanced toward the flight's departure airfield, it might overfly targets on its way to the IP.

Instead, place an IP for CAS the same way we place any other IP. The AI will fly to that and start searching from there.

This also:

* Removes the midpoint waypoint, since it didn't serve any real purpose
* Names the FLOT boundary waypoints for what they actually are

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/2231.