### PR TITLE
Filter out empty string CLSIDs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Data]** Allow CH-47D, CH-53E and UH-60A to operate from carriers and LHAs.
 * **[Data]** Added the F-15E's LANTIRN to the list of known targeting pods. Player F-15E flight with TGPs will now be assigned laser codes.
 * **[Flight Planning]** Patrolling flight plans (CAS, CAP, refueling, etc) now handle TOT offsets.
+* **[Loadouts]** Fixed error when loading certain DCS loadouts which contained an empty pylon (notably the Mosquito).
 * **[Mission Generation]** Restored previous AI behavior for anti-ship missions. A DCS update caused only a single aircraft in a flight to attack. The full flight will now attack like they used to.
 * **[Mission Generation]** Fix generation of OCA Runway missions to allow LGBs to be used.
 * **[Mission Generation]** Fixed AI flights flying far too slowly toward NAV points.

--- a/game/ato/loadouts.py
+++ b/game/ato/loadouts.py
@@ -134,7 +134,17 @@ class Loadout:
             pylons = payload["pylons"]
             try:
                 pylon_assignments = {
-                    p["num"]: Weapon.with_clsid(p["CLSID"]) for p in pylons.values()
+                    p["num"]: Weapon.with_clsid(p["CLSID"])
+                    for p in pylons.values()
+                    # When unloading incompatible pylons (for example, some of the
+                    # Mosquito's pylons cannot be loaded when other pylons are carrying
+                    # rockets), DCS sometimes equips the empty string rather than
+                    # unsetting the pylon. An unset pylon and the empty string appear to
+                    # have identical behavior, and it's annoying to deal with weapons
+                    # that pydcs doesn't know about, so just clear those pylons rather
+                    # than explicitly handling "".
+                    # https://github.com/dcs-liberation/dcs_liberation/issues/3171
+                    if p["CLSID"] != ""
                 }
             except KeyError:
                 logging.exception(


### PR DESCRIPTION
There's more detail in the comment, but this fixes an issue where some Mosquito loadouts could not be loaded.

Might fix https://github.com/dcs-liberation/dcs_liberation/issues/3171. There aren't enough instructions in the bug for me to be sure, but it sounds like a similar problem, although I came across it with bombs rather than rockets.