### PR TITLE
Add NASAMs to MERAD unit list for campaign template

### DIFF
--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -61,6 +61,8 @@ class MizCampaignLoader:
         AirDefence.Hawk_ln.id,
         AirDefence.S_75M_Volhov.id,
         AirDefence.X_5p73_s_125_ln.id,
+        AirDefence.NASAMS_LN_B.id,
+        AirDefence.NASAMS_LN_C.id,
     }
 
     SHORT_RANGE_SAM_UNIT_TYPES = {


### PR DESCRIPTION
Adds NASAM launcher B and C to the list of units that can be placed in a campaign template to define a MERAD spawn location.

This is needed to maintain compatibility with the new versions of my campaigns.