### PR TITLE
Drop old squadron rules.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Saves from 8.x are not compatible with 9.0.0.
 
 * **[Engine]** Support for DCS Open Beta 2.8.8.43489.
 * **[Campaign]** Added ferry only control points, which offer campaign designers a way to add squadrons that can be brought in after additional airfields are captured.
+* **[Campaign]** The new squadron rules (size limits, beginning the campaign at full strength) are now the default and required. The old style of unlimited squadron sizes and starting with zero aircraft has been removed.
 * **[Data]** Added support for the ARA Veinticinco de Mayo.
 * **[Data]** Changed display name of the AI-only F-15E Strike Eagle for clarity.
 * **[Flight Planning]** Improved IP selection for targets that are near the center of a threat zone.

--- a/game/coalition.py
+++ b/game/coalition.py
@@ -163,12 +163,12 @@ class Coalition:
         # is handled correctly.
         self.transfers.perform_transfers()
 
-    def preinit_turn_0(self, squadrons_start_full: bool) -> None:
+    def preinit_turn_0(self) -> None:
         """Runs final Coalition initialization.
 
         Final initialization occurs before Game.initialize_turn runs for turn 0.
         """
-        self.air_wing.populate_for_turn_0(squadrons_start_full)
+        self.air_wing.populate_for_turn_0()
 
     def initialize_turn(self, is_turn_0: bool) -> None:
         """Processes coalition-specific turn initialization.
@@ -189,7 +189,7 @@ class Coalition:
         with logged_duration("Transport planning"):
             self.transfers.plan_transports(self.game.conditions.start_time)
 
-        if not is_turn_0 or not self.game.settings.enable_squadron_aircraft_limits:
+        if not is_turn_0:
             self.plan_missions(self.game.conditions.start_time)
         self.plan_procurement()
 

--- a/game/game.py
+++ b/game/game.py
@@ -292,7 +292,7 @@ class Game:
         if self.turn > 1:
             self.conditions = self.generate_conditions()
 
-    def begin_turn_0(self, squadrons_start_full: bool) -> None:
+    def begin_turn_0(self) -> None:
         """Initialization for the first turn of the game."""
         from .sim import GameUpdateEvents
 
@@ -317,8 +317,8 @@ class Game:
                 # Rotate the whole TGO with the new heading
                 tgo.rotate(heading or tgo.heading)
 
-        self.blue.preinit_turn_0(squadrons_start_full)
-        self.red.preinit_turn_0(squadrons_start_full)
+        self.blue.preinit_turn_0()
+        self.red.preinit_turn_0()
         # TODO: Check for overfull bases.
         # We don't need to actually stream events for turn zero because we haven't given
         # *any* state to the UI yet, so it will need to do a full draw once we do.

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -254,15 +254,6 @@ class Settings:
             "this many pilots each turn up to the limit."
         ),
     )
-    # Feature flag for squadron limits.
-    enable_squadron_aircraft_limits: bool = boolean_option(
-        "Enable per-squadron aircraft limits",
-        CAMPAIGN_MANAGEMENT_PAGE,
-        PILOTS_AND_SQUADRONS_SECTION,
-        default=False,
-        remember_player_choice=True,
-        detail="If set, squadrons will be limited to a maximum number of aircraft.",
-    )
 
     # HQ Automation
     automate_runway_repair: bool = boolean_option(

--- a/game/squadrons/airwing.py
+++ b/game/squadrons/airwing.py
@@ -127,9 +127,9 @@ class AirWing:
     def squadron_at_index(self, index: int) -> Squadron:
         return list(self.iter_squadrons())[index]
 
-    def populate_for_turn_0(self, squadrons_start_full: bool) -> None:
+    def populate_for_turn_0(self) -> None:
         for squadron in self.iter_squadrons():
-            squadron.populate_for_turn_0(squadrons_start_full)
+            squadron.populate_for_turn_0()
 
     def end_turn(self) -> None:
         for squadron in self.iter_squadrons():

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -162,12 +162,11 @@ class Squadron:
         self.current_roster.extend(new_pilots)
         self.available_pilots.extend(new_pilots)
 
-    def populate_for_turn_0(self, squadrons_start_full: bool) -> None:
+    def populate_for_turn_0(self) -> None:
         if any(p.status is not PilotStatus.Active for p in self.pilot_pool):
             raise ValueError("Squadrons can only be created with active pilots.")
         self._recruit_pilots(self.settings.squadron_pilot_limit)
-        if squadrons_start_full:
-            self.owned_aircraft = self.max_size
+        self.owned_aircraft = self.max_size
 
     def end_turn(self) -> None:
         if self.destination is not None:
@@ -338,8 +337,6 @@ class Squadron:
         return self.owned_aircraft + self.pending_deliveries
 
     def has_aircraft_capacity_for(self, n: int) -> bool:
-        if not self.settings.enable_squadron_aircraft_limits:
-            return True
         remaining = self.max_size - self.owned_aircraft - self.pending_deliveries
         return remaining >= n
 

--- a/game/version.py
+++ b/game/version.py
@@ -188,4 +188,7 @@ VERSION = _build_version_string()
 #:
 #: Version 10.11
 #: * Support for ferry-only bases.
-CAMPAIGN_FORMAT_VERSION = (10, 10)
+#:
+#: Version 11.0
+#: * The squadron sizes introduced in 10.7 are required.
+CAMPAIGN_FORMAT_VERSION = (11, 0)

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -230,10 +230,7 @@ def parse_args() -> argparse.Namespace:
     new_game.add_argument(
         "--use-new-squadron-rules",
         action="store_true",
-        help=(
-            "Limit the number of aircraft per squadron and begin the campaign with "
-            "them at full strength."
-        ),
+        help="Deprecated. Does nothing.",
     )
 
     new_game.add_argument(
@@ -285,7 +282,6 @@ class CreateGameParams:
     start_date: datetime
     restrict_weapons_by_date: bool
     advanced_iads: bool
-    use_new_squadron_rules: bool
     show_air_wing_config: bool
 
     @staticmethod
@@ -303,7 +299,6 @@ class CreateGameParams:
             args.date,
             args.restrict_weapons_by_date,
             args.advanced_iads,
-            args.use_new_squadron_rules,
             args.show_air_wing_config,
         )
 
@@ -327,7 +322,6 @@ def create_game(params: CreateGameParams) -> Game:
             enable_frontline_cheats=params.cheats,
             enable_base_capture_cheat=params.cheats,
             restrict_weapons_by_date=params.restrict_weapons_by_date,
-            enable_squadron_aircraft_limits=params.use_new_squadron_rules,
         ),
         GeneratorSettings(
             start_date=params.start_date,
@@ -357,7 +351,7 @@ def create_game(params: CreateGameParams) -> Game:
     if params.show_air_wing_config:
         if AirWingConfigurationDialog(game, None).exec() == QDialog.DialogCode.Rejected:
             sys.exit("Aborted air wing configuration")
-    game.begin_turn_0(squadrons_start_full=params.use_new_squadron_rules)
+    game.begin_turn_0()
     return game
 
 

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -839,9 +839,6 @@ class AirWingConfigurationDialog(QDialog):
             tab.revert()
 
     def can_continue(self) -> bool:
-        if not self.game.settings.enable_squadron_aircraft_limits:
-            return True
-
         overfull = list(self.parking_tracker.iter_overfull())
         if not overfull:
             return True

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -163,7 +163,6 @@ class NewGameWizard(QtWidgets.QWizard):
 
         self.lua_plugin_manager.save_player_settings()
 
-        use_new_squadron_rules = self.field("use_new_squadron_rules")
         logging.info("New campaign start date: %s", start_date.strftime("%m/%d/%Y"))
         settings = Settings(
             player_income_multiplier=self.field("player_income_multiplier") / 10,
@@ -177,7 +176,6 @@ class NewGameWizard(QtWidgets.QWizard):
             ),
             automate_aircraft_reinforcements=self.field("automate_aircraft_purchases"),
             supercarrier=self.field("supercarrier"),
-            enable_squadron_aircraft_limits=use_new_squadron_rules,
         )
         settings.save_player_settings()
         generator_settings = GeneratorSettings(
@@ -235,7 +233,7 @@ class NewGameWizard(QtWidgets.QWizard):
             logging.info("Aborted air wing configuration")
             return
 
-        game.begin_turn_0(squadrons_start_full=use_new_squadron_rules)
+        game.begin_turn_0()
         GameUpdateSignal.get_instance().game_generated.emit(game)
 
         super(NewGameWizard, self).accept()
@@ -587,35 +585,6 @@ class BudgetInputs(QtWidgets.QGridLayout):
         self.addWidget(self.starting_money, 1, 1)
 
 
-class NewSquadronRulesWarning(QLabel):
-    def __init__(
-        self, campaign: Campaign | None, parent: QWidget | None = None
-    ) -> None:
-        super().__init__(parent)
-        self.set_campaign(campaign)
-
-    def set_campaign(self, campaign: Campaign | None) -> None:
-        if campaign is None:
-            self.setText("No campaign selected")
-            return
-        if campaign.version >= (10, 9):
-            text = f"{campaign.name} is compatible with the new squadron rules."
-        elif campaign.version >= (10, 7):
-            text = (
-                f"{campaign.name} has been updated since the new squadron rules were "
-                "introduced, but support for those rules was still optional. You may "
-                "need to remove, resize, or relocate squadrons before beginning the "
-                "game."
-            )
-        else:
-            text = (
-                f"{campaign.name} has not been updated since the new squadron rules. "
-                "Were introduced. You may need to remove, resize, or relocate "
-                "squadrons before beginning the game."
-            )
-        self.setText(wrap_label_text(text))
-
-
 class DifficultyAndAutomationOptions(QtWidgets.QWizardPage):
     def __init__(
         self, default_settings: Settings, current_campaign: Campaign | None, parent=None
@@ -656,22 +625,6 @@ class DifficultyAndAutomationOptions(QtWidgets.QWizardPage):
         self.registerField("enemy_starting_money", self.enemy_budget.starting_money)
         economy_layout.addLayout(self.enemy_budget)
 
-        new_squadron_rules = QtWidgets.QCheckBox("Enable new squadron rules")
-        new_squadron_rules.setChecked(default_settings.enable_squadron_aircraft_limits)
-        self.registerField("use_new_squadron_rules", new_squadron_rules)
-        economy_layout.addWidget(new_squadron_rules)
-        self.new_squadron_rules_warning = NewSquadronRulesWarning(current_campaign)
-        economy_layout.addWidget(self.new_squadron_rules_warning)
-        economy_layout.addWidget(
-            QLabel(
-                wrap_label_text(
-                    "With new squadron rules enabled, squadrons will not be able to "
-                    "exceed a maximum number of aircraft (configurable), and the "
-                    "campaign will begin with all squadrons at full strength."
-                )
-            )
-        )
-
         assist_group = QtWidgets.QGroupBox("Player assists")
         layout.addWidget(assist_group)
         assist_layout = QtWidgets.QGridLayout()
@@ -706,7 +659,6 @@ class DifficultyAndAutomationOptions(QtWidgets.QWizardPage):
         self.enemy_income.spinner.setValue(
             int(campaign.recommended_enemy_income_multiplier * 10)
         )
-        self.new_squadron_rules_warning.set_campaign(campaign)
 
 
 class PluginOptionCheckbox(QCheckBox):

--- a/resources/campaigns/battle_of_abu_dhabi.yaml
+++ b/resources/campaigns/battle_of_abu_dhabi.yaml
@@ -9,7 +9,7 @@ description:
   pushing south.</p>
 miz: battle_of_abu_dhabi.miz
 performance: 2
-version: "10.9"
+version: "11.0"
 squadrons:
   # Blue CPs:
   # The default faction is Iran, but the F-14B is given higher precedence so

--- a/resources/campaigns/black_sea.yaml
+++ b/resources/campaigns/black_sea.yaml
@@ -9,7 +9,7 @@ recommended_enemy_faction: Russia 2010
 recommended_start_date: 2004-01-07
 miz: black_sea.miz
 performance: 2
-version: "10.9"
+version: "11.0"
 squadrons:
   # Anapa-Vityazevo
   12:

--- a/resources/campaigns/caen_to_evreux.yaml
+++ b/resources/campaigns/caen_to_evreux.yaml
@@ -12,7 +12,7 @@ recommended_enemy_faction: Germany 1944
 recommended_start_date: 1944-07-04
 miz: caen_to_evreux.miz
 performance: 1
-version: "10.9"
+version: "11.0"
 squadrons:
   # Evreux
   26:
@@ -53,7 +53,7 @@ squadrons:
     - primary: OCA/Runway
       secondary: air-to-ground
       aircraft:
-        - Boston Mk.III  
+        - Boston Mk.III
         - A-20G Havoc
       size: 10
   # Ford_AF

--- a/resources/campaigns/exercise_bright_star.yaml
+++ b/resources/campaigns/exercise_bright_star.yaml
@@ -4,11 +4,20 @@ theater: Sinai
 authors: Starfire
 recommended_player_faction: Bluefor Modern
 recommended_enemy_faction: Egypt 2000s
-description: <p>For over 4 decades, the United States and Egypt have run a series of biannual joint military exercises called Bright Star. Over the years, the number of participating countries has grown substantially. Exercise Bright Star 2025 boasts 8 participant nations and 14 observer nations. The United States and a portion of the exercise coalition will play the part of a fictional hostile nation dubbed Orangeland, staging a mock invasion against Cairo. Israel, having for the first time accepted the invitation to observe, is hosting the aggressor faction of the exercise coalition at its airfields.</p>
+description:
+  <p>For over 4 decades, the United States and Egypt have run a series of
+  biannual joint military exercises called Bright Star. Over the years, the
+  number of participating countries has grown substantially. Exercise Bright
+  Star 2025 boasts 8 participant nations and 14 observer nations. The United
+  States and a portion of the exercise coalition will play the part of a
+  fictional hostile nation dubbed Orangeland, staging a mock invasion against
+  Cairo. Israel, having for the first time accepted the invitation to observe,
+  is hosting the aggressor faction of the exercise coalition at its
+  airfields.</p>
 miz: exercise_bright_star.miz
 performance: 1
 recommended_start_date: 2025-09-01
-version: "10.9"
+version: "11.0"
 squadrons:
   Blue CV-1:
     - primary: SEAD
@@ -29,7 +38,7 @@ squadrons:
       aircraft:
         - SH-60B Seahawk
       size: 2
-# Hatzerim (141)
+  # Hatzerim (141)
   7:
     - primary: Escort
       secondary: air-to-air
@@ -61,7 +70,7 @@ squadrons:
       aircraft:
         - Mirage 2000C
       size: 12
-# Kedem
+  # Kedem
   12:
     - primary: Transport
       aircraft:
@@ -72,7 +81,7 @@ squadrons:
       aircraft:
         - UH-1H Iroquois
       size: 4
-# Nevatim (106)
+  # Nevatim (106)
   8:
     - primary: AEW&C
       aircraft:
@@ -91,7 +100,7 @@ squadrons:
       aircraft:
         - A-10C Thunderbolt II (Suite 7)
       size: 8
-# Melez (30)
+  # Melez (30)
   5:
     - primary: CAS
       secondary: air-to-ground
@@ -108,7 +117,7 @@ squadrons:
       aircraft:
         - Mirage 2000C
       size: 12
-# Wadi al Jandali (72)
+  # Wadi al Jandali (72)
   13:
     - primary: AEW&C
       aircraft:
@@ -134,7 +143,7 @@ squadrons:
       aircraft:
         - SA 342L Gazelle
       size: 4
-# Cairo West (95)
+  # Cairo West (95)
   18:
     - primary: Transport
       aircraft:

--- a/resources/campaigns/exercise_vegas_nerve.yaml
+++ b/resources/campaigns/exercise_vegas_nerve.yaml
@@ -4,13 +4,20 @@ theater: Nevada
 authors: Starfire
 recommended_player_faction: USA 2005
 recommended_enemy_faction: Redfor (China) 2010
-description: <p>Welcome to Vegas Nerve, an asymmetrical Red Flag Exercise scenario. You are starting off in control of the two Tonopah airports, and will push south from there. For the duration of this exercise, Creech AFB has been cleared of all fixed wing aircraft and will function as a FARP for rotor ops. OPFOR has a substantial resource advantage and an extensive IADS. Reducing that resource advantage while degrading their IADS will be vital to a successful completion of this exercise. Good luck, Commander.</p>
+description:
+  <p>Welcome to Vegas Nerve, an asymmetrical Red Flag Exercise scenario. You are
+  starting off in control of the two Tonopah airports, and will push south from
+  there. For the duration of this exercise, Creech AFB has been cleared of all
+  fixed wing aircraft and will function as a FARP for rotor ops. OPFOR has a
+  substantial resource advantage and an extensive IADS. Reducing that resource
+  advantage while degrading their IADS will be vital to a successful completion
+  of this exercise. Good luck, Commander.</p>
 miz: exercise_vegas_nerve.miz
 performance: 1
 recommended_start_date: 2011-02-24
-version: "10.9"
+version: "11.0"
 squadrons:
-# Tonopah Airport
+  # Tonopah Airport
   17:
     - primary: TARCAP
       secondary: any
@@ -26,7 +33,7 @@ squadrons:
       aircraft:
         - E-3A
       size: 1
-# Tonopah Test Range
+  # Tonopah Test Range
   18:
     - primary: BAI
       secondary: air-to-ground
@@ -53,7 +60,7 @@ squadrons:
       aircraft:
         - UH-1H Iroquois
       size: 2
-# Groom Lake
+  # Groom Lake
   2:
     - primary: Escort
       secondary: air-to-air
@@ -65,7 +72,7 @@ squadrons:
       aircraft:
         - Su-25T Frogfoot
       size: 20
-# Creech
+  # Creech
   Creech FARP:
     - primary: CAS
       secondary: air-to-ground
@@ -77,7 +84,7 @@ squadrons:
       aircraft:
         - Mi-24P Hind-F
       size: 4
-# Nellis AFB
+  # Nellis AFB
   4:
     - primary: Strike
       secondary: air-to-ground
@@ -98,7 +105,7 @@ squadrons:
       aircraft:
         - Su-34 Fullback
       size: 20
-# Boulder City Airport
+  # Boulder City Airport
   6:
     - primary: SEAD Escort
       secondary: any

--- a/resources/campaigns/final_countdown_2.yaml
+++ b/resources/campaigns/final_countdown_2.yaml
@@ -6,8 +6,7 @@ recommended_player_faction:
   country: Combined Joint Task Forces Blue
   name: D-Day Allied Forces 1944 and 1990
   authors: Starfire
-  description:
-    <p>Faction for Final Countdown II</p>
+  description: <p>Faction for Final Countdown II</p>
   locales:
     - en_US
   aircrafts:
@@ -23,8 +22,8 @@ recommended_player_faction:
   awacs:
     - E-2C Hawkeye
   tankers:
-   - S-3B Tanker   
-  frontline_units: 
+    - S-3B Tanker
+  frontline_units:
     - A17 Light Tank Mk VII Tetrarch
     - A22 Infantry Tank MK IV Churchill VII
     - A27L Cruiser Tank MK VIII Centaur IV
@@ -47,13 +46,13 @@ recommended_player_faction:
     - CVN-74 John C. Stennis
   missiles: []
   air_defense_units:
-     - Bofors 40 mm Gun
+    - Bofors 40 mm Gun
   preset_groups:
-     - Ally Flak
+    - Ally Flak
   requirements:
     WW2 Asset Pack: https://www.digitalcombatsimulator.com/en/products/other/wwii_assets_pack/
   carrier_names:
-     - CVN-71 Theodore Roosevelt
+    - CVN-71 Theodore Roosevelt
   has_jtac: true
   jtac_unit: MQ-9 Reaper
   unrestricted_satnav: true
@@ -62,11 +61,22 @@ recommended_player_faction:
   cargo_ship: LST Mk.II
 recommended_enemy_faction: Germany 1944
 description:
-  <p>While enroute to the Persian Gulf for Operation Desert Shield, the USS Theodore Roosevelt and its carrier strike group are engufled by an electrical vortex and transported through time and space to the English channel on the morning of the Normandy Landings - June 6th 1944. Seeking to reduce the cost in lives to the Allied Forces about to storm the beaches, the captain of the Roosevelt has elected to provide air support for the landings.</p><p><strong>Note:</strong> This campaign has a custom faction that combines modern US naval forces with WW2 Allied forces. To play it as intended, you should carefully ration your use of modern aircraft and not replenish them if shot down (as you cannot get new Tomcats and Hornets in 1944). You can also choose to play it as a purely WW2 campaign by switching to one of the WW2 Ally factions.</p>
+  <p>While enroute to the Persian Gulf for Operation Desert Shield, the USS
+  Theodore Roosevelt and its carrier strike group are engufled by an electrical
+  vortex and transported through time and space to the English channel on the
+  morning of the Normandy Landings - June 6th 1944. Seeking to reduce the cost
+  in lives to the Allied Forces about to storm the beaches, the captain of the
+  Roosevelt has elected to provide air support for the
+  landings.</p><p><strong>Note:</strong> This campaign has a custom faction that
+  combines modern US naval forces with WW2 Allied forces. To play it as
+  intended, you should carefully ration your use of modern aircraft and not
+  replenish them if shot down (as you cannot get new Tomcats and Hornets in
+  1944). You can also choose to play it as a purely WW2 campaign by switching to
+  one of the WW2 Ally factions.</p>
 miz: final_countdown_2.miz
 performance: 2
 recommended_start_date: 1944-06-06
-version: "10.9"
+version: "11.0"
 squadrons:
   #Blue CV (90)
   Blue-CV:
@@ -149,11 +159,11 @@ squadrons:
         - Ju 88 A-4
       size: 8
   #Broglie (32)
-  68: 
+  68:
     - primary: Escort
       secondary: any
       aircraft:
-      - Bf 109 K-4 Kurfürst
+        - Bf 109 K-4 Kurfürst
       size: 24
   #Saint-Andre-de-lEure (30)
   70:
@@ -168,9 +178,9 @@ squadrons:
         - Ju 88 A-4
       size: 12
   #Vilacoublay (76)
-  42: 
+  42:
     - primary: BARCAP
       secondary: any
       aircraft:
-      - Fw 190 A-8 Anton
+        - Fw 190 A-8 Anton
       size: 20

--- a/resources/campaigns/golan_heights_lite.yaml
+++ b/resources/campaigns/golan_heights_lite.yaml
@@ -4,98 +4,101 @@ theater: Syria
 authors: Khopa
 recommended_player_faction: Israel 2000
 recommended_enemy_faction: Syria 2011
-description: <p>In this scenario, you start in Israel and the conflict is focused around the golan heights, an historically disputed territory.<br/><br/>This scenario is designed to be performance and helicopter friendly.</p>
+description:
+  <p>In this scenario, you start in Israel and the conflict is focused around
+  the golan heights, an historically disputed territory.<br/><br/>This scenario
+  is designed to be performance and helicopter friendly.</p>
 miz: golan_heights_lite.miz
 performance: 1
-version: "10.9"
+version: "11.0"
 advanced_iads: true # Campaign has connection_nodes / power_sources / command_centers
 iads_config:
   - LHA-1 Tarawa # A Naval Group without connections but still participating as EWR
   - Naval-2 # 2 Ship as EWR
   - CVN-74 John Stennis # Aircraft Carrier as EWR
   - Golan North-100:
-    - IADS_CN2
-    - IADS_PS4
-    - IADS_PS3
+      - IADS_CN2
+      - IADS_PS4
+      - IADS_PS3
   - Golan North-11:
-    - IADS_CN2
-    - IADS_PS3
+      - IADS_CN2
+      - IADS_PS3
   - Golan North-139:
-    - IADS_PS2
-    - IADS_CN6
+      - IADS_PS2
+      - IADS_CN6
   - Golan North-15:
-    - IADS_PS5
-    - IADS_PS6
-    - IADS_CN3
-    - IADS_CN1
+      - IADS_PS5
+      - IADS_PS6
+      - IADS_CN3
+      - IADS_CN1
   - Golan North-150:
-    - IADS_PS2
-    - IADS_CN1
-    - IADS_CN6
+      - IADS_PS2
+      - IADS_CN1
+      - IADS_CN6
   - Golan North-158:
-    - IADS_PS6
-    - IADS_CN1
+      - IADS_PS6
+      - IADS_CN1
   - Golan North-159:
-    - IADS_PS3
-    - IADS_CN4
+      - IADS_PS3
+      - IADS_CN4
   - Golan North-17:
-    - IADS_PS4
-    - IADS_CN7
-    - IADS_CN5
+      - IADS_PS4
+      - IADS_CN7
+      - IADS_CN5
   - Golan North-5:
-    - IADS_PS3
-    - IADS_CN4
+      - IADS_PS3
+      - IADS_CN4
   - Golan North-6:
-    - IADS_PS3
-    - IADS_CN4
+      - IADS_PS3
+      - IADS_CN4
   - Golan North-74:
-    - IADS_PS6
-    - IADS_CN1
+      - IADS_PS6
+      - IADS_CN1
   - Golan North-81:
-    - IADS_PS1
-    - IADS_CN6
-    - IADS_CN8
+      - IADS_PS1
+      - IADS_CN6
+      - IADS_CN8
   - Golan North-84:
-    - IADS_PS2
-    - IADS_CN6
+      - IADS_PS2
+      - IADS_CN6
   - Golan North-88:
-    - IADS_PS6
-    - IADS_PS2
-    - IADS_CN1
-    - IADS_CN6
-    - IADS_CN8
+      - IADS_PS6
+      - IADS_PS2
+      - IADS_CN1
+      - IADS_CN6
+      - IADS_CN8
   - Golan North-9:
-    - IADS_PS1
-    - IADS_CN8
+      - IADS_PS1
+      - IADS_CN8
   - Golan North-99:
-    - IADS_PS4
-    - IADS_CN7
-    - IADS_CN2
+      - IADS_PS4
+      - IADS_CN7
+      - IADS_CN2
   - Golan North-146:
-    - IADS_PS2
-    - IADS_CN6
+      - IADS_PS2
+      - IADS_CN6
   - Golan North-52:
-    - IADS_PS5
-    - IADS_CN3
-    - IADS_CN5
+      - IADS_PS5
+      - IADS_CN3
+      - IADS_CN5
   - Golan North-118:
-    - IADS_PS3
-    - IADS_CN4
+      - IADS_PS3
+      - IADS_CN4
   - Golan North-119:
-    - IADS_PS4
-    - IADS_CN7
-    - IADS_CN5
+      - IADS_PS4
+      - IADS_CN7
+      - IADS_CN5
   - Golan North-122:
-    - IADS_PS2
-    - IADS_CN6
+      - IADS_PS2
+      - IADS_CN6
   - IADS Blue Command Center:
-    - IADS_PS3
-    - IADS_CN4
-    - IADS_CN2
+      - IADS_PS3
+      - IADS_CN4
+      - IADS_CN2
   - IADS Red Command Center:
-    - IADS_PS1
-    - IADS_CN6
-    - IADS_CN8
+      - IADS_PS1
+      - IADS_CN6
+      - IADS_CN8
 squadrons:
   # Ramat-David
   30:

--- a/resources/campaigns/grabthars_hammer.yaml
+++ b/resources/campaigns/grabthars_hammer.yaml
@@ -7,16 +7,16 @@ recommended_enemy_faction: Russia 2010
 description:
   <p>An Argentinean extremist group has contracted the Sons of Warvan (SoW), an
   unusually well-equipped PMC with close ties to the Russian government, to
-  construct a beryllium bomb at the secret Omega 13 production facility in Ushaia
-  for use in its ongoing conflict with Chile. United States military forces have
-  established a foothold at San Julian. While the SoW are distracted up north, it
-  is up to the Marines to launch an assault upon Ushaia from an LHA in order to
-  disable the bomb production facility. Fortunately, Ushaia is lightly defended as
-  the SoW are trying to avoid unwanted attention.</p>
+  construct a beryllium bomb at the secret Omega 13 production facility in
+  Ushaia for use in its ongoing conflict with Chile. United States military
+  forces have established a foothold at San Julian. While the SoW are distracted
+  up north, it is up to the Marines to launch an assault upon Ushaia from an LHA
+  in order to disable the bomb production facility. Fortunately, Ushaia is
+  lightly defended as the SoW are trying to avoid unwanted attention.</p>
 miz: grabthars_hammer.miz
 performance: 2
 recommended_start_date: 1999-12-25
-version: "10.9"
+version: "11.0"
 squadrons:
   #Mount Pleasant
   2:

--- a/resources/campaigns/operation_noisy_cricket.yaml
+++ b/resources/campaigns/operation_noisy_cricket.yaml
@@ -30,7 +30,7 @@ recommended_player_money: 0
 recommended_enemy_money: 0
 recommended_player_income_multiplier: 0.2
 recommended_enemy_income_multiplier: 0.2
-version: "10.9"
+version: "11.0"
 squadrons:
   Blue CV-1:
     - primary: SEAD

--- a/resources/campaigns/operation_peace_spring.yaml
+++ b/resources/campaigns/operation_peace_spring.yaml
@@ -4,13 +4,22 @@ theater: Syria
 authors: Starfire
 recommended_player_faction: Bluefor Modern
 recommended_enemy_faction: Iraq 1991
-description: <p>This is a semi-fictional what-if scenario for Operation Peace Spring, during which Turkish forces that crossed into Syria on an offensive against Kurdish militias were emboldened by early successes to continue pushing further southward. Attempts to broker a ceasefire have failed. Members of Operation Inherent Resolve have gathered at Ramat David Airbase in Israel to launch a counter-offensive.</p><p><strong>Note:</strong> The default faction is set as Iraq 1991 in order to provide an opponent with a wider variety of units. While Turkey 2005 would be the historical faction (and has preset squadrons included), they only have two jets available (F-4 and F-16).</p>
+description:
+  <p>This is a semi-fictional what-if scenario for Operation Peace Spring,
+  during which Turkish forces that crossed into Syria on an offensive against
+  Kurdish militias were emboldened by early successes to continue pushing
+  further southward. Attempts to broker a ceasefire have failed. Members of
+  Operation Inherent Resolve have gathered at Ramat David Airbase in Israel to
+  launch a counter-offensive.</p><p><strong>Note:</strong> The default faction
+  is set as Iraq 1991 in order to provide an opponent with a wider variety of
+  units. While Turkey 2005 would be the historical faction (and has preset
+  squadrons included), they only have two jets available (F-4 and F-16).</p>
 miz: operation_peace_spring.miz
 performance: 1
 recommended_start_date: 2019-12-23
-version: "10.9"
+version: "11.0"
 squadrons:
-# Ramat David
+  # Ramat David
   30:
     - primary: CAS
       secondary: air-to-ground
@@ -31,7 +40,7 @@ squadrons:
       aircraft:
         - E-3A
       size: 2
-# King Hussein Air College
+  # King Hussein Air College
   19:
     - primary: DEAD
       secondary: any
@@ -62,7 +71,7 @@ squadrons:
       aircraft:
         - UH-1H Iroquois
       size: 2
-# Damascus
+  # Damascus
   7:
     - primary: TARCAP
       secondary: air-to-air
@@ -82,7 +91,7 @@ squadrons:
         - OH-58D Kiowa Warrior
         - Mi-24P Hind-F
       size: 8
-# Tiyas
+  # Tiyas
   39:
     - primary: SEAD
       secondary: air-to-ground
@@ -90,7 +99,7 @@ squadrons:
         - F-16CM Fighting Falcon (Block 50)
         - Su-24M Fencer-D
       size: 20
-# Abu Al Duhur
+  # Abu Al Duhur
   1:
     - primary: Strike
       secondary: air-to-ground
@@ -98,7 +107,7 @@ squadrons:
         - F-4E Phantom II
         - H-6J Badger
       size: 20
-# Gaziantep
+  # Gaziantep
   11:
     - primary: BARCAP
       secondary: any
@@ -106,7 +115,7 @@ squadrons:
         - F-16CM Fighting Falcon (Block 50)
         - MiG-29A Fulcrum-A
       size: 12
-# Incirlik
+  # Incirlik
   16:
     - primary: Strike
       secondary: air-to-ground

--- a/resources/campaigns/operation_vectrons_claw.yaml
+++ b/resources/campaigns/operation_vectrons_claw.yaml
@@ -27,7 +27,7 @@ description:
 miz: operation_vectrons_claw.miz
 performance: 1
 recommended_start_date: 2008-08-08
-version: "10.11"
+version: "11.0"
 control_points:
   From Incirlik:
     ferry_only: true


### PR DESCRIPTION
The new rules (max squadron sizes, start the campaign with full squadrons) appear to be working well, so enabling them by default and dropping the old rules.

I bumped the campaign versions for the ones that claimed support and tested a handful. All of Fuzzle's campaigns actually had the wrong version in the yaml. They claim support for this but none that I tested actually fit within the limits (despite having sizes defined).