### PR TITLE
Minor text corrections for clarity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -497,7 +497,7 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[Mission Generation]** The lua data for other plugins is now generated correctly
 * **[Mission Generation]** Fixed problem with opfor planning missions against sold ground objects like SAMs
 * **[Mission Generation]** The legacy always-available tanker option no longer prevents mission creation.
-* **[Mission Generation]** Prevent the creation of a transfer order with 0 units for a rare situtation when a point was captured.
+* **[Mission Generation]** Prevent the creation of a transfer order with 0 units for a rare situation when a point was captured.
 * **[Mission Generation]** Planned transfers which will be impossible after a base capture will no longer prevent the mission result submit.
 * **[Mission Generation]** Fix occasional KeyError preventing mission generation when all units of the same type in a convoy were killed.
 * **[Mission Generation]** Fix for AAA Flak generator using Opel Blitz preventing the mission from being generated because duplicate unit names were used.

--- a/changelog.md
+++ b/changelog.md
@@ -479,7 +479,7 @@ Saves from 4.0.0 are compatible with 4.1.0.
 * **[Plugins]** Increased time JTAC Autolase messages stay visible on the UI.
 * **[Plugins]** Updated SkynetIADS to 2.2.0 (adds NASAMS support).  
 * **[UI]** Added ability to take notes and have those notes appear as a kneeboard page.
-* **[UI]** Hovering over the weather information now dispalys the cloud base (meters and feet).
+* **[UI]** Hovering over the weather information now displays the cloud base (meters and feet).
 * **[UI]** Google search link added to unit information when there is no information provided.
 * **[UI]** Control point name displayed with ground object group name on map.
 * **[UI]** Buy or Replace will now show the correct price for generated ground objects like sams.

--- a/changelog.md
+++ b/changelog.md
@@ -910,7 +910,7 @@ Saves from 2.3 are not compatible with 2.4.
 * **[Moddability]** LUA plugins can now be injected into Liberation missions.
 * **[Moddability]** Optional Skynet IADS lua plugin now included
 * **[New Game]** Starting budget can be freely selected
-* **[New Game]** Exanded information for faction and campaign selection in the new game wizard
+* **[New Game]** Expanded information for faction and campaign selection in the new game wizard
 * **[UI]** Add double and right click actions to many UI elements.
 * **[UI]** Add polygon drawing mode for map background
 * **[UI]** Added a warning if you press takeoff with no player enabled flights

--- a/changelog.md
+++ b/changelog.md
@@ -986,7 +986,7 @@ Saves from 2.3 are not compatible with 2.4.
   * M-2000C (Thanks to contributor danalbert)
 * **[Base Menu]** Added possibility to repair destroyed SAM and base defenses units for the player (Click on a SAM site to fix it)
 * **[Base Menu]** Added possibility to buy/sell/replace SAM units
-* **[Map]** Added recon images for buildings on strike targets, click on a Strike target to get detailed informations
+* **[Map]** Added recon images for buildings on strike targets, click on a Strike target to get detailed information
 * **[Units/Factions]** Added F-16C to USA 1990
 * **[Units/Factions]** Added MQ-9 Reaper as CAS unit for USA 2005
 * **[Units/Factions]** Added Mig-21, Mig-23, SA-342L to Syria 2011

--- a/changelog.md
+++ b/changelog.md
@@ -803,7 +803,7 @@ Saves from 2.3 are not compatible with 2.4.
 * **[UI]** Ship groups could be replaced by SAM sites in the UI, which would lead to broken mission being generated - fixed 
 * **[New Game Wizard]** Removed the "mid game" campaign generator option which is currently broken
 * **[Mission Generator]** Empty navy groups will no longer be generated
-* **[Mission Generator]** Fixed BAI, SEAD, and DEAD flights ocassionally being assigned the wrong targets.
+* **[Mission Generator]** Fixed BAI, SEAD, and DEAD flights occasionally being assigned the wrong targets.
 * **[Flight Planner]** Fixed not being able to plan packages against opfor carriers
 * **[UI]** Repaired SAMs no longer show as dead.
 * **[UI]** Fixed not being able to manage a disbanded site after disbanding and closing the base menu.

