### PR TITLE
Issue 3337

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,8 +8,10 @@ Saves from 10.x are not compatible with 11.0.0.
 * **[Campaign]** Improved tracking of parked aircraft deaths. Parked aircraft are now considered dead once sufficient damage is done, meaning guns, rockets and AGMs are viable weapons for OCA/Aircraft missions. Previously Liberation relied on DCS death tracking which required parked aircraft to be hit with more powerful weapons e.g. 2000lb bombs as they were uncontrolled.
 * **[Campaign]** Track damage to theater ground objects across turns. Damage can accumulate across turns leading to death of the unit. This behavior only applies to SAMs, ships and other units that appear on the Liberation map. Frontline units and buildings are not tracked (yet).
 
-
 ## Fixes
+
+* **[Mission Generation]** When planning anti-ship missions against carriers or LHAs, target escorts (if present) if the carrier/LHA is sunk.
+* **[UI]** Identify that a carrier or LHA is sunk instead of "damaged".
 
 # 10.0.0
 

--- a/game/missiongenerator/aircraft/waypoints/antishipingress.py
+++ b/game/missiongenerator/aircraft/waypoints/antishipingress.py
@@ -20,8 +20,14 @@ class AntiShipIngressBuilder(PydcsWaypointBuilder):
             group_names.append(target.name)
         elif isinstance(target, NavalControlPoint):
             carrier_name = target.get_carrier_group_name()
-            if carrier_name:
+            if carrier_name and self.mission.find_group(
+                carrier_name
+            ):  # Found a carrier, target it.
                 group_names.append(carrier_name)
+            else:  # Could not find carrier/LHA, indicating it was sunk. Target other groups if present e.g. escorts.
+                for ground_object in target.ground_objects:
+                    for group in ground_object.groups:
+                        group_names.append(group.group_name)
         else:
             logging.error(
                 "Unexpected target type for anti-ship mission: %s",

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1283,7 +1283,10 @@ class NavalControlPoint(ControlPoint, ABC):
         return RunwayStatus(damaged=not self.runway_is_operational())
 
     def describe_runway_status(self) -> str:
-        return f"Flight deck {self.runway_status.describe()}"
+        if self.runway_is_operational():
+            return f"Flight deck {self.runway_status.describe()}"
+        # Special handling for not operational carriers/LHAs
+        return f"Sunk"
 
     @property
     def runway_can_be_repaired(self) -> bool:


### PR DESCRIPTION
This PR addresses #3337 by:
- Updating the UI to identify that a destroyed carrier/LHA as "Sunk"
- Fall back on targeting other groups in the NavalControlPoint (e.g. escorts if present) if the carrier/LHA is sunk.