### PR TITLE
Update requirements.txt to point to pydcs version with legacy miz loading fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           Compress-Archive -Path .\dist\dcs_liberation\ -DestinationPath
           dist\dcs_liberation.zip
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: dcs_liberation
           path: dist/dcs_liberation.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pre-commit==3.5.0
 pydantic==2.5.2
 pydantic-settings==2.1.0
 pydantic_core==2.14.5
-pydcs @ git+https://github.com/dcs-liberation/dcs@d94fa3d0735d3f11f144ecfb01a2eb2057ee2385
+pydcs @ git+https://github.com/dcs-liberation/dcs@47b524e3cfaa945d1f42717ee00f949b3354125c
 pyinstaller==5.13.1
 pyinstaller-hooks-contrib==2023.6
 pyproj==3.6.1


### PR DESCRIPTION
This PR updates pydcs to include fix for loading legacy miz files.

