### PR TITLE
Downgrade pyinstaller.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,8 @@ pydantic==2.5.2
 pydantic-settings==2.1.0
 pydantic_core==2.14.5
 pydcs @ git+https://github.com/pydcs/dcs@05ebda06cbe77b09b2b0fae915993caaa30c81bd
-pyinstaller==6.2.0
-pyinstaller-hooks-contrib==2023.10
+pyinstaller==5.13.0
+pyinstaller-hooks-contrib==2023.6
 pyproj==3.6.1
 PySide6==6.6.0
 PySide6-Addons==6.6.0


### PR DESCRIPTION
I forgot to test the pyinstaller binary when I upgraded all the other dependencies, and there's a breaking change in 6.0.0:

https://pyinstaller.org/en/latest/CHANGES.html#incompatible-changes

> All of onedir build's contents except for the executable are now moved
> into a sub-directory (called _internal by default). sys._MEIPASS is
> adjusted to point to this _internal directory. The breaking
> implications for this are:
>
> * Assumptions that os.path.dirname(sys.executable) == sys._MEIPASS
>   will break. Code locating application resources using
>   os.path.dirname(sys.executable) should be adjusted to use __file__
>   or sys._MEIPASS and any code locating the original executable using
>   sys._MEIPASS should use sys.executable directly.
> * Any custom post processing steps (either in the .spec file or
>   externally) which modify the bundle will likely need adjusting to
>   accommodate the new directory.

This is actually great because it declutters the top level directory to just `dcs_liberation.exe` and a directory named `_internal` that has all the guts, but the CWD is no longer the directory that has `resources/` in it, so we can't find any of our resources. There are a few options for fixing that (cd into that directory probably being the easiest, or we could stop relying on CWD relative paths), but for now just downgrade to unbreak the build.