### PR TITLE
Basic datalink configuration.

### DIFF
--- a/game/datalink/sourcetracknumber.py
+++ b/game/datalink/sourcetracknumber.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+from game.datalink.sourcetracknumberprefix import SourceTrackNumberPrefix
+
+
+@dataclass(frozen=True)
+class SourceTrackNumber:
+    """Source track number (STN) for a flight member."""
+
+    prefix: SourceTrackNumberPrefix
+    index: int
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise ValueError("STN indexes cannot be negative")
+        if self.index >= 8:
+            raise ValueError("STN indexes must be < 8")
+
+    def __str__(self) -> str:
+        return f"{self.prefix}{self.index}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.prefix!r}, {self.index})"

--- a/game/datalink/sourcetracknumberprefix.py
+++ b/game/datalink/sourcetracknumberprefix.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SourceTrackNumberPrefix:
+    """The prefix of a source track number (STN) for a flight.
+
+    STNs are 5 octal digits. To make it easier for players to guess the codes for their
+    flight members, these are segmented so that the least significant digit is always
+    the flight member index. This wastes of the address space, but even at the lowest
+    density (single-member flights, ~88% waste), there are still enough prefixes for
+    4096 aircraft.
+
+    There is no per-package segmenting, however. DCS imposes a flight-size limitation on
+    us (usually four, sometimes fewer), but we do not restrict the number of flights
+    that can be in a package. If we were to carve out a digit for the package, we'd be
+    limiting the package to a max of eight flights. It's larger than a typical package,
+    but it's not unreasonable for a large OCA strike. If we carved out two digits, the
+    limit would be more than enough (64), but it would also limit the game to 64
+    packages. That's also quite high, but it's low enough that it could be hit. There's
+    some wiggle room here, since for now the only aircraft that need STNs are the F-16C,
+    F/A-18C, and A-10C II, but we shouldn't break in the unlikely case where the game is
+    composed entirely of those airframes.
+
+    Carving up the address space in different ways (such as two bits for the flight and
+    six for the package) would defeat the purpose of doing so, since they wouldn't be
+    recognizable prefixes for players, since these are expressed as octal in the jet.
+    """
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError("STN prefixes cannot be negative")
+        if self.value >= 0o10000:
+            raise ValueError("STN prefixes must be < 0o10000")
+
+    def __str__(self) -> str:
+        return f"{oct(self.value)[2:]:0>4}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({oct(self.value)})"

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -13,6 +13,7 @@ from dcs.unitpropertydescription import UnitPropertyDescription
 from dcs.unittype import FlyingType
 
 from game.data.units import UnitClass
+from game.dcs.datalinkconfig import DatalinkConfig
 from game.dcs.lasercodeconfig import LaserCodeConfig
 from game.dcs.unittype import UnitType
 from game.radio.channels import (
@@ -206,6 +207,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
     has_built_in_target_pod: bool
 
     laser_code_configs: list[LaserCodeConfig]
+    datalink_config: DatalinkConfig | None
 
     use_f15e_waypoint_names: bool
 
@@ -346,6 +348,9 @@ class AircraftType(UnitType[Type[FlyingType]]):
 
     def task_priority(self, task: FlightType) -> int:
         return self.task_priorities[task]
+
+    def should_alloc_stn(self) -> bool:
+        return self.datalink_config is not None
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         # Update any existing models with new data on load.
@@ -504,6 +509,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
             laser_code_configs=[
                 LaserCodeConfig.from_yaml(d) for d in data.get("laser_codes", [])
             ],
+            datalink_config=DatalinkConfig.from_data(data),
             use_f15e_waypoint_names=data.get("use_f15e_waypoint_names", False),
         )
 

--- a/game/dcs/datalinkconfig.py
+++ b/game/dcs/datalinkconfig.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DatalinkConfig:
+    max_team_members: int
+    max_donors: int
+
+    @staticmethod
+    def from_data(data: dict[str, Any]) -> DatalinkConfig | None:
+        try:
+            data = data["datalink"]
+        except KeyError:
+            return None
+        return DatalinkConfig(int(data["max_team_members"]), int(data["max_donors"]))

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from datetime import datetime
 from functools import cached_property
 from typing import Any, Dict, TYPE_CHECKING
