### PR TITLE
address issue 3162 by applying threshold to CVN position check

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
 * **[Mission Generation]** Fix generation of OCA Runway missions to allow LGBs to be used.
 * **[Mission Generation]** Fixed AI flights flying far too slowly toward NAV points.
+* **[Mission Generation]** Fixed Recovery Tanker mission type intermittently failing due to not being able to find the CVN.
 * **[Modding]** Unit variants can now actually override base unit type properties.
 * **[New Game Wizard]** Factions are reset to default after clicking "Back" to Theater Configuration screen.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -36,7 +36,11 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
         theater_objects = self.unit_map.theater_objects
         for key, value in theater_objects.items():
             # Check name and position in case there are multiple of same carrier.
-            if name in key and value.theater_unit.position == carrier_position:
+            if (
+                name in key
+                and value.theater_unit.position.distance_to_point(carrier_position)
+                < 1.0
+            ):
                 return value.dcs_group_id
         raise RuntimeError(
             f"Could not find a carrier in the mission matching {name} at "


### PR DESCRIPTION
This PR addresses #3162 by applying a threshold on the CVN position check. In the save game provided in #3162 , the floating point comparison were failing even though the CVN was in (roughly) the same position.

This PR was tested by:

- Loading the save from #3162 in the develop branch and observing that mission generation failed
- Loading the same save using this feature branch and observing that the mission generation succeeded.