### PR TITLE
Renumber flight members for meatbags.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ Saves from 9.x are not compatible with 10.0.0.
 
 ## Fixes
 
+* **[UI]** Flight members in the loadout menu are now numbered starting from 1 instead of 0.
+
 # 9.0.0
 
 Saves from 8.x are not compatible with 9.0.0.

--- a/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
+++ b/qt_ui/windows/mission/flight/payload/QFlightPayloadTab.py
@@ -38,12 +38,12 @@ class FlightMemberSelector(QSpinBox):
     def __init__(self, flight: Flight, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.flight = flight
-        self.setMinimum(0)
-        self.setMaximum(flight.count - 1)
+        self.setMinimum(1)
+        self.setMaximum(flight.count)
 
     @property
     def selected_member(self) -> FlightMember:
-        return self.flight.roster.members[self.value()]
+        return self.flight.roster.members[self.value() - 1]
 
 
 class QFlightPayloadTab(QFrame):


### PR DESCRIPTION
Puny humans count wrong, but we ought to match DCS.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3244.