### PR TITLE
Update UI template to match setting name

### DIFF
--- a/resources/ui/templates/mission_start_EN.j2
+++ b/resources/ui/templates/mission_start_EN.j2
@@ -13,7 +13,7 @@
 </p>
 
 <p>
-  To avoid delays entirely, use the "Never delay player flights" option in the
+  To avoid delays entirely, use the "Player flights ignore TOT and spawn immediately" option in the
   mission generation settings. Note that this will <strong>not</strong> adjust
   the timing of your mission; this option only allows you to wait in the
   cockpit.


### PR DESCRIPTION
This PR updates the UI template for the mission start screen to rename "Never delay player flights" to "Player flights ignore TOT and spawn immediately" as the setting name has been updated.