### PR TITLE
Remove package when last flight in package is cancelled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Saves from 13.x are not compatible with 14.0.0.
 
 * **[UI]** Air Wing and Transfers buttons disabled when no game is loaded as pressing them without a game loaded resulted in a crash.
 * **[UI]** Units are restored to full health when repaired.
+* **[UI]** A package is cancelled (deleted) when the last flight in the package is cancelled instead of showing "No mission".
 
 # 13.0.0
 

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -172,6 +172,12 @@ class PackageModel(QAbstractListModel):
             else:
                 flight.abort()
                 EventStream.put_nowait(GameUpdateEvents().update_flight(flight))
+            # If there are no more flights in the package, delete the package.
+            if len(self.package.flights) == 0:
+                flight.squadron.coalition.ato.remove_package(flight.package)
+                # Update ATO model so packages list is refreshed.
+                is_player = flight.squadron.coalition.player
+                self.game_model.ato_model_for(is_player).replace_from_game(is_player)
 
     def delete_flight(self, flight: Flight) -> None:
         """Removes the given flight from the package."""


### PR DESCRIPTION
This PR handles the scenario where the last flight in a package is cancelled (deleted). Previously, the package would show "No mission". With this PR, the package is cancelled (deleted).