@@ -16,6 +17,7 @@ from game.ato.flightstate import Completed
 from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.ato.starttype import StartType
+from game.datalink.sourcetracknumberprefix import SourceTrackNumberPrefix
 from game.factions.faction import Faction
 from game.missiongenerator.missiondata import MissionData
 from game.radio.radios import RadioRegistry
@@ -47,6 +49,7 @@ class AircraftGenerator:
         time: datetime,
         radio_registry: RadioRegistry,
         tacan_registry: TacanRegistry,
+        stn_prefix_allocator: Iterator[int],
         unit_map: UnitMap,
         mission_data: MissionData,
         helipads: dict[ControlPoint, StaticGroup],
@@ -57,6 +60,7 @@ class AircraftGenerator:
         self.time = time
         self.radio_registry = radio_registry
         self.tacan_registy = tacan_registry
+        self.stn_prefix_allocator = stn_prefix_allocator
         self.unit_map = unit_map
         # A list of per-package briefing data, which is in turn a list of per-flight
         # briefing data.
@@ -176,6 +180,7 @@ class AircraftGenerator:
             self.time,
             self.radio_registry,
             self.tacan_registy,
+            SourceTrackNumberPrefix(next(self.stn_prefix_allocator)),
             self.mission_data,
             dynamic_runways,
             self.use_client,

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -172,6 +172,10 @@ class AircraftGenerator:
             flight, country, self.mission, self.helipads
         ).create_flight_group()
 
+        stn_prefix: SourceTrackNumberPrefix | None = None
+        if flight.squadron.aircraft.should_alloc_stn():
+            stn_prefix = SourceTrackNumberPrefix(next(self.stn_prefix_allocator))
+
         briefing_data = FlightGroupConfigurator(
             flight,
             group,
@@ -180,7 +184,7 @@ class AircraftGenerator:
             self.time,
             self.radio_registry,
             self.tacan_registy,
-            SourceTrackNumberPrefix(next(self.stn_prefix_allocator)),
+            stn_prefix,
             self.mission_data,
             dynamic_runways,
             self.use_client,

--- a/game/missiongenerator/aircraft/flightdata.py
+++ b/game/missiongenerator/aircraft/flightdata.py
@@ -7,6 +7,7 @@ from typing import Optional, TYPE_CHECKING
 from dcs.flyingunit import FlyingUnit
 
 from game.callsigns import create_group_callsign_from_unit
+from game.datalink.sourcetracknumber import SourceTrackNumber
 
 if TYPE_CHECKING:
     from game.ato import FlightType, FlightWaypoint, Package
@@ -65,6 +66,8 @@ class FlightData:
     joker_fuel: Optional[int]
 
     laser_codes: list[Optional[int]]
+
+    source_track_numbers: list[SourceTrackNumber]
 
     custom_name: Optional[str]
 

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -42,7 +42,7 @@ class FlightGroupConfigurator:
         time: datetime,
         radio_registry: RadioRegistry,
         tacan_registry: TacanRegistry,
-        stn_prefix: SourceTrackNumberPrefix,
+        stn_prefix: SourceTrackNumberPrefix | None,
         mission_data: MissionData,
         dynamic_runways: dict[str, RunwayData],
         use_client: bool,
@@ -70,12 +70,13 @@ class FlightGroupConfigurator:
         flight_channel = self.setup_radios()
 
         laser_codes: list[Optional[int]] = []
-        stns = []
+        stns: list[SourceTrackNumber] = []
         for idx, (unit, member) in enumerate(
             zip(self.group.units, self.flight.iter_members())
         ):
             self.configure_flight_member(unit, member, laser_codes)
-            stns.append(SourceTrackNumber(self.stn_prefix, idx))
+            if self.stn_prefix is not None:
+                stns.append(SourceTrackNumber(self.stn_prefix, idx))
 
         divert = None
         if self.flight.divert is not None:

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -710,7 +710,9 @@ class PackagePage(KneeboardPage):
 
         table = []
         for flight in self.flights:
-            for idx, laser_code in enumerate(flight.laser_codes, 1):
+            for idx, (laser_code, stn) in enumerate(
+                zip(flight.laser_codes, flight.source_track_numbers), 1
+            ):
                 # Blank the flight-wide properties to make the table easier to scan.
                 if idx > 1:
                     task = ""
@@ -725,9 +727,10 @@ class PackagePage(KneeboardPage):
                         task,
                         radio,
                         "" if laser_code is None else str(laser_code),
+                        "" if stn is None else str(stn),
                     ]
                 )
