### PR TITLE
Revert "Update to Python 3.12."

### DIFF
--- a/.github/actions/setup-liberation-python/action.yaml
+++ b/.github/actions/setup-liberation-python/action.yaml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.12"
+        python-version: "3.11"
         cache: pip
 
     - name: Install environment

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
 
 sphinx:
   configuration: docs/conf.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,6 @@ python-dateutil==2.8.2
 python-dotenv==1.0.0
 pywin32-ctypes==0.2.2
 PyYAML==6.0.1
-setuptools==69.0.2
 shapely==2.0.2
 shiboken6==6.6.0
 six==1.16.0


### PR DESCRIPTION
Might fix https://github.com/dcs-liberation/dcs_liberation/issues/3276. If not, we need to revert the Qt upgrade too, and if we downgrade Qt we can't use Python 3.12 anyway.

This reverts commit 65eb10639b36e71168931dad601836b77ec90bbe.