### PR TITLE
Update NATO Desert Storm faction to include Tornado GR4

### DIFF
--- a/resources/factions/NATO_Desert_Storm.yaml
+++ b/resources/factions/NATO_Desert_Storm.yaml
@@ -30,6 +30,7 @@ aircrafts:
   - SA 342M Gazelle
   - SA 342M Gazelle Mistral
   - Tornado IDS
+  - Tornado GR4
   - UH-1H Iroquois
 awacs:
   - E-2C Hawkeye


### PR DESCRIPTION
This PR addresses #1877 by adding Tornado GR4 to NATO Desert Storm faction. The Tornado IDS unit is left in the faction to provide backward compatibility for custom campaigns that use the faction.