### PR TITLE
Don't send the selected flight plan to the back.

### DIFF
--- a/client/src/components/flightplan/FlightPlan.tsx
+++ b/client/src/components/flightplan/FlightPlan.tsx
@@ -46,7 +46,9 @@ function FlightPlanPath(props: FlightPlanProps) {
   // behind everything than was added before them. Anything added after always
   // goes on top.
   useEffect(() => {
-    polylineRef.current?.bringToBack();
+    if (!props.selected) {
+      polylineRef.current?.bringToBack();
+    }
   });
 
   if (waypoints == null) {


### PR DESCRIPTION
We want the selected flight plan to show on top of all the other flight plans, and because we can't properly z-order with the other elements of the map (see the code comment), this is probably the best we can do.

This means that the selected flight will be drawn on top of the front line again, and will in some cases intercept mouse clicks meant for the front line, but it's much less of a problem than when all the paths were drawn on top.

Fixes https://github.com/dcs-liberation/dcs_liberation/issues/3305.