### PR TITLE
Fix task priority script for display name split.

### DIFF
--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -400,7 +400,7 @@ def dump_task_priorities() -> None:
     data: dict[str, dict[str, int]] = {}
     for task in FlightType:
         data[task.value] = {
-            a.name: a.task_priority(task)
+            a.display_name: a.task_priority(task)
             for a in AircraftType.priority_list_for_task(task)
         }
 


### PR DESCRIPTION
`name` was split into an ID and a display name a while back, but this was never updated to account for that.