### PR TITLE
Lock python version to 3.11.4 as 3.11.5 introduces a change that brea…

### DIFF
--- a/.github/actions/setup-liberation-python/action.yaml
+++ b/.github/actions/setup-liberation-python/action.yaml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.11.4"
         cache: pip
 
     - name: Install environment


### PR DESCRIPTION
3.11.5 introduces a change that breaks unpickling of save files that leads to #3379. This PR introduces a short term fix by locking the python version used in the build until the root cause can be found and fixed.
