### PR TITLE
reposition row stretch to address issue 1288

### DIFF
--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -26,15 +26,14 @@ class QHorizontalSeparationLine(QFrame):
 
 
 class FinancesLayout(QGridLayout):
-    def __init__(self, game: Game, player: bool, total_at_top: bool = False) -> None:
+    def __init__(self, game: Game, player: bool) -> None:
         super().__init__()
         self.row = itertools.count(0)
 
         income = Income(game, player)
 
-        if total_at_top:
-            self.add_total(game, income, player)
-            self.add_line()
+        self.add_total(game, income, player)
+        self.add_line()
 
         control_points = reversed(
             sorted(income.control_points, key=lambda c: c.income_per_turn)
@@ -48,9 +47,7 @@ class FinancesLayout(QGridLayout):
         for building in buildings:
             self.add_building(building)
 
-        if not total_at_top:
-            self.add_line()
-            self.add_total(game, income, player)
+        self.setRowStretch(next(self.row), 1)
 
     def add_total(self, game, income, player):
         self.add_row(

--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -59,7 +59,6 @@ class FinancesLayout(QGridLayout):
         )
         budget = game.coalition_for(player).budget
         self.add_row(middle="Balance", right=f"<b>{budget:.1f}M</b>")
-        self.setRowStretch(next(self.row), 1)
 
     def add_row(
         self,

--- a/qt_ui/windows/intel.py
+++ b/qt_ui/windows/intel.py
@@ -46,7 +46,7 @@ class ScrollingFrame(QFrame):
 class EconomyIntelTab(ScrollingFrame):
     def __init__(self, game: Game, player: bool) -> None:
         super().__init__()
-        self.addLayout(FinancesLayout(game, player=player, total_at_top=True))
+        self.addLayout(FinancesLayout(game, player=player))
 
 
 class IntelTableLayout(QGridLayout):


### PR DESCRIPTION
This PR addresses Issue #1288 by removing the row stretch. 

Before:

![Screenshot 2023-10-02 232559](https://github.com/dcs-liberation/dcs_liberation/assets/64713351/b2c91547-53dc-4d16-b710-9c981ab56cee)

After:

![Screenshot 2023-10-03 225012](https://github.com/dcs-liberation/dcs_liberation/assets/64713351/50dc7bbb-f98a-4779-aa6d-dae62b53421b)

