### PR TITLE
Disable Air Wing and Transfer buttons if no game is enabled

### DIFF
--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -242,6 +242,8 @@ class QLiberationWindow(QMainWindow):
         self.openSettingsAction.setVisible(enabled)
         self.openStatsAction.setVisible(enabled)
         self.openNotesAction.setVisible(enabled)
+        self.openAirWingAction.setVisible(enabled)
+        self.openTransfersAction.setVisible(enabled)
 
         # Also Disable SaveAction to prevent Keyboard Shortcut
         self.saveGameAction.setEnabled(enabled)


### PR DESCRIPTION
This PR addresses #3481 by disabling the Air Wing and Transfer buttons if no game is loaded.