### PR TITLE
address issue 3175 by introducing special divide by zero handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Mission Generation]** Fix generation of OCA Runway missions to allow LGBs to be used.
 * **[Mission Generation]** Fixed AI flights flying far too slowly toward NAV points.
 * **[Mission Generation]** Fixed Recovery Tanker mission type intermittently failing due to not being able to find the CVN.
+* **[Mission Generation]** Fixed "division by zero" error on mission generation when a flight has an "In-Flight" start type and starts on top of a mission waypoint.
 * **[Modding]** Unit variants can now actually override base unit type properties.
 * **[New Game Wizard]** Factions are reset to default after clicking "Back" to Theater Configuration screen.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.

--- a/game/ato/flightstate/navigating.py
+++ b/game/ato/flightstate/navigating.py
@@ -29,6 +29,11 @@ class Navigating(InFlight):
             events.update_flight_position(self.flight, self.estimate_position())
 
     def progress(self) -> float:
+        # if next waypoint is very close, assume we reach it immediately to avoid divide
+        # by zero error
+        if self.total_time_to_next_waypoint.total_seconds() < 1:
+            return 1.0
+
         return (
             self.elapsed_time.total_seconds()
             / self.total_time_to_next_waypoint.total_seconds()


### PR DESCRIPTION
This PR addresses issue #3175 by handling the scenario where `total_time_to_next_waypoint` is 0. 

This PR was tested by:
1. Recreating the scenario described in the issue in the latest `develop` build and confirming the division by 0 error can be reproduced.
2. Applying the PR and confirming that the mission is correctly generated.
3. Running the mission and observing that the tanker is orbiting the CVN group in the F10 menu.