### PR TITLE
Add DEAD capability to AH-64D Blk II

### DIFF
--- a/resources/units/aircraft/AH-64D_BLK_II.yaml
+++ b/resources/units/aircraft/AH-64D_BLK_II.yaml
@@ -37,4 +37,5 @@ radios:
 tasks:
   BAI: 510
   CAS: 510
+  DEAD: 115
   OCA/Aircraft: 510


### PR DESCRIPTION
At the moment, the AH-64D Blk II can't be used for DEAD missions. This is a problem for chopper-only campaigns where it is the best BLUFOR option for taking out AAA and SHORADs. I have added DEAD to the Apache's mission list, but have set the priority just above the warbirds, so that the autoplanner won't pick it over modern fixed wing aircraft.