### PR TITLE
Add DEAD mission capability to Blackshark 3

### DIFF
--- a/resources/units/aircraft/Ka-50_3.yaml
+++ b/resources/units/aircraft/Ka-50_3.yaml
@@ -27,4 +27,5 @@ kneeboard_units: "metric"
 tasks:
   BAI: 440
   CAS: 440
+  DEAD: 114
   OCA/Aircraft: 440


### PR DESCRIPTION
Allows KA-50 Blackshark 3 to perform DEAD mission.