### PR TITLE
Bump starlette and fastapi versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ coverage==7.3.2
 distlib==0.3.7
 exceptiongroup==1.2.0
 Faker==20.1.0
-fastapi==0.104.1
+fastapi==0.109.1
 filelock==3.13.1
 future==0.18.3
 h11==0.14.0
@@ -54,7 +54,7 @@ shapely==2.0.2
 shiboken6==6.4.1
 six==1.16.0
 sniffio==1.3.0
-starlette==0.27.0
+starlette==0.35.1
 tabulate==0.9.0
 tomli==2.0.1
 types-Jinja2==2.11.9


### PR DESCRIPTION
Bump starlette to 0.35.1 and fastapi to 0.109.1 in one commit as they depend on each other.