### PR TITLE
Improve F-15E S4+ loadouts

### DIFF
--- a/resources/customized_payloads/F-15ESE.lua
+++ b/resources/customized_payloads/F-15ESE.lua
@@ -2,8 +2,7 @@ local unitPayloads = {
 	["name"] = "F-15ESE",
 	["payloads"] = {
 		[1] = {
-			["displayName"] = "Liberation TARCAP",
-			["name"] = "Liberation TARCAP",
+			["name"] = "Liberation BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
@@ -63,52 +62,44 @@ local unitPayloads = {
 			},
 		},
 		[2] = {
-			["displayName"] = "Liberation Strike",
-			["name"] = "Liberation Strike",
+			["displayName"] = "Liberation OCA/Runway",
+			["name"] = "Liberation OCA/Runway",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
 					["num"] = 15,
 				},
 				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[3] = {
 					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
 					["num"] = 13,
 				},
-				[4] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
+				[3] = {
+					["CLSID"] = "{CFT_R_BLU107_x_6}",
+					["num"] = 12,
 				},
-				[5] = {
+				[4] = {
 					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
 					["num"] = 9,
 				},
-				[6] = {
-					["CLSID"] = "{GBU-38}",
-					["num"] = 8,
-				},
-				[7] = {
+				[5] = {
 					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
 					["num"] = 7,
 				},
-				[8] = {
-					["CLSID"] = "{CFT_L_GBU_38_x_3}",
+				[6] = {
+					["CLSID"] = "{CFT_L_BLU107_x_6}",
 					["num"] = 4,
 				},
+				[7] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
 				[9] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{CFT_R_GBU_38_x_3}",
-					["num"] = 12,
-				},
-				[11] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -116,52 +107,60 @@ local unitPayloads = {
 			},
 		},
 		[3] = {
-			["displayName"] = "Liberation CAS",
-			["name"] = "Liberation CAS",
+			["displayName"] = "Liberation TARCAP",
+			["name"] = "Liberation TARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
 					["num"] = 15,
 				},
 				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 14,
 				},
 				[3] = {
 					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
 					["num"] = 13,
 				},
 				[4] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 11,
 				},
 				[5] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 10,
+				},
+				[6] = {
 					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
 					["num"] = 9,
 				},
-				[6] = {
-					["CLSID"] = "{GBU-38}",
+				[7] = {
+					["CLSID"] = "<CLEAN>",
 					["num"] = 8,
 				},
-				[7] = {
+				[8] = {
 					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
 					["num"] = 7,
 				},
-				[8] = {
-					["CLSID"] = "{CFT_L_GBU_38_x_3}",
-					["num"] = 4,
-				},
 				[9] = {
-					["CLSID"] = "{CFT_R_GBU_38_x_3}",
-					["num"] = 12,
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 6,
 				},
 				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[12] = {
 					["CLSID"] = "{F15E_EXTTANK}",
 					["num"] = 2,
 				},
-				[11] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
+				[13] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -230,59 +229,51 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
-			["name"] = "Liberation BARCAP",
+			["name"] = "Liberation BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
+					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
-				},
-				[3] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[4] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 11,
-				},
-				[5] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 10,
-				},
-				[6] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 8,
-				},
-				[8] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 6,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 5,
-				},
-				[11] = {
 					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
 					["num"] = 3,
 				},
