### PR TITLE
Update up_the_coast enemy faction

### DIFF
--- a/resources/campaigns/up_the_coast.yaml
+++ b/resources/campaigns/up_the_coast.yaml
@@ -3,7 +3,7 @@ name: Caucasus - Up The Coast
 theater: Caucasus
 authors: HolyOrangeJuice, We Run Liberation
 recommended_player_faction: Bluefor Modern
-recommended_enemy_faction: Russia 1975 (Mi-24P)
+recommended_enemy_faction: Russia 1975
 description:
   <p>In this mission, it is just as important to kill the economy generating
   buildings, as it is to kill the enemy ground units. The enemy will be able to


### PR DESCRIPTION
Switch default enemy faction to Russia 1975 from the now-removed Russia 1975 (Mi-24).