### PR TITLE
Add FCR to the Apache Blk II's new loadout slot

### DIFF
--- a/resources/customized_payloads/AH-64D_BLK_II.lua
+++ b/resources/customized_payloads/AH-64D_BLK_II.lua
@@ -2,30 +2,6 @@ local unitPayloads = {
 	["name"] = "AH-64D_BLK_II",
 	["payloads"] = {
 		[1] = {
-			["name"] = "Liberation CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{M299_4xAGM_114L}",
-					["num"] = 4,
-				},
-				[3] = {
-					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
-					["num"] = 2,
-				},
-				[4] = {
-					["CLSID"] = "{M299_4xAGM_114L}",
-					["num"] = 1,
-				},
-			},
-			["tasks"] = {
-				[1] = 31,
-			},
-		},
-		[2] = {
 			["displayName"] = "Liberation BAI",
 			["name"] = "Liberation BAI",
 			["pylons"] = {
@@ -45,12 +21,72 @@ local unitPayloads = {
 					["CLSID"] = "{M299_4xAGM_114L}",
 					["num"] = 1,
 				},
+				[5] = {
+					["CLSID"] = "{AN_APG_78}",
+					["num"] = 6,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[2] = {
+			["name"] = "Liberation OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{M261_M229}",
+					["num"] = 4,
+				},
+				[4] = {
+					["CLSID"] = "{M261_M229}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{AN_APG_78}",
+					["num"] = 6,
+				},
 			},
 			["tasks"] = {
 				[1] = 31,
 			},
 		},
 		[3] = {
+			["name"] = "Liberation CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{M299_4xAGM_114L}",
+					["num"] = 4,
+				},
+				[3] = {
+					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{M299_4xAGM_114L}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{AN_APG_78}",
+					["num"] = 6,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[4] = {
 			["displayName"] = "Liberation DEAD",
 			["name"] = "Liberation DEAD",
 			["pylons"] = {
@@ -70,29 +106,38 @@ local unitPayloads = {
 					["CLSID"] = "{M299_4xAGM_114L}",
 					["num"] = 1,
 				},
+				[5] = {
+					["CLSID"] = "{AN_APG_78}",
+					["num"] = 6,
+				},
 			},
 			["tasks"] = {
 				[1] = 31,
 			},
 		},
-		[4] = {
-			["name"] = "Liberation OCA/Aircraft",
+		[5] = {
+			["displayName"] = "Liberation Escort",
+			["name"] = "Liberation Escort",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
 					["num"] = 3,
 				},
 				[2] = {
+					["CLSID"] = "{M299_4xAGM_114L}",
+					["num"] = 4,
+				},
+				[3] = {
 					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
 					["num"] = 2,
 				},
-				[3] = {
-					["CLSID"] = "{M261_M229}",
-					["num"] = 4,
-				},
 				[4] = {
-					["CLSID"] = "{M261_M229}",
+					["CLSID"] = "{M299_4xAGM_114L}",
 					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{AN_APG_78}",
+					["num"] = 6,
 				},
 			},
 			["tasks"] = {


### PR DESCRIPTION
The Apache Blk II now has a dedicated loadout slot for the CFR, rather than it being set by a checkbox in the mission editor. This PR updates the loadouts for that new slot.

This PR should not be merged until Liberation/pydcs has been updated to support the change.