### PR TITLE
Add F-4E to Egypt 2000 faction

### DIFF
--- a/resources/factions/egypt_2000.yaml
+++ b/resources/factions/egypt_2000.yaml
@@ -7,8 +7,9 @@ locales:
   - ar_SA
 aircrafts:
   - MiG-29S Fulcrum-C
-  - J-7B
+  - MiG-21bis Fishbed-N
   - Mirage 2000C
+  - F-4E Phantom II
   - F-16CM Fighting Falcon (Block 50)
   - IL-76MD
   - C-130


### PR DESCRIPTION
Add F-4E Phantom II to Egypt 2000 faction as they were in active service until 2014.