### PR TITLE
Update DEAD task priority

### DIFF
--- a/resources/units/aircraft/S-3B.yaml
+++ b/resources/units/aircraft/S-3B.yaml
@@ -22,7 +22,7 @@ tasks:
   Anti-ship: 50
   BAI: 570
   CAS: 570
-  DEAD: 100
+  DEAD: 200
   OCA/Aircraft: 570
   OCA/Runway: 370
   Strike: 370


### PR DESCRIPTION
Bumping from 100 to 200 so it's preferred over WW2 aircraft but less preferred than B-52.