-				[12] = {
+				[3] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[4] = {
 					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[6] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[7] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+				[8] = {
+					["CLSID"] = "{CFT_L_GBU_31_x_2}",
+					["num"] = 4,
+				},
+				[9] = {
+					["CLSID"] = "{CFT_R_GBU_31_x_2}",
+					["num"] = 12,
+				},
+				[10] = {
+					["CLSID"] = "{GBU-31}",
 					["num"] = 2,
 				},
-				[13] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
+				[11] = {
+					["CLSID"] = "{GBU-31}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -290,8 +281,8 @@ local unitPayloads = {
 			},
 		},
 		[6] = {
-			["displayName"] = "Liberation OCA/Aircraft",
-			["name"] = "Liberation OCA/Aircraft",
+			["displayName"] = "Liberation CAS",
+			["name"] = "Liberation CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
@@ -314,7 +305,7 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[6] = {
-					["CLSID"] = "{GBU-31V3B}",
+					["CLSID"] = "{F15E_EXTTANK}",
 					["num"] = 8,
 				},
 				[7] = {
@@ -322,19 +313,11 @@ local unitPayloads = {
 					["num"] = 7,
 				},
 				[8] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
-				},
-				[9] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{GBU-31V3B}",
+					["CLSID"] = "{CFT_R_CBU_97_x_6}",
 					["num"] = 12,
 				},
-				[11] = {
-					["CLSID"] = "{GBU-31V3B}",
+				[9] = {
+					["CLSID"] = "{CFT_L_CBU_97_x_6}",
 					["num"] = 4,
 				},
 			},
@@ -343,59 +326,6 @@ local unitPayloads = {
 			},
 		},
 		[7] = {
-			["displayName"] = "Liberation OCA/Runway",
-			["name"] = "Liberation OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[4] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
-				},
-				[5] = {
-					["CLSID"] = "{CFT_R_BLU107_x_6}",
-					["num"] = 12,
-				},
-				[6] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[7] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{CFT_L_BLU107_x_6}",
-					["num"] = 4,
-				},
-				[9] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
-				},
-				[10] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[11] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 8,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[8] = {
 			["displayName"] = "Liberation DEAD",
 			["name"] = "Liberation DEAD",
 			["pylons"] = {
@@ -420,7 +350,7 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[6] = {
-					["CLSID"] = "{GBU-31}",
+					["CLSID"] = "{F15E_EXTTANK}",
 					["num"] = 8,
 				},
 				[7] = {
@@ -436,11 +366,11 @@ local unitPayloads = {
 					["num"] = 12,
 				},
 				[10] = {
-					["CLSID"] = "{F15E_EXTTANK}",
+					["CLSID"] = "{GBU-31}",
 					["num"] = 14,
 				},
 				[11] = {
-					["CLSID"] = "{F15E_EXTTANK}",
+					["CLSID"] = "{GBU-31}",
 					["num"] = 2,
 				},
 			},
@@ -448,7 +378,113 @@ local unitPayloads = {
 				[1] = 32,
 			},
 		},
+		[8] = {
+			["displayName"] = "Liberation OCA/Aircraft",
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[4] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 14,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{CFT_R_GBU_38_x_3}",
+					["num"] = 12,
+				},
+				[11] = {
+					["CLSID"] = "{CFT_L_GBU_38_x_3}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
 		[9] = {
+			["displayName"] = "Liberation Strike",
+			["name"] = "Liberation Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 15,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 13,
+				},
+				[4] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{F15E_EXTTANK}",
+					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{CFT_L_GBU_38_x_3}",
+					["num"] = 4,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 14,
+				},
+				[11] = {
+					["CLSID"] = "{CFT_R_GBU_38_x_3}",
+					["num"] = 12,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[10] = {
 			["displayName"] = "Liberation Escort",
 			["name"] = "Liberation Escort",
 			["pylons"] = {
@@ -503,58 +539,6 @@ local unitPayloads = {
 				[13] = {
 					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
 					["num"] = 1,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[10] = {
-			["name"] = "Liberation BAI",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 3,
-				},
-				[3] = {
-					["CLSID"] = "{F-15E_AAQ-13_LANTIRN}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{GBU-31}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{F-15E_AAQ-14_LANTIRN}",
-					["num"] = 7,
-				},
-				[6] = {
-					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
-					["num"] = 13,
-				},
-				[7] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 15,
-				},
-				[8] = {
-					["CLSID"] = "{CFT_L_GBU_31_x_2}",
-					["num"] = 4,
-				},
-				[9] = {
-					["CLSID"] = "{CFT_R_GBU_31_x_2}",
-					["num"] = 12,
-				},
-				[10] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 2,
-				},
-				[11] = {
-					["CLSID"] = "{F15E_EXTTANK}",
-					["num"] = 14,
 				},
 			},
 			["tasks"] = {


### PR DESCRIPTION
I've come to realise that two external tanks is overkill for pretty much all A2G mission types. The AI no longer have a problem with fuel, and player flights will essentially never run out of fuel with the 2 CFTs and a single external tank. I have done 700+ mile trips at mil power the whole way with fuel to spare. I have therefore switched all A2G mission loadouts to a single tank. A2A loadouts still carry 2 tanks, as players may require the extra fuel if they make very extensive use of afterburner in air combat.

It turns out the GBU31v3 JDAMs are bugged in more than one way. We've known that they vanish if carried in pairs on the CFT pylons, but now it turns out their penetration doesn't actually work. This means they are no better in any way than the GBU31v1s, which are not bugged on CFT pylons.

I have therefore removed the penetrator JDAMs from all loadouts, replacing them with regular JDAMs.