-        writer.table(table, ["Aircraft", "Task", "Radio", "Laser code"])
+        writer.table(table, ["Aircraft", "Task", "Radio", "Laser code", "STN"])
 
         writer.write(path)
 

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -66,6 +66,7 @@ class MissionGenerator:
 
         self.radio_registry = RadioRegistry()
         self.tacan_registry = TacanRegistry()
+        self.stn_prefix_allocator = iter(range(0o10000))
 
         self.generation_started = False
 
@@ -259,6 +260,7 @@ class MissionGenerator:
             self.time,
             self.radio_registry,
             self.tacan_registry,
+            self.stn_prefix_allocator,
             self.unit_map,
             mission_data=air_support_generator.mission_data,
             helipads=tgo_generator.helipads,

--- a/resources/units/aircraft/F-16C_50.yaml
+++ b/resources/units/aircraft/F-16C_50.yaml
@@ -78,3 +78,6 @@ laser_codes:
         digit: 1
       - id: LaserCode1
         digit: 0
+datalink:
+  max_team_members: 8
+  max_donors: 4

--- a/resources/units/aircraft/FA-18C_hornet.yaml
+++ b/resources/units/aircraft/FA-18C_hornet.yaml
@@ -1,21 +1,21 @@
 carrier_capable: true
-description:
-  'The F/A-18C Hornet is twin engine, supersonic fighter that is flown
-  by a single pilot in a "glass cockpit". It combines extreme maneuverability , a
-  deadly arsenal of weapons, and the ability to operate from an aircraft carrier.
-  Operated by several nations, this multi-role fighter has been instrumental in conflicts
-  from 1986 to today.
+description: 'The F/A-18C Hornet is twin engine, supersonic fighter that is
+  flown by a single pilot in a "glass cockpit". It combines extreme
+  maneuverability , a deadly arsenal of weapons, and the ability to operate from
+  an aircraft carrier. Operated by several nations, this multi-role fighter has
+  been instrumental in conflicts from 1986 to today.
 
 
-  The Hornet is equipped with a large suite of sensors that includes a radar, targeting
-  pod, and a helmet mounted sight. In addition to its internal 20mm cannon, the Hornet
-  can be armed with a large assortment of unguided bombs and rockets, laser and GPS-guided
-  bombs, air-to-surface missiles of all sorts, and both radar and infrared-guided
-  air-to-air missiles.
+  The Hornet is equipped with a large suite of sensors that includes a radar,
+  targeting pod, and a helmet mounted sight. In addition to its internal 20mm
+  cannon, the Hornet can be armed with a large assortment of unguided bombs and
+  rockets, laser and GPS-guided bombs, air-to-surface missiles of all sorts, and
+  both radar and infrared-guided air-to-air missiles.
 
 
-  The Hornet is also known for its extreme, slow-speed maneuverability in a dogfight.
-  Although incredibly deadly, the Hornet is also a very easy aircraft to fly.'
+  The Hornet is also known for its extreme, slow-speed maneuverability in a
+  dogfight. Although incredibly deadly, the Hornet is also a very easy aircraft
+  to fly.'
 introduced: 1987
 manufacturer: McDonnell Douglas
 origin: USA
@@ -68,3 +68,6 @@ tasks:
   SEAD Escort: 160
   Strike: 600
   TARCAP: 450
+datalink:
+  max_team_members: 4
+  max_donors: 8

