### PR TITLE
Increase max distance for waypoint solver.

### DIFF
--- a/game/flightplan/waypointstrategy.py
+++ b/game/flightplan/waypointstrategy.py
@@ -188,7 +188,7 @@ class WaypointStrategy:
     def __init__(self, threat_zones: MultiPolygon) -> None:
         self.threat_zones = threat_zones
         self.prerequisites: list[Prerequisite] = []
-        self._max_area = Point(0, 0).buffer(1_000_000)
+        self._max_area = Point(0, 0).buffer(2_000_000)
         self.allowed_area = self._max_area.buffer(0)
         self.debug_infos: list[WaypointDebugInfo] = []
         self._threat_tolerance: ThreatTolerance | None = None


### PR DESCRIPTION
1000km isn't large enough in the case where there's an off-map spawn that's a long way from the target, but still in range for aircraft like the B-1. Double it, which for now is enough to fix the one pathological case we know.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3156.