### PR TITLE
Add naval vessels to Egypt faction

### DIFF
--- a/resources/factions/egypt_2000.yaml
+++ b/resources/factions/egypt_2000.yaml
@@ -62,6 +62,10 @@ preset_groups:
   - SA-23/S-300VM
   - Patriot
   - Hawk
+naval_units:
+  - FFG Oliver Hazard Perry
+  - Corvette 1241.1 Molniya
+  - FAC La Combattante IIa
 missiles:
   - SSM SS-1C Scud-B
 air_defense_units:


### PR DESCRIPTION
Adds several naval vessels to the Egypt faction.

Oliver Hazard Perry frigate (Egypt has 4)
Molniya missile frigate (Egypt has 1)
FAC La Combattante IIa (Egypt has 5 ships of the same class)