### PR TITLE
Add mechanism to prevent double counting of damage induced kills when…

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -391,6 +391,9 @@ class Debriefing:
             else:
                 enemy_losses.append(aircraft)
 
+        # Keep track of damaged units that are counted as killed so we don't double count 
+        # when DCS reports damage multiple times.
+        units_killed_by_damage = set()
         for unit_data in self.state_data.unit_hit_point_updates:
             damaged_unit = FlyingUnitHitPointUpdate.from_json(unit_data, self.unit_map)
             if damaged_unit is None:
@@ -399,6 +402,9 @@ class Debriefing:
                 # If unit already killed, nothing to do.
                 if unit_data["name"] in self.state_data.killed_aircraft:
                     continue
+                if unit_data["name"] in units_killed_by_damage:
+                    continue
+                units_killed_by_damage.add(unit_data["name"])
                 if damaged_unit.is_friendly(to_player=True):
                     player_losses.append(damaged_unit.unit)
                 else:

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -391,7 +391,7 @@ class Debriefing:
             else:
                 enemy_losses.append(aircraft)
 
-        # Keep track of damaged units that are counted as killed so we don't double count 
+        # Keep track of damaged units that are counted as killed so we don't double count
         # when DCS reports damage multiple times.
         units_killed_by_damage = set()
         for unit_data in self.state_data.unit_hit_point_updates:


### PR DESCRIPTION
… DCS reports multiple hits

This PR fixes a bug introduced when tracking OCA/Aircraft kills that results in double counting when DCS reports multiple hits, typically when guns are used.