### PR TITLE
Don't return available destinations when retreating aircraft if the runway is not operational

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Saves from 11.x are not compatible with 12.0.0.
 
 * **[Campaign]** Removed deprecated settings for generating persistent and invulnerable AWACs and tankers.
 * **[Mods]** F/A-18 E/F/G Super Hornet mod version updated to 2.3.
+* **[Campaign]** Do not allow aircraft from a captured control point to retreat if the captured control point has a damaged runway.
 
 ## Fixes
 

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -764,6 +764,9 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
     def aircraft_retreat_destination(
         self, squadron: Squadron
     ) -> Optional[ControlPoint]:
+        if not self.runway_is_operational():
+            return None
+
         closest = ObjectiveDistanceCache.get_closest_airfields(self)
         max_retreat_distance = squadron.aircraft.max_mission_range
         # Skip the first airbase because that's the airbase we're retreating


### PR DESCRIPTION
Short circuits selecting control points to retreat aircraft to when the control point being captured has a damaged runway.

Fixes #3434. 

I'm not sure how to test this locally though, so I have no idea if it works. 