### PR TITLE
Remove AI F-15E from Starfire's campaigns

### DIFF
--- a/resources/campaigns/exercise_bright_star.yaml
+++ b/resources/campaigns/exercise_bright_star.yaml
@@ -27,7 +27,7 @@ squadrons:
       size: 24
     - primary: AEW&C
       aircraft:
-        - E-2C Hawkeye
+        - E-2D Advanced Hawkeye
       size: 2
     - primary: Refueling
       aircraft:
@@ -55,12 +55,7 @@ squadrons:
       secondary: any
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
-      size: 8
-    - primary: Strike
-      secondary: any
-      aircraft:
-        - F-15E Strike Eagle
-      size: 8
+      size: 16
     - primary: DEAD
       secondary: any
       aircraft:

--- a/resources/campaigns/final_countdown_2.yaml
+++ b/resources/campaigns/final_countdown_2.yaml
@@ -19,6 +19,7 @@ recommended_player_faction:
     - F-14B Tomcat
     - F/A-18C Hornet (Lot 20)
     - S-3B Viking
+    - UH-60L
     - UH-60A
   awacs:
     - E-2C Hawkeye
@@ -107,8 +108,9 @@ squadrons:
     - primary: Air Assault
       secondary: any
       aircraft:
+        - UH-60L
         - UH-60A
-      size: 4
+      size: 6
   #Stoney Cross (39)
   58:
     - primary: OCA/Runway

--- a/resources/campaigns/grabthars_hammer.yaml
+++ b/resources/campaigns/grabthars_hammer.yaml
@@ -35,11 +35,6 @@ squadrons:
       aircraft:
         - F-15C Eagle
       size: 8
-    - primary: BAI
-      secondary: air-to-ground
-      aircraft:
-        - F-15E Strike Eagle
-      size: 8
     - primary: Refueling
       aircraft:
         - KC-135 Stratotanker
@@ -90,12 +85,12 @@ squadrons:
         - AV-8B Harrier II Night Attack
       size: 18
     - primary: Air Assault
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - UH-1H Iroquois
       size: 2
   Bombers from Edwards AFB:
-    - primary: DEAD
+    - primary: Strike
       secondary: air-to-ground
       aircraft:
         - B-52H Stratofortress

--- a/resources/campaigns/operation_noisy_cricket.yaml
+++ b/resources/campaigns/operation_noisy_cricket.yaml
@@ -40,7 +40,7 @@ squadrons:
       size: 40
     - primary: AEW&C
       aircraft:
-        - E-2C Hawkeye
+        - E-2D Advanced Hawkeye
       size: 2
     - primary: Refueling
       aircraft:
@@ -49,7 +49,8 @@ squadrons:
     - primary: Air Assault
       secondary: any
       aircraft:
-        - SH-60B Seahawk
+        - UH-60L
+        - UH-60A
       size: 4
   #Al Minhad AFB (61)
   12:
@@ -78,12 +79,12 @@ squadrons:
       secondary: any
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
-      size: 8
-    - primary: BAI
+      size: 20
+    - primary: DEAD
       secondary: air-to-ground
       aircraft:
-        - F-15E Strike Eagle
-      size: 12
+        - AV-8B Harrier II Night Attack
+      size: 20
   #Bandar Abbas Intl (51)
   2:
     - primary: SEAD

--- a/resources/campaigns/operation_peace_spring.yaml
+++ b/resources/campaigns/operation_peace_spring.yaml
@@ -32,7 +32,7 @@ squadrons:
       size: 20
     - primary: AEW&C
       aircraft:
-        - E-2C Hawkeye
+        - E-2D Advanced Hawkeye
       size: 4
     - primary: Refueling
       aircraft:
@@ -55,12 +55,7 @@ squadrons:
       secondary: any
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
-      size: 4
-    - primary: OCA/Aircraft
-      secondary: any
-      aircraft:
-        - F-15E Strike Eagle
-      size: 8
+      size: 12
     - primary: TARCAP
       secondary: air-to-air
       aircraft:

--- a/resources/campaigns/operation_vectrons_claw.yaml
+++ b/resources/campaigns/operation_vectrons_claw.yaml
@@ -59,6 +59,7 @@ squadrons:
     - primary: Air Assault
       secondary: any
       aircraft:
+        - UH-60L
         - UH-60A
       size: 2
   Blue LHA:
@@ -83,31 +84,11 @@ squadrons:
       aircraft:
         - F-16CM Fighting Falcon (Block 50)
       size: 16
-    - primary: DEAD
-      secondary: any
-      aircraft:
-        - F-16CM Fighting Falcon (Block 50)
-      size: 16
     - primary: BAI
       secondary: any
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
       size: 8
-    - primary: BAI
-      secondary: air-to-ground
-      aircraft:
-        - F-15E Strike Eagle
-      size: 8
-    - primary: Strike
-      secondary: air-to-ground
-      aircraft:
-        - B-1B Lancer
-      size: 4
-    - primary: Strike
-      secondary: air-to-ground
-      aircraft:
-        - B-52H Stratofortress
-      size: 4
     - primary: Refueling
       aircraft:
         - KC-135 Stratotanker


### PR DESCRIPTION
Now that the F-15E Suite 4+ has JDAMs and the bug preventing AI from using LGBs has been fixed, I have removed the AI-only F-15Es from my campaigns. Also minor tweaks to a couple of squadron types/sizes based on play-testing results.