### PR TITLE
S3 Viking mission type and loadout update

### DIFF
--- a/resources/customized_payloads/S-3B.lua
+++ b/resources/customized_payloads/S-3B.lua
@@ -2,63 +2,49 @@ local unitPayloads = {
 	["name"] = "S-3B",
 	["payloads"] = {
 		[1] = {
-			["name"] = "SEAD",
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
-					["num"] = 1,
+					["CLSID"] = "{B83CB620-5BBE-4BEA-910C-EB605A327EF9}",
+					["num"] = 6,
 				},
 				[2] = {
-					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
-					["num"] = 2,
+					["CLSID"] = "{B83CB620-5BBE-4BEA-910C-EB605A327EF9}",
+					["num"] = 1,
 				},
 				[3] = {
 					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
-					["num"] = 3,
+					["num"] = 2,
 				},
 				[4] = {
 					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
-					["num"] = 4,
+					["num"] = 3,
 				},
 				[5] = {
 					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
-					["num"] = 5,
+					["num"] = 4,
 				},
 				[6] = {
-					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
-					["num"] = 6,
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 5,
 				},
 			},
 			["tasks"] = {
-				[1] = 29,
+				[1] = 30,
 			},
 		},
 		[2] = {
-			["name"] = "ANTISHIP",
+			["displayName"] = "Liberation DEAD",
+			["name"] = "Liberation DEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{8B7CADF9-4954-46B3-8CFB-93F2F5B90B03}",
-					["num"] = 1,
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 6,
 				},
 				[2] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{8B7CADF9-4954-46B3-8CFB-93F2F5B90B03}",
-					["num"] = 6,
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -66,52 +52,119 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Liberation Anti-ship",
+			["name"] = "Liberation Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 1,
+					["CLSID"] = "{8B7CADF9-4954-46B3-8CFB-93F2F5B90B03}",
+					["num"] = 6,
 				},
 				[2] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 6,
+					["CLSID"] = "{8B7CADF9-4954-46B3-8CFB-93F2F5B90B03}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
-				[1] = 32,
-				[1] = 33,
+				[1] = 30,
 			},
 		},
 		[4] = {
-			["name"] = "CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}",
+					["CLSID"] = "{444BA8AE-82A7-4345-842E-76154EFCCA46}",
+					["num"] = 6,
+				},
+				[2] = {
+					["CLSID"] = "{444BA8AE-82A7-4345-842E-76154EFCCA46}",
 					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 30,
+			},
+		},
+		[5] = {
+			["displayName"] = "Liberation BAI",
+			["name"] = "Liberation BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 6,
+				},
+				[2] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 3,
+				},
+				[6] = {
+					["CLSID"] = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 30,
+			},
+		},
+		[6] = {
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
+					["num"] = 6,
+				},
+				[2] = {
+					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 30,
+			},
+		},
+		[7] = {
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{BCE4E030-38E9-423E-98ED-24BE3DA87C32}",
+					["num"] = 6,
 				},
 				[2] = {
 					["CLSID"] = "{BCE4E030-38E9-423E-98ED-24BE3DA87C32}",
-					["num"] = 2,
+					["num"] = 1,
 				},
 				[3] = {
 					["CLSID"] = "{BCE4E030-38E9-423E-98ED-24BE3DA87C32}",
-					["num"] = 3,
+					["num"] = 5,
 				},
 				[4] = {
 					["CLSID"] = "{BCE4E030-38E9-423E-98ED-24BE3DA87C32}",
@@ -119,49 +172,19 @@ local unitPayloads = {
 				},
 				[5] = {
 					["CLSID"] = "{BCE4E030-38E9-423E-98ED-24BE3DA87C32}",
-					["num"] = 5,
+					["num"] = 3,
 				},
 				[6] = {
-					["CLSID"] = "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}",
-					["num"] = 6,
+					["CLSID"] = "{BCE4E030-38E9-423E-98ED-24BE3DA87C32}",
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
-				[1] = 31,
+				[1] = 30,
 			},
 		},
 	},
-	[5] = {
-		["name"] = "RUNWAY_ATTACK",
-		["pylons"] = {
-			[1] = {
-				["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-				["num"] = 1,
-			},
-			[2] = {
-				["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-				["num"] = 2,
-			},
-			[3] = {
-				["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-				["num"] = 3,
-			},
-			[4] = {
-				["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-				["num"] = 4,
-			},
-			[5] = {
-				["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-				["num"] = 5,
-			},
-			[6] = {
-				["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-				["num"] = 6,
-			},
-		},
-		["tasks"] = {
-			[1] = 34,
-		},
+	["tasks"] = {
 	},
 	["unitType"] = "S-3B",
 }

--- a/resources/units/aircraft/S-3B.yaml
+++ b/resources/units/aircraft/S-3B.yaml
@@ -22,6 +22,7 @@ tasks:
   Anti-ship: 50
   BAI: 570
   CAS: 570
+  DEAD: 100
   OCA/Aircraft: 570
   OCA/Runway: 370
   Strike: 370


### PR DESCRIPTION
Updates the S3 Viking so they can now do DEAD (since the new model can carry SLAMs). Also updates the loadouts for all the other mission types as they are outdated (2000 pounders for anti-runway, 500 pounders for strike, Mavericks for BAI/CAS, etc).