### PR TITLE
Update Black Sea from 2/3 to 3/3 performance

### DIFF
--- a/resources/campaigns/black_sea.yaml
+++ b/resources/campaigns/black_sea.yaml
@@ -8,7 +8,7 @@ recommended_player_faction: USA 2005
 recommended_enemy_faction: Russia 2010
 recommended_start_date: 2004-01-07
 miz: black_sea.miz
-performance: 2
+performance: 3
 version: "11.0"
 squadrons:
   # Anapa-Vityazevo


### PR DESCRIPTION
I think this campaign is really not performance friendly and should be marked as a 3/3. It is the first campaign on the list and quite a few new players pick it as their first one and then struggle with performance issues. Framerate on this campaign is quite a bit lower than on many of the other 2/3 campaigns, on account of the large number of aircraft and very heavy SAM coverage.