### PR TITLE
Update pydcs version for DCS 2.9.3.51704

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Saves from 10.x are not compatible with 11.0.0.
 
 ## Features/Improvements
 
-* **[Engine]** Support for DCS 2.9.3.51704 Open Beta. (F-15E JDAM and JSOW, F-16 AIM-9P, updated Falklands and Normandy airfields).
+* **[Engine]** Support for DCS 2.9.3.51704 Open Beta. 
 
 ## Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ Saves from 10.x are not compatible with 11.0.0.
 
 ## Features/Improvements
 
+* **[Engine]** Support for DCS 2.9.3.51704 Open Beta. (F-15E JDAM and JSOW, F-16 AIM-9P, updated Falklands and Normandy airfields).
+
 ## Fixes
 
 # 10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pre-commit==3.5.0
 pydantic==2.5.2
 pydantic-settings==2.1.0
 pydantic_core==2.14.5
-pydcs @ git+https://github.com/pydcs/dcs@1092fc419d3f879e8e7951b25e15d8b7c9938627
+pydcs @ git+https://github.com/pydcs/dcs@7eeec23ea428846ebbbd0ea4c746f8eafea04e0d
 pyinstaller==5.13.1
 pyinstaller-hooks-contrib==2023.6
 pyproj==3.6.1

--- a/resources/customized_payloads/SA342L.lua
+++ b/resources/customized_payloads/SA342L.lua
@@ -10,11 +10,11 @@ local unitPayloads = {
 				},
 				[2] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 				[3] = {
 					["CLSID"] = "{FAS}",
-					["num"] = 5,
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -30,11 +30,11 @@ local unitPayloads = {
 				},
 				[2] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 				[3] = {
 					["CLSID"] = "{FAS}",
-					["num"] = 5,
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -50,11 +50,11 @@ local unitPayloads = {
 				},
 				[2] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 				[3] = {
 					["CLSID"] = "{FAS}",
-					["num"] = 5,
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -70,11 +70,11 @@ local unitPayloads = {
 				},
 				[2] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 				[3] = {
 					["CLSID"] = "{FAS}",
-					["num"] = 5,
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -90,11 +90,11 @@ local unitPayloads = {
 				},
 				[2] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 				[3] = {
 					["CLSID"] = "{FAS}",
-					["num"] = 5,
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {

--- a/resources/customized_payloads/SA342M.lua
+++ b/resources/customized_payloads/SA342M.lua
@@ -5,28 +5,20 @@ local unitPayloads = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{HOT3_R2_M}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{HOT3G}",
+					["CLSID"] = "{HOT3_L2_M}",
 					["num"] = 2,
 				},
 				[3] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{FAS}",
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{HOT3G}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{FAS}",
-					["num"] = 5,
-				},
-				[6] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -37,28 +29,20 @@ local unitPayloads = {
 			["name"] = "CAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{HOT3_R2_M}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{HOT3G}",
+					["CLSID"] = "{HOT3_L2_M}",
 					["num"] = 2,
 				},
 				[3] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{FAS}",
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{HOT3G}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{FAS}",
-					["num"] = 5,
-				},
-				[6] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -69,28 +53,20 @@ local unitPayloads = {
 			["name"] = "STRIKE",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{HOT3_R2_M}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{HOT3G}",
+					["CLSID"] = "{HOT3_L2_M}",
 					["num"] = 2,
 				},
 				[3] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{FAS}",
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{HOT3G}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{FAS}",
-					["num"] = 5,
-				},
-				[6] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -101,28 +77,20 @@ local unitPayloads = {
 			["name"] = "SEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{HOT3_R2_M}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{HOT3G}",
+					["CLSID"] = "{HOT3_L2_M}",
 					["num"] = 2,
 				},
 				[3] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{FAS}",
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{HOT3G}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{FAS}",
-					["num"] = 5,
-				},
-				[6] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -133,28 +101,20 @@ local unitPayloads = {
 			["name"] = "ANTISHIP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{HOT3_R2_M}",
 					["num"] = 1,
 				},
 				[2] = {
-					["CLSID"] = "{HOT3G}",
+					["CLSID"] = "{HOT3_L2_M}",
 					["num"] = 2,
 				},
 				[3] = {
-					["CLSID"] = "{HOT3D}",
+					["CLSID"] = "{FAS}",
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{HOT3G}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{FAS}",
-					["num"] = 5,
-				},
-				[6] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {

--- a/resources/customized_payloads/SA342Minigun.lua
+++ b/resources/customized_payloads/SA342Minigun.lua
@@ -6,7 +6,7 @@ local unitPayloads = {
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
@@ -19,7 +19,7 @@ local unitPayloads = {
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{IR_Deflector}",
-					["num"] = 6,
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {

--- a/resources/units/aircraft/AH-64D_BLK_II.yaml
+++ b/resources/units/aircraft/AH-64D_BLK_II.yaml
@@ -40,6 +40,4 @@ tasks:
   CAS: 510
   DEAD: 115
   OCA/Aircraft: 510
-default_overrides:
-  FCR_RFI_removed: false
 hit_points: 20


### PR DESCRIPTION
- Updates pydcs version for DCS 2.9.3.51704
- Removes AH-64 FCR/RFI default override, which does not exist any more.
- Update custom payloads for SA342L/M due to changes to CLSIDs. SA342 Minigun payloads also updated but not tested as the unit type does not have any tasks assigned.

This PR is missing updates to the AH-64 payloads, so this PR complements #3343 