### PR TITLE
Make theater refuelling flight plan on-station time configurable based on the desired mission duration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Saves from 11.x are not compatible with 12.0.0.
 * **[Campaign]** Fixed double counting of parked aircraft kills when DCS reports multiple kill events.
 * **[Campaign]** Fixed error where frontline units are not re-deployed when multiple control points were captured in one turn or when control points are captured "out of order" using air-assault missions.
 * **[Cheat Menu]** Re-deploy frontline units when using cheats to capture control points, so that cheats behave the same way as capturing a control point in-mission.
+* **[Flight Planning]** Theater refuelling flight plans (those not tied to a particular package) will remain on station for a longer period, specifically the desired mission duration + 30 minutes. By default, this increases the on-station time from 1 hour to 1.5 hours. 
 * **[UI]** Naval control points (carriers, LHAs) can no longer be moved onto land.
 
 

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -17,7 +17,7 @@ class TheaterRefuelingFlightPlan(RefuelingFlightPlan):
 
     @property
     def patrol_duration(self) -> timedelta:
-        return timedelta(hours=1)
+        return self.flight.coalition.game.settings.desired_player_mission_duration + timedelta(minutes=30)
 
 
 class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -17,7 +17,13 @@ class TheaterRefuelingFlightPlan(RefuelingFlightPlan):
 
     @property
     def patrol_duration(self) -> timedelta:
-        return self.flight.coalition.game.settings.desired_player_mission_duration + timedelta(minutes=30)
+        # Add 30 minutes to desired_player_mission_duration as TOTs for flights
+        # can sit up to this time. This extension means the tanker remains on
+        # station for the flights' return.
+        return (
+            self.flight.coalition.game.settings.desired_player_mission_duration
+            + timedelta(minutes=30)
+        )
 
 
 class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -467,6 +467,10 @@ class Settings:
         default=timedelta(minutes=60),
         min=30,
         max=150,
+        detail=("Period of time after the start of a turn where "
+                "there is coverage by one or more CAP flight(s), "
+                "refuelling flights not tied to a specific package are on station, " 
+                "and other flights have their TOTs."),
     )
 
     # Performance

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -467,10 +467,12 @@ class Settings:
         default=timedelta(minutes=60),
         min=30,
         max=150,
-        detail=("Period of time after the start of a turn where "
-                "there is coverage by one or more CAP flight(s), "
-                "refuelling flights not tied to a specific package are on station, " 
-                "and other flights have their TOTs."),
+        detail=(
+            "Period of time after the start of a turn where "
+            "there is coverage by one or more CAP flight(s), "
+            "refuelling flights not tied to a specific package are on station, "
+            "and other flights have their TOTs."
+        ),
     )
 
     # Performance


### PR DESCRIPTION
This PR 
- Addresses #1511 by setting the tanker on-station time to the desired mission duration + 30 minutes
- Elaborate on what the desired mission duration setting does in the Settings UI.