### PR TITLE
Add support for DCS 2.9's AI unlimited fuel.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Flight Planning]** Laser codes that are pre-assigned to weapons at mission start can now be chosen from a list in the loadout UI. This does not affect the aircraft's TGP, just the weapons. Currently only implemented for the F-15E S4+ and F-16C.
 * **[Mission Generation]** Configured target and initial points for F-15E S4+.
 * **[Mission Generation]** Added a package kneeboard page that shows the radio frequencies, tasks, and laser codes for each member of your package.
+* **[Mission Generation]** Added option to generate AI flights with unlimited fuel (enabled by default).
 * **[Modding]** Factions can now specify the ship type to be used for cargo shipping. The Handy Wind will be used by default, but WW2 factions can pick something more appropriate.
 * **[Modding]** Unit variants can now set a display name separate from their ID.
 * **[Modding]** Updated Community A-4E-C mod version support to 2.2.0 release.

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -58,7 +58,9 @@ class FlightGroupConfigurator:
         self.unit_map = unit_map
 
     def configure(self) -> FlightData:
-        AircraftBehavior(self.flight.flight_type).apply_to(self.flight, self.group)
+        AircraftBehavior(self.flight.flight_type, self.game.settings).apply_to(
+            self.flight, self.group
+        )
         AircraftPainter(self.flight, self.group).apply_livery()
         self.setup_props()
         self.setup_payloads()

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -339,6 +339,18 @@ class Settings:
     )
 
     # Gameplay
+    ai_has_unlimited_fuel: bool = boolean_option(
+        "Unlimited fuel for AI flights",
+        page=MISSION_GENERATOR_PAGE,
+        section=GAMEPLAY_SECTION,
+        default=True,
+        detail=(
+            "If enabled, AI-only flights will have unlimited fuel. This can be "
+            "disabled to force AI flights to play by the same rules as players, but be "
+            "warned that the DCS AI is not particularly fuel conscious, so will often "
+            "run out of fuel when players would not."
+        ),
+    )
     fast_forward_to_first_contact: bool = boolean_option(
         "Fast forward mission to first contact (WIP)",
         page=MISSION_GENERATOR_PAGE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==2.21.0
 pydantic==1.10.7
-git+https://github.com/pydcs/dcs@df2d4f29b2297280f6bb8d46dead468479b700d0#egg=pydcs
+git+https://github.com/pydcs/dcs@f8232606a21eaef82af7ba78c2013403da4a86f5#egg=pydcs
 pyinstaller==5.13.0
 pyinstaller-hooks-contrib==2023.6
 pyproj==3.4.1


### PR DESCRIPTION
This is enabled by default because I can't think of a time where it's ever been more fun to watch the AI run out of fuel after cycling between afterburner and speedbrake for twenty minutes.

This is only lightly tested (I verified that the task shows up appropriately in the ME when set, not when unset, and never for players), since the interesting part of the implementation is up to ED.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3201.