### PR TITLE
Fix a few more Pydantic conversions.

### DIFF
--- a/game/server/controlpoints/models.py
+++ b/game/server/controlpoints/models.py
@@ -28,7 +28,7 @@ class ControlPointJs(BaseModel):
     def for_control_point(control_point: ControlPoint) -> ControlPointJs:
         destination = None
         if control_point.target_position is not None:
-            destination = control_point.target_position.latlng()
+            destination = LeafletPoint.from_pydcs(control_point.target_position)
         return ControlPointJs(
             id=control_point.id,
             name=control_point.name,

--- a/game/server/iadsnetwork/models.py
+++ b/game/server/iadsnetwork/models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
+
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from game.server.leaflet import LeafletPoint
 from game.theater.iadsnetwork.iadsnetwork import IadsNetworkNode, IadsNetwork
-from game.theater.theatergroundobject import TheaterGroundObject
 
 
 class IadsConnectionJs(BaseModel):
@@ -45,8 +45,8 @@ class IadsConnectionJs(BaseModel):
                 IadsConnectionJs(
                     id=id,
                     points=[
-                        tgo.position.latlng(),
-                        connection.ground_object.position.latlng(),
+                        LeafletPoint.from_pydcs(tgo.position),
+                        LeafletPoint.from_pydcs(connection.ground_object.position),
                     ],
                     node=tgo.id,
                     connected=connection.ground_object.id,


### PR DESCRIPTION
One of the newer versions got a lot more strict. It now only expects dicts that match the model, or objects of the model. Previously it also accepted objects which had the same properties as the model. Convert a few more LatLngs to LeafletPoints.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3279.