### PR TITLE
Stop naval control points from being moved onto land

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ Saves from 11.x are not compatible with 12.0.0.
 
 ## Fixes
 
+* **[Campaign]** Fixed double counting of parked aircraft kills when DCS reports multiple kill events.
+* **[UI]** Naval control points (carriers, LHAs) can no longer be moved onto land.
+
+
 # 11.0.0
 
 Saves from 10.x are not compatible with 11.0.0.

--- a/game/server/controlpoints/routes.py
+++ b/game/server/controlpoints/routes.py
@@ -92,7 +92,7 @@ def set_destination(
     if cp.is_fleet and not game.theater.is_in_sea(point):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail=f"Cannot move naval {cp} onto land.",
+            detail=f"Cannot move naval control point {cp} onto land.",
         )
     cp.target_position = point
     from .. import EventStream

--- a/game/server/controlpoints/routes.py
+++ b/game/server/controlpoints/routes.py
@@ -89,6 +89,11 @@ def set_destination(
             detail=f"Cannot move {cp} more than "
             f"{cp.max_move_distance.nautical_miles}nm.",
         )
+    if cp.is_fleet and not game.theater.is_in_sea(point):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot move naval {cp} onto land.",
+        )
     cp.target_position = point
     from .. import EventStream
 


### PR DESCRIPTION
This PR fixes #3243 by checking whether the destination point is in the sea for naval control points before permitting the movement.