### PR TITLE
Add a package kneeboard page.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Flight Planning]** Loadouts and aircraft properties can now be set per-flight member. Warning: AI flights should not use mixed loadouts.
 * **[Flight Planning]** Laser codes that are pre-assigned to weapons at mission start can now be chosen from a list in the loadout UI. This does not affect the aircraft's TGP, just the weapons. Currently only implemented for the F-15E S4+ and F-16C.
 * **[Mission Generation]** Configured target and initial points for F-15E S4+.
+* **[Mission Generation]** Added a package kneeboard page that shows the radio frequencies, tasks, and laser codes for each member of your package.
 * **[Modding]** Factions can now specify the ship type to be used for cargo shipping. The Handy Wind will be used by default, but WW2 factions can pick something more appropriate.
 * **[Modding]** Unit variants can now set a display name separate from their ID.
 * **[UI]** An error will be displayed when invalid fast-forward options are selected rather than beginning a never ending simulation.

--- a/game/missiongenerator/briefinggenerator.py
+++ b/game/missiongenerator/briefinggenerator.py
@@ -56,7 +56,7 @@ class MissionInfoGenerator:
         self.game = game
         self.awacs: List[AwacsInfo] = []
         self.comms: List[CommInfo] = []
-        self.flights: List[FlightData] = []
+        self.briefing_data: list[list[FlightData]] = []
         self.jtacs: List[JtacInfo] = []
         self.tankers: List[TankerInfo] = []
         self.frontlines: List[FrontLineInfo] = []
@@ -79,13 +79,13 @@ class MissionInfoGenerator:
         """
         self.comms.append(CommInfo(name, freq))
 
-    def add_flight(self, flight: FlightData) -> None:
+    def add_package_briefing_data(self, data: list[FlightData]) -> None:
         """Adds flight info to the mission.
 
         Args:
-            flight: Flight information.
+            data: The list of briefing data for each flight in a package.
         """
-        self.flights.append(flight)
+        self.briefing_data.append(data)
 
     def add_jtac(self, jtac: JtacInfo) -> None:
         """Adds a JTAC to the mission.
@@ -177,12 +177,13 @@ class BriefingGenerator(MissionInfoGenerator):
     # TODO: This should determine if runway is friendly through a method more robust than the existing string match
     def generate_allied_flights_by_departure(self) -> None:
         """Create iterable to display allied flights grouped by departure airfield."""
-        for flight in self.flights:
-            if not flight.client_units and flight.friendly:
-                name = flight.departure.airfield_name
-                if (
-                    name in self.allied_flights_by_departure
-                ):  # where else can we get this?
-                    self.allied_flights_by_departure[name].append(flight)
-                else:
-                    self.allied_flights_by_departure[name] = [flight]
+        for package in self.briefing_data:
+            for flight in package:
+                if not flight.client_units and flight.friendly:
+                    name = flight.departure.airfield_name
+                    if (
+                        name in self.allied_flights_by_departure
+                    ):  # where else can we get this?
+                        self.allied_flights_by_departure[name].append(flight)
+                    else:
+                        self.allied_flights_by_departure[name] = [flight]

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -724,12 +724,13 @@ class KneeboardGenerator(MissionInfoGenerator):
             that aircraft.
         """
         all_flights: Dict[AircraftType, List[KneeboardPage]] = defaultdict(list)
-        for flight in self.flights:
-            if not flight.client_units:
-                continue
-            all_flights[flight.aircraft_type].extend(
-                self.generate_flight_kneeboard(flight)
-            )
+        for flights in self.briefing_data:
+            for flight in flights:
+                if not flight.client_units:
+                    continue
+                all_flights[flight.aircraft_type].extend(
+                    self.generate_flight_kneeboard(flight)
+                )
         return all_flights
 
     def generate_task_page(self, flight: FlightData) -> Optional[KneeboardPage]:

--- a/game/missiongenerator/missiondata.py
+++ b/game/missiongenerator/missiondata.py
@@ -90,7 +90,7 @@ class MissionData:
     awacs: list[AwacsInfo] = field(default_factory=list)
     runways: list[RunwayData] = field(default_factory=list)
     carriers: list[CarrierInfo] = field(default_factory=list)
-    flights: list[FlightData] = field(default_factory=list)
+    briefing_data: list[list[FlightData]] = field(default_factory=list)
     tankers: list[TankerInfo] = field(default_factory=list)
     jtacs: list[JtacInfo] = field(default_factory=list)
     logistics: list[LogisticsInfo] = field(default_factory=list)

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -281,14 +281,15 @@ class MissionGenerator:
             self.mission.country(self.game.red.country_name),
         )
 
-        for flight in aircraft_generator.flights:
-            if not flight.client_units:
-                continue
-            flight.aircraft_type.assign_channels_for_flight(
-                flight, air_support_generator.mission_data
-            )
+        for package in aircraft_generator.briefing_data:
+            for flight in package:
+                if not flight.client_units:
+                    continue
+                flight.aircraft_type.assign_channels_for_flight(
+                    flight, air_support_generator.mission_data
+                )
 
-        self.mission_data.flights = aircraft_generator.flights
+        self.mission_data.briefing_data = aircraft_generator.briefing_data
 
     def generate_destroyed_units(self) -> None:
         """Add destroyed units to the Mission"""
@@ -344,8 +345,8 @@ class MissionGenerator:
                 if jtac.blue:
                     gen.add_jtac(jtac)
 
-            for flight in mission_data.flights:
-                gen.add_flight(flight)
+            for package in mission_data.briefing_data:
+                gen.add_package_briefing_data(package)
             gen.generate()
 
     def setup_combined_arms(self) -> None:


### PR DESCRIPTION
The package page shows each flight member in the whole package. The data shown for now is the callsign, task, radio frequency, and laser code. The STN for each flight will be added once that's done.

This does generate one package page per flight. That means that packages where multiple flights have players and use the same aircraft type will have some duplicated pages, but the alternative is that some players would need to skip past all their flight members' pages to find their package page instead of having it grouped with their own.