### PR TITLE
Check if callsign is None before releasing to handle scenario where callsign was never generated correctly

### DIFF
--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -312,9 +312,12 @@ class AtoModel(QAbstractListModel):
         index = self.ato.packages.index(package)
         self.beginRemoveRows(QModelIndex(), index, index)
         for flight in package.flights:
-            self.game_model.game.blue.callsign_generator.release_callsign(
-                flight.callsign
-            )
+            # Check if flight.callsign is None to handle case where callsign was not generated.
+            # This can happen when a module does not support the standard  callsigns e.g. Kiowa.
+            if flight.callsign is not None:
+                self.game_model.game.blue.callsign_generator.release_callsign(
+                    flight.callsign
+                )
         self.ato.remove_package(package)
         self.endRemoveRows()
         # noinspection PyUnresolvedReferences


### PR DESCRIPTION
This PR is a workaround for modules where the standard callsigns (Ford, Uzi etc) are not supported. Callsigns are not generated correctly and a crash occurs when trying to release them if a package is released.