### PR TITLE
Update pydcs to fix spawning issue with DCS 2.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pre-commit==3.5.0
 pydantic==2.5.2
 pydantic-settings==2.1.0
 pydantic_core==2.14.5
-pydcs @ git+https://github.com/dcs-liberation/dcs@fd375b6b797a15b77d48301d9a9cb55d4ed641ad
+pydcs @ git+https://github.com/dcs-liberation/dcs@d94fa3d0735d3f11f144ecfb01a2eb2057ee2385
 pyinstaller==5.13.1
 pyinstaller-hooks-contrib==2023.6
 pyproj==3.6.1


### PR DESCRIPTION
This PR is to update pydcs to a version that fixes the spawning issue in DCS 2.9.6 where spawning on carriers and FARPs do not work due to changes in the warehouse system.