--- a/tests/datalink/test_sourcetracknumber.py
+++ b/tests/datalink/test_sourcetracknumber.py
@@ -1,0 +1,34 @@
+import pytest
+
+from game.datalink.sourcetracknumber import SourceTrackNumber
+from game.datalink.sourcetracknumberprefix import SourceTrackNumberPrefix
+
+
+def test_limits() -> None:
+    SourceTrackNumber(SourceTrackNumberPrefix(0), 0)
+    SourceTrackNumber(SourceTrackNumberPrefix(0o7777), 7)
+    with pytest.raises(ValueError):
+        SourceTrackNumber(SourceTrackNumberPrefix(0), -1)
+    with pytest.raises(ValueError):
+        SourceTrackNumber(SourceTrackNumberPrefix(0o7777), 0o10)
+
+
+def test_str() -> None:
+    assert str(SourceTrackNumber(SourceTrackNumberPrefix(0), 0)) == "00000"
+    assert str(SourceTrackNumber(SourceTrackNumberPrefix(0o123), 4)) == "01234"
+    assert str(SourceTrackNumber(SourceTrackNumberPrefix(0o7777), 7)) == "77777"
+
+
+def test_repr() -> None:
+    assert (
+        repr(SourceTrackNumber(SourceTrackNumberPrefix(0), 0))
+        == "SourceTrackNumber(SourceTrackNumberPrefix(0o0), 0)"
+    )
+    assert (
+        repr(SourceTrackNumber(SourceTrackNumberPrefix(0o123), 4))
+        == "SourceTrackNumber(SourceTrackNumberPrefix(0o123), 4)"
+    )
+    assert (
+        repr(SourceTrackNumber(SourceTrackNumberPrefix(0o7777), 7))
+        == "SourceTrackNumber(SourceTrackNumberPrefix(0o7777), 7)"
+    )

--- a/tests/datalink/test_sourcetracknumberprefix.py
+++ b/tests/datalink/test_sourcetracknumberprefix.py
@@ -1,0 +1,24 @@
+import pytest
+
+from game.datalink.sourcetracknumberprefix import SourceTrackNumberPrefix
+
+
+def test_limits() -> None:
+    SourceTrackNumberPrefix(0)
+    SourceTrackNumberPrefix(0o7777)
+    with pytest.raises(ValueError):
+        SourceTrackNumberPrefix(0o10000)
+    with pytest.raises(ValueError):
+        SourceTrackNumberPrefix(-1)
+
+
+def test_str() -> None:
+    assert str(SourceTrackNumberPrefix(0)) == "0000"
+    assert str(SourceTrackNumberPrefix(0o123)) == "0123"
+    assert str(SourceTrackNumberPrefix(0o7777)) == "7777"
+
+
+def test_repr() -> None:
+    assert repr(SourceTrackNumberPrefix(0)) == "SourceTrackNumberPrefix(0o0)"
+    assert repr(SourceTrackNumberPrefix(0o123)) == "SourceTrackNumberPrefix(0o123)"
+    assert repr(SourceTrackNumberPrefix(0o7777)) == "SourceTrackNumberPrefix(0o7777)"

--- a/tests/dcs/test_datalinkconfig.py
+++ b/tests/dcs/test_datalinkconfig.py
@@ -1,0 +1,55 @@
+import pytest
+
+from game.dcs.datalinkconfig import DatalinkConfig
+
+
+def test_from_data_no_data() -> None:
+    assert DatalinkConfig.from_data({}) is None
+
+
+def test_from_data_bad_data() -> None:
+    with pytest.raises(KeyError):
+        DatalinkConfig.from_data(
+            {
+                "datalink": {
+                    "max_team_members": 4,
+                }
+            }
+        )
+    with pytest.raises(KeyError):
+        DatalinkConfig.from_data(
+            {
+                "datalink": {
+                    "max_donors": 4,
+                }
+            }
+        )
+    with pytest.raises(ValueError):
+        DatalinkConfig.from_data(
+            {
+                "datalink": {
+                    "max_team_members": 4,
+                    "max_donors": "a",
+                }
+            }
+        )
+    with pytest.raises(ValueError):
+        DatalinkConfig.from_data(
+            {
+                "datalink": {
+                    "max_team_members": "a",
+                    "max_donors": 4,
+                }
+            }
+        )
+
+
+def test_from_data() -> None:
+    assert DatalinkConfig.from_data(
+        {
+            "datalink": {
+                "max_team_members": 4,
+                "max_donors": 8,
+            }
+        }
+    ) == DatalinkConfig(max_team_members=4, max_donors=8)


### PR DESCRIPTION
This is a stop-gap solution so we can get a release out that supports datalink as quickly as possible. It would be better to assign these early so the player can select which flights should be their team/donors, but for that we need to keep a registry in Game, plumb it through to each Flight creation (and there are many callsites for that), subscribe each flight to its datalink contacts (so disbanded flights do not remain part of a network), and of course the UI itself. That'll come later.