### PR TITLE
Fix allocation range for Link 4.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@ Saves from 8.x are not compatible with 9.0.0.
 * **[Mission Generation]** Fixed "division by zero" error on mission generation when a flight has an "In-Flight" start type and starts on top of a mission waypoint.
 * **[Mission Generation]** Fixed flights not being selectable in the mission editor if fast-forward was used and they were generated at a waypoint that had a fixed TOT (such as a BARCAP that was on-station).
 * **[Mission Generation]** Fixed error when planning TARCAPs on the sole remaining enemy airfield.
+* **[Mission Generation]** Fixed allocation range for carrier Link 4 datalink.
 * **[Modding]** Unit variants can now actually override base unit type properties.
 * **[New Game Wizard]** Factions are reset to default after clicking "Back" to Theater Configuration screen.
 * **[Plugins]** Fixed Lua errors in Skynet plugin that would occur whenever one coalition had no IADS nodes.

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -446,7 +446,7 @@ class GenericCarrierGenerator(GroundObjectGenerator):
                 icls = next(self.icls_alloc)
                 link4 = None
                 if carrier_type in [Stennis, CVN_71, CVN_72, CVN_73, CVN_75]:
-                    link4 = self.radio_registry.alloc_uhf()
+                    link4 = self.radio_registry.alloc_link4()
                 self.activate_beacons(ship_group, tacan, tacan_callsign, icls, link4)
                 self.add_runway_data(
                     brc or Heading.from_degrees(0), atc, tacan, tacan_callsign, icls

--- a/game/radio/radios.py
+++ b/game/radio/radios.py
@@ -337,11 +337,13 @@ class RadioRegistry:
         "BLUFOR UHF", (RadioRange(MHz(225), MHz(400), MHz(1), Modulation.AM),)
     )
 
+    LINK_4 = Radio("Link 4", (RadioRange(MHz(300), MHz(325), kHz(100), Modulation.AM),))
+
     def __init__(self) -> None:
         self.allocated_channels: Set[RadioFrequency] = set()
         self.radio_allocators: Dict[Radio, Iterator[RadioFrequency]] = {}
 
-        radios = itertools.chain(RADIOS, [self.BLUFOR_UHF])
+        radios = itertools.chain(RADIOS, [self.BLUFOR_UHF, self.LINK_4])
         for radio in radios:
             self.radio_allocators[radio] = radio.range()
 
@@ -385,6 +387,9 @@ class RadioRegistry:
                 already allocated.
         """
         return self.alloc_for_radio(self.BLUFOR_UHF)
+
+    def alloc_link4(self) -> RadioFrequency:
+        return self.alloc_for_radio(self.LINK_4)
 
     def reserve(self, frequency: RadioFrequency) -> None:
         """Reserves the given channel.


### PR DESCRIPTION
Prior to DCS 2.9 Jester was able to use datalink frequencies outside the range the aircraft was capable of, but this has presumably always been broken for human RIOs.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3222.