--- a/changelog.md
+++ b/changelog.md
@@ -986,7 +986,7 @@ Saves from 2.3 are not compatible with 2.4.
   * M-2000C (Thanks to contributor danalbert)
 * **[Base Menu]** Added possibility to repair destroyed SAM and base defenses units for the player (Click on a SAM site to fix it)
 * **[Base Menu]** Added possibility to buy/sell/replace SAM units
-* **[Map]** Added recon images for buildings on strike targets, click on a Strike target to get detailled informations
+* **[Map]** Added recon images for buildings on strike targets, click on a Strike target to get detailed informations
 * **[Units/Factions]** Added F-16C to USA 1990
 * **[Units/Factions]** Added MQ-9 Reaper as CAS unit for USA 2005
 * **[Units/Factions]** Added Mig-21, Mig-23, SA-342L to Syria 2011

--- a/docs/modding/fuel-consumption-measurement.md
+++ b/docs/modding/fuel-consumption-measurement.md
@@ -21,7 +21,7 @@ measure the distance traveled from takeoff. Mark your location on the map.
 
 Level out and increase to cruise speed if needed. Liberation assumes 0.85 mach
 for supersonic aircraft, for subsonic aircraft it depends so pick something
-reasonable and note your descision in a comment in the file when done. Maintain
+reasonable and note your decision in a comment in the file when done. Maintain
 speed, heading, and altitude for a long distance (the longer the distance, the
 more accurate the result, but be careful to leave enough fuel for the final
 section). Once complete, note the distance traveled and the remaining fuel.

--- a/docs/modding/fuel-consumption-measurement.md
+++ b/docs/modding/fuel-consumption-measurement.md
@@ -13,7 +13,7 @@ When you enter the jet, note the amount of fuel below, then taxi to the far end
 of the runway. Hold short and note the remaining fuel below.
 
 Follow a typical takeoff pattern for the aircraft. For the F/A-18C, this might
