### PR TITLE
Fix disappearing aircraft when deleting packages.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Saves from 9.x are not compatible with 10.0.0.
 
 ## Fixes
 
+* **[Flight Planning]** Aircraft from even numbered flights will no longer become inaccessible when canceling a draft package.
 * **[UI]** Flight members in the loadout menu are now numbered starting from 1 instead of 0.
 
 # 9.0.0

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -288,7 +288,7 @@ class AtoModel(QAbstractListModel):
                     return
 
                 package_model = self.find_matching_package_model(package)
-                for flight in package.flights:
+                for flight in list(package.flights):
                     if flight.state.cancelable:
                         package_model.delete_flight(flight)
                         events.delete_flight(flight)

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -261,7 +261,7 @@ class QNewPackageDialog(QPackageDialog):
 
     def on_cancel(self) -> None:
         super().on_cancel()
-        for flight in self.package_model.package.flights:
+        for flight in list(self.package_model.package.flights):
             self.package_model.cancel_or_abort_flight(flight)
 
 


### PR DESCRIPTION
There are a few different code paths for deleting packages depending on the state of the package, and two of them were deleting items from a list they were iterating over without first making a copy, causing each iteration of the loop to skip over a flight, making it still used since the flight was never deleted, but unreachable since the package that owned it was deleted.

This only happened when the package was canceled in its draft state (the user clicked the X without ever saving the package), or if the user canceled a package mid fast forward (the controls for which aren't even visible to users) while only a portion of the package was active. In both cases, only even numbered flights were lost.

There's a better fix lurking in here somewhere but the interaction with the Qt model complicates it. Fortunately that mess would be cleaned up automatically by moving this dialog into React, which we'll do some day.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3257. Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3258.