### PR TITLE
fix a number of regressions in the flight waypoint list by changing t…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,8 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[UI]** Fixed UI bug where altering an "ahead of package" TOT offset would change the offset back to a "behind pacakge" offset.
 * **[UI]** Fixed bug where changing TOT offsets could result in flight startup times that are in the past.
 * **[UI]** Fixed odd spacing of the finance window when there were not enough items to fill the page.
+* **[UI]** Fixed regression where waypoint altitude changes in the waypoint list screen are applied to the wrong waypoint.
+* **[UI]** Fixed regression where waypoint additions in custom flight plans are not reflected until the window is reloaded. 
 
 # 8.1.0
 


### PR DESCRIPTION
…he indexing and finding a work-around to blocking of signals

This PR addresses some (but not all) recently reported issues with the waypoints screen reported in Issue #3188 . This PR was tested by:

- Changing the waypoint altitude and confirming it shows up correctly when reloading the waypoint list window and on the map
- Adding a waypoint and confirming that it shows up immediately and persists on reload
- Deleting a waypoint (except the first waypoint) and confirming that it is removed immediately and persists on reload,

Known issues: first waypoint (typically hold) cannot be deleted -- still looking into this one.