-be AB takeoff, reduce to MIL at 350KIAS, and maintian 350KIAS/0.85 mach until
+be AB takeoff, reduce to MIL at 350KIAS, and maintain 350KIAS/0.85 mach until
 cruise altitude (angles 25).
 
 Once you reach angels 25, pause the game. Note your remaining fuel below and

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -104,7 +104,7 @@ class Builder(IBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             pickup_position = self.flight.departure.position
         else:
             # TODO The calculation of the Pickup LZ is currently randomized. This
-            # leads to the problem that we can not gurantee that the LZ is clear of
+            # leads to the problem that we can not guarantee that the LZ is clear of
             # obstacles. This has to be improved in the future so that the Mission can
             # be autoplanned. In the current state the User has to check the created
             # Waypoints for the Pickup and Dropoff LZs are free of obstacles.

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -119,7 +119,7 @@ class Builder(IBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
         assault_area = builder.assault_area(self.package.target)
         heading = self.package.target.position.heading_between_point(pickup_position)
 
-        # TODO we can not gurantee a safe LZ for DropOff. See comment above.
+        # TODO we can not guarantee a safe LZ for DropOff. See comment above.
         drop_off_zone = MissionTarget(
             "Dropoff zone",
             self.package.target.position.point_from_heading(heading, 1200),

--- a/game/campaignloader/squadrondefgenerator.py
+++ b/game/campaignloader/squadrondefgenerator.py
@@ -295,7 +295,7 @@ class SquadronDefGenerator:
                 "Ultramarine",
                 "Vengeful",
                 "Venom",
-                "Vermillion",
+                "Vermilion",
                 "Vicious",
                 "Victorious",
                 "Vigilant",

--- a/game/data/doctrine.py
+++ b/game/data/doctrine.py
@@ -160,7 +160,7 @@ class Doctrine:
     #: The altitude used for combat section of a flight.
     combat_altitude: Distance
 
-    #: The altitude used for forming up a pacakge.
+    #: The altitude used for forming up a package.
     rendezvous_altitude: Distance
 
     #: Defines prioritization of ground unit purchases.

--- a/game/data/doctrine.py
+++ b/game/data/doctrine.py
@@ -37,7 +37,7 @@ class Helicopter:
     #: The altitude used for combat section of a flight, overrides the base combat_altitude parameter for helos
     combat_altitude: Distance
 
-    #: The altitude used for forming up a pacakge. Overrides the base rendezvous_altitude parameter for helos
+    #: The altitude used for forming up a package. Overrides the base rendezvous_altitude parameter for helos
     rendezvous_altitude: Distance
 
     #: Altitude of the nav points (cruise section) of air assault missions.

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -248,7 +248,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
             return self.patrol_altitude
         else:
             # Estimate based on max speed.
-            # Aircaft with max speed 600 kph will prefer patrol at 10 000 ft
+            # Aircraft with max speed 600 kph will prefer patrol at 10 000 ft
             # Aircraft with max speed 2800 kph will prefer pratrol at 33 000 ft
             altitude_for_lowest_speed = feet(10 * 1000)
             altitude_for_highest_speed = feet(33 * 1000)

--- a/game/game.py
+++ b/game/game.py
@@ -572,7 +572,7 @@ class Game:
                 if isinstance(tgo, EwrGroundObject):
                     max_detection_range = tgo.max_detection_range().meters
                     for z in self.__culling_zones:
-                        seperation = z.distance_to_point(tgo.position)
+                        separation = z.distance_to_point(tgo.position)
                         # Don't cull EWR if in detection range.
                         if seperation < max_detection_range:
                             return False

--- a/game/game.py
+++ b/game/game.py
@@ -574,7 +574,7 @@ class Game:
                     for z in self.__culling_zones:
                         separation = z.distance_to_point(tgo.position)
                         # Don't cull EWR if in detection range.
-                        if seperation < max_detection_range:
+                        if separation < max_detection_range:
                             return False
                 if isinstance(tgo, SamGroundObject):
                     max_threat_range = tgo.max_threat_range().meters

--- a/game/game.py
+++ b/game/game.py
@@ -305,7 +305,7 @@ class Game:
             for tgo in control_point.connected_objectives:
                 self.db.tgos.add(tgo.id, tgo)
 
-        # Correct the heading of specifc TGOs, can only be done after init turn 0
+        # Correct the heading of specific TGOs, can only be done after init turn 0
         for tgo in self.theater.ground_objects:
             # If heading is 0 then we change the orientation to head towards the
             # closest conflict. Heading of 0 means that the campaign designer wants

--- a/game/game.py
+++ b/game/game.py
@@ -444,7 +444,7 @@ class Game:
         events.begin_new_turn()
 
     def message(self, title: str, text: str = "") -> None:
-        self.informations.append(Information(title, text, turn=self.turn))
+        self.information.append(Information(title, text, turn=self.turn))
 
     @property
     def current_turn_time_of_day(self) -> TimeOfDay:

--- a/game/game.py
+++ b/game/game.py
@@ -584,7 +584,7 @@ class Game:
                         respect_bubble = (
                             max_threat_range + Distance.from_nautical_miles(12).meters
                         )
-                        if seperation < respect_bubble:
+                        if separation < respect_bubble:
                             return False
             return self.position_culled(tgo.position)
 

--- a/game/game.py
+++ b/game/game.py
@@ -579,7 +579,7 @@ class Game:
                 if isinstance(tgo, SamGroundObject):
                     max_threat_range = tgo.max_threat_range().meters
                     for z in self.__culling_zones:
-                        seperation = z.distance_to_point(tgo.position)
+                        separation = z.distance_to_point(tgo.position)
                         # Create a 12nm buffer around nearby SAMs.
                         respect_bubble = (
                             max_threat_range + Distance.from_nautical_miles(12).meters

--- a/game/ground_forces/combat_stance.py
+++ b/game/ground_forces/combat_stance.py
@@ -7,6 +7,6 @@ class CombatStance(Enum):
         1  # Unit will attempt to make progress with medium sized group of units
     )
     RETREAT = 2  # Unit will retreat
-    BREAKTHROUGH = 3  # Unit will attempt a breakthrough, rushing forward very aggresively with big group of armored units, and even less armored units will move aggresively
+    BREAKTHROUGH = 3  # Unit will attempt a breakthrough, rushing forward very aggressively with big group of armored units, and even less armored units will move aggressively
     ELIMINATION = 4  # Unit will progress aggresively toward anemy units, attempting to eliminate the ennemy force
     AMBUSH = 5  # Units will adopt a defensive stance a bit different from 'DEFENSIVE', ATGM & INFANTRY with RPG will be located on frontline with the armored units. (The groups of units will be smaller)

--- a/game/ground_forces/combat_stance.py
+++ b/game/ground_forces/combat_stance.py
@@ -8,5 +8,5 @@ class CombatStance(Enum):
     )
     RETREAT = 2  # Unit will retreat
     BREAKTHROUGH = 3  # Unit will attempt a breakthrough, rushing forward very aggressively with big group of armored units, and even less armored units will move aggressively
-    ELIMINATION = 4  # Unit will progress aggresively toward anemy units, attempting to eliminate the ennemy force
+    ELIMINATION = 4  # Unit will progress aggressively toward anemy units, attempting to eliminate the ennemy force
     AMBUSH = 5  # Units will adopt a defensive stance a bit different from 'DEFENSIVE', ATGM & INFANTRY with RPG will be located on frontline with the armored units. (The groups of units will be smaller)

--- a/game/htn.py
+++ b/game/htn.py
@@ -95,7 +95,7 @@ class Planner(Generic[WorldStateT, PrimitiveTaskT]):
                 # resuming a prior attempt to execute this task after a subtask of the
                 # previously selected method failed.
                 #
-                # Otherwise this is the first exectution of this task so we need to
+                # Otherwise this is the first execution of this task so we need to
                 # create the generator.
                 if planning_state.methods is None:
                     methods = task.each_valid_method(planning_state.state)

--- a/game/layout/layout.py
+++ b/game/layout/layout.py
@@ -105,7 +105,7 @@ class TgoLayoutUnitGroup:
     # size / all available LayoutUnits
     unit_count: list[int] = field(default_factory=list)
 
-    # defintion which unit types are supported
+    # definition which unit types are supported
     unit_types: list[Type[DcsUnitType]] = field(default_factory=list)
     unit_classes: list[UnitClass] = field(default_factory=list)
     fallback_classes: list[UnitClass] = field(default_factory=list)

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -75,7 +75,7 @@ class PydcsWaypointBuilder:
             # though it's set to "Turning Point". If I set this to "Fly Over
             # Point" and then save the mission in the ME DCS resets it.
             if self.flight.client_count > 0:
-                # Set Altitute to 0 AGL for player flights so that they can slave target pods or weapons to the waypoint
+                # Set Altitude to 0 AGL for player flights so that they can slave target pods or weapons to the waypoint
                 waypoint.alt = 0
                 waypoint.alt_type = "RADIO"
 

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -601,7 +601,7 @@ class HelipadGenerator:
         # This gets called for every control point, so we don't want to add an empty group (causes DCS mission editor to crash)
         if len(self.cp.helipads) == 0:
             return
-        # Note: Helipad are generated as neutral object in order not to interfer with
+        # Note: Helipad are generated as neutral object in order not to interfere with
         # capture triggers
         country = self.m.country(self.game.coalition_for(self.cp.captured).country_name)
 

--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -76,7 +76,7 @@ class LuaPluginDefinition:
 
     @classmethod
     def from_json(cls, name: str, path: Path) -> LuaPluginDefinition:
-        """Loads teh plugin definitions from the given plugin.json path."""
+        """Loads the plugin definitions from the given plugin.json path."""
         data = json.loads(path.read_text())
 
         options = []

--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class LuaPluginWorkOrder:
-    """A script to be loaded at mision start.
+    """A script to be loaded at mission start.
 
     Typically, a work order is used for the main plugin script, and another for
     configuration. The main script is added to scriptsWorkOrders and the configuration

--- a/game/weather/weather.py
+++ b/game/weather/weather.py
@@ -150,7 +150,7 @@ class Weather(ABC):
     @staticmethod
     def random_temperature(average_temperature: float) -> float:
         # "Safe" constants based roughly on ME.
-        # Temperatures are in Celcius.
+        # Temperatures are in Celsius.
         SAFE_MIN = -12
         SAFE_MAX = 49
         # Use normalvariate to get normal distribution, more realistic than uniform

--- a/qt_ui/widgets/QDebriefingInformation.py
+++ b/qt_ui/widgets/QDebriefingInformation.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QFrame
 
 class QDebriefingInformation(QFrame):
     """
-    UI component to display debreifing informations
+    UI component to display debreifing information
     """
 
     def __init__(self):

--- a/qt_ui/widgets/QLiberationCalendar.py
+++ b/qt_ui/widgets/QLiberationCalendar.py
@@ -8,7 +8,7 @@ class QLiberationCalendar(QCalendarWidget):
         self.setVerticalHeaderFormat(QCalendarWidget.NoVerticalHeader)
         self.setGridVisible(False)
 
-        # Overrride default QCalendar behaviour that is rendering week end days in red
+        # Override default QCalendar behaviour that is rendering week end days in red
         for d in (
             QtCore.Qt.Monday,
             QtCore.Qt.Tuesday,

--- a/qt_ui/widgets/ato.py
+++ b/qt_ui/widgets/ato.py
@@ -298,7 +298,7 @@ class QPackageList(QListView):
         self.ato_model.cancel_or_abort_package_at_index(index)
 
     def on_new_packages(self, _parent: QModelIndex, first: int, _last: int) -> None:
-        # Select the newly created pacakges. This should only ever happen due to
+        # Select the newly created packages. This should only ever happen due to
         # the player saving a new package, so selecting it helps them view/edit
         # it faster.
         self.selectionModel().setCurrentIndex(

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -115,7 +115,7 @@ class SquadronBaseSelector(QComboBox):
 
         if selected_base:
             self.setCurrentText(selected_base.name)
-        # TODO can we get a prefered base if none is selected?
+        # TODO can we get a preferred base if none is selected?
 
     def set_aircraft_type(self, aircraft_type: Optional[AircraftType]):
         self.clear()

--- a/qt_ui/windows/infos/QInfoList.py
+++ b/qt_ui/windows/infos/QInfoList.py
@@ -25,7 +25,7 @@ class QInfoList(QListView):
     def update_list(self):
         self.model.clear()
         if self.game is not None:
-            for i, info in enumerate(reversed(self.game.informations)):
+            for i, info in enumerate(reversed(self.game.information)):
                 self.model.appendRow(QInfoItem(info))
             self.selectionModel().setCurrentIndex(
                 self.indexAt(QPoint(1, 1)), QItemSelectionModel.Select


### PR DESCRIPTION
A small cleanup of textual errors across the project.

### Typo corrections:
- `changelog.md`, line 482: `dispalys` → `displays`
- `changelog.md`, line 500: `situtation` → `situation`
- `changelog.md`, line 806: `ocassionally` → `occasionally`
- `changelog.md`, line 913: `Exanded` → `Expanded`
- `changelog.md`, line 989: `detailled` → `detailed`
- `changelog.md`, line 989: `informations` → `information`
- `docs/modding/fuel-consumption-measurement.md`, line 16: `maintian` → `maintain`
- `docs/modding/fuel-consumption-measurement.md`, line 24: `descision` → `decision`
- `game/ato/flightplans/airassault.py`, line 107: `gurantee` → `guarantee`
- `game/ato/flightplans/airassault.py`, line 122: `gurantee` → `guarantee`
- `game/campaignloader/squadrondefgenerator.py`, line 298: `Vermillion` → `Vermilion`
- `game/data/doctrine.py`, line 40: `pacakge` → `package`
- `game/data/doctrine.py`, line 163: `pacakge` → `package`
- `game/dcs/aircrafttype.py`, line 251: `Aircaft` → `Aircraft`
- `game/game.py`, line 308: `specifc` → `specific`
- `game/game.py`, line 447: `informations` → `information`
- `game/game.py`, line 575: `seperation` → `separation`
- `game/game.py`, line 577: `seperation` → `separation`
- `game/game.py`, line 582: `seperation` → `separation`
- `game/game.py`, line 587: `seperation` → `separation`
- `game/ground_forces/combat_stance.py`, line 10: `aggresively` → `aggressively`
- `game/ground_forces/combat_stance.py`, line 11: `aggresively` → `aggressively`
- `game/htn.py`, line 98: `exectution` → `execution`
- `game/layout/layout.py`, line 108: `defintion` → `definition`
- `game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py`, line 78: `Altitute` → `Altitude`
- `game/weather/weather.py`, line 153: `Celcius` → `Celsius`
- `qt_ui/widgets/QDebriefingInformation.py`, line 6: `informations` → `information`
- `qt_ui/widgets/QLiberationCalendar.py`, line 11: `Overrride` → `Override`
- `qt_ui/widgets/ato.py`, line 301: `pacakges` → `packages`
- `qt_ui/windows/AirWingConfigurationDialog.py`, line 118: `prefered` → `preferred`
- `qt_ui/windows/infos/QInfoList.py`, line 28: `informations` → `information`

No functional code has been altered.