### PR TITLE
Make termination of fast forward more robust

### DIFF
--- a/game/ato/flightstate/inflight.py
+++ b/game/ato/flightstate/inflight.py
@@ -168,12 +168,7 @@ class InFlight(FlightState, ABC):
         return StartType.IN_FLIGHT
 
     def should_halt_sim(self) -> bool:
-        if (
-            self.flight.client_count > 0
-            and self.settings.fast_forward_stop_condition
-            == FastForwardStopCondition.PLAYER_AT_IP
-            and self.is_at_ip
-        ):
+        if self._halt_sim_for_player_at_ip():
             logging.info(
                 f"Interrupting simulation because {self.flight} has players and has "
                 "reached IP"

--- a/game/ato/flightstate/inflight.py
+++ b/game/ato/flightstate/inflight.py
@@ -179,4 +179,70 @@ class InFlight(FlightState, ABC):
                 "reached IP"
             )
             return True
+
+        if self.settings.fast_forwward_stop_condition in {
+            FastForwardStopCondition.PLAYER_TAKEOFF,
+            FastForwardStopCondition.PLAYER_TAXI,
+            FastForwardStopCondition.PLAYER_STARTUP,
+        }:
+            logging.info(
+                f"Interrupting simulation because {self.flight} has players and is already inflight "
+            )
+            return True
         return False
+
+    def _halt_sim_for_player_at_ip(self) -> bool:
+        if (
+            self.settings.fast_forward_stop_condition
+            != FastForwardStopCondition.PLAYER_AT_IP
+        ):
+            return False
+
+        if self.flight.client_count == 0:
+            return False
+
+        ingress_waypoint_types = {
+            FlightWaypointType.INGRESS_BAI,
+            FlightWaypointType.INGRESS_CAS,
+            FlightWaypointType.INGRESS_DEAD,
+            FlightWaypointType.INGRESS_OCA_AIRCRAFT,
+            FlightWaypointType.INGRESS_OCA_RUNWAY,
+            FlightWaypointType.INGRESS_SEAD,
+            FlightWaypointType.INGRESS_STRIKE,
+            FlightWaypointType.INGRESS_AIR_ASSAULT,
+        }
+
+        flight_plan_has_ip = False
+        flight_plan_has_patrol_start = False  # BARCAP plans don't have IP, just a PATROL_TRACK at the start waypoint
+        flight_plan_has_nav = False  # CAS plans don't have IP, but has NAV points.
+        for waypont_index in range(
+            self.waypoint_index, len(self.flight.flight_plan.waypoints)
+        ):
+            if (
+                self.flight.flight_plan.waypoints[waypoint_index].waypoint_type
+                in ingress_waypoint_types
+            ):
+                flight_plan_has_ip = True
+                break
+            if (
+                self.flight.flight_plan.waypoints[waypoint_index].waypoint_type
+                == FlightWaypointType.PATROL_TRACK
+            ):
+                flight_plan_has_patrol_start = True
+            if (
+                self.flight.flight_plan.waypoints[waypoint_index].waypoint_type
+                == FlightWaypointType.NAV
+            ):
+                flight_plan_has_nav = True
+
+        if flight_plan_has_ip:
+            return self.current_waypoint.waypoint_point in ingress_waypoint_types
+        if flight_plan_has_patrol_start:
+            return (
+                self.current_waypoint.waypoint_point == FlightWaypointType.PATROL_TRACK
+            )
+        if flight_plan_has_nav:
+            return self.current_waypoint.waypoint_point == FlightWaypointType.NAV
+
+        # Not a recognized flight plan type, stop sim to be on the safe side.
+        return True

--- a/game/ato/flightstate/inflight.py
+++ b/game/ato/flightstate/inflight.py
@@ -180,7 +180,7 @@ class InFlight(FlightState, ABC):
             )
             return True
 
-        if self.settings.fast_forwward_stop_condition in {
+        if self.settings.fast_forward_stop_condition in {
             FastForwardStopCondition.PLAYER_TAKEOFF,
             FastForwardStopCondition.PLAYER_TAXI,
             FastForwardStopCondition.PLAYER_STARTUP,
@@ -215,7 +215,7 @@ class InFlight(FlightState, ABC):
         flight_plan_has_ip = False
         flight_plan_has_patrol_start = False  # BARCAP plans don't have IP, just a PATROL_TRACK at the start waypoint
         flight_plan_has_nav = False  # CAS plans don't have IP, but has NAV points.
-        for waypont_index in range(
+        for waypoint_index in range(
             self.waypoint_index, len(self.flight.flight_plan.waypoints)
         ):
             if (
@@ -236,13 +236,13 @@ class InFlight(FlightState, ABC):
                 flight_plan_has_nav = True
 
         if flight_plan_has_ip:
-            return self.current_waypoint.waypoint_point in ingress_waypoint_types
+            return self.current_waypoint.waypoint_type in ingress_waypoint_types
         if flight_plan_has_patrol_start:
             return (
-                self.current_waypoint.waypoint_point == FlightWaypointType.PATROL_TRACK
+                self.current_waypoint.waypoint_type == FlightWaypointType.PATROL_TRACK
             )
         if flight_plan_has_nav:
-            return self.current_waypoint.waypoint_point == FlightWaypointType.NAV
+            return self.current_waypoint.waypoint_type == FlightWaypointType.NAV
 
         # Not a recognized flight plan type, stop sim to be on the safe side.
         return True

--- a/game/ato/flightstate/takeoff.py
+++ b/game/ato/flightstate/takeoff.py
@@ -56,7 +56,7 @@ class Takeoff(AtDeparture):
             )
             return True
 
-        if self.settings.fast_forwward_stop_condition in {
+        if self.settings.fast_forward_stop_condition in {
             FastForwardStopCondition.PLAYER_TAXI,
             FastForwardStopCondition.PLAYER_STARTUP,
         }:

--- a/game/ato/flightstate/takeoff.py
+++ b/game/ato/flightstate/takeoff.py
@@ -55,6 +55,15 @@ class Takeoff(AtDeparture):
                 "reached takeoff time"
             )
             return True
+
+        if self.settings.fast_forwward_stop_condition in {
+            FastForwardStopCondition.PLAYER_TAXI,
+            FastForwardStopCondition.PLAYER_STARTUP,
+        }:
+            logging.info(
+                f"Interrupting simulation because {self.flight} has players and is already taking off "
+            )
+            return True
         return False
 
     @property

--- a/game/ato/flightstate/taxi.py
+++ b/game/ato/flightstate/taxi.py
@@ -47,7 +47,7 @@ class Taxi(AtDeparture):
                 "reached taxi time"
             )
             return True
-        if self.settings.fast_forwward_stop_condition in {
+        if self.settings.fast_forward_stop_condition in {
             FastForwardStopCondition.PLAYER_STARTUP,
         }:
             logging.info(

--- a/game/ato/flightstate/taxi.py
+++ b/game/ato/flightstate/taxi.py
@@ -47,6 +47,13 @@ class Taxi(AtDeparture):
                 "reached taxi time"
             )
             return True
+        if self.settings.fast_forwward_stop_condition in {
+            FastForwardStopCondition.PLAYER_STARTUP,
+        }:
+            logging.info(
+                f"Interrupting simulation because {self.flight} has players and is already taxiing "
+            )
+            return True
         return False
 
     @property

--- a/game/game.py
+++ b/game/game.py
@@ -613,3 +613,10 @@ class Game:
             )
         elif turn_state is TurnState.LOSS:
             self.message("Game Over, you lose. Start a new campaign to continue.")
+
+    def ato_has_clients(self) -> bool:
+        for package in self.blue.ato.packages:
+            for flight in package.flights:
+                if flight.client_count > 0:
+                    return True
+        return False

--- a/game/sim/missionsimulation.py
+++ b/game/sim/missionsimulation.py
@@ -56,6 +56,14 @@ class MissionSimulation:
         ):
             events.complete_simulation()
             return events
+            
+        # Stop fast forward if there are no clients and the settings require a player to reach a certain state.
+        if not self.game.ato_has_clients() and self.game.settings.fast_forward_stop_condition in {            FastForwardStopCondition.PLAYER_TAKEOFF,
+            FastForwardStopCondition.PLAYER_TAXI,
+            FastForwardStopCondition.PLAYER_STARTUP,FastForwardStopCondition.PLAYER_AT_IP}:
+            events.complete_simulation()
+            return events
+            
         self.aircraft_simulation.on_game_tick(
             events, self.time, TICK, combat_resolution_method, force_continue
         )

--- a/game/sim/missionsimulation.py
+++ b/game/sim/missionsimulation.py
@@ -56,14 +56,21 @@ class MissionSimulation:
         ):
             events.complete_simulation()
             return events
-            
+
         # Stop fast forward if there are no clients and the settings require a player to reach a certain state.
-        if not self.game.ato_has_clients() and self.game.settings.fast_forward_stop_condition in {            FastForwardStopCondition.PLAYER_TAKEOFF,
-            FastForwardStopCondition.PLAYER_TAXI,
-            FastForwardStopCondition.PLAYER_STARTUP,FastForwardStopCondition.PLAYER_AT_IP}:
+        if (
+            not self.game.ato_has_clients()
+            and self.game.settings.fast_forward_stop_condition
+            in {
+                FastForwardStopCondition.PLAYER_TAKEOFF,
+                FastForwardStopCondition.PLAYER_TAXI,
+                FastForwardStopCondition.PLAYER_STARTUP,
+                FastForwardStopCondition.PLAYER_AT_IP,
+            }
+        ):
             events.complete_simulation()
             return events
-            
+
         self.aircraft_simulation.on_game_tick(
             events, self.time, TICK, combat_resolution_method, force_continue
         )

--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -149,13 +149,6 @@ class QTopPanel(QFrame):
             estimator = TotEstimator(package)
             package.time_over_target = estimator.earliest_tot(now)
 
-    def ato_has_clients(self) -> bool:
-        for package in self.game.blue.ato.packages:
-            for flight in package.flights:
-                if flight.client_count > 0:
-                    return True
-        return False
-
     def confirm_no_client_launch(self) -> bool:
         result = QMessageBox.question(
             self,
@@ -248,7 +241,7 @@ class QTopPanel(QFrame):
 
     def launch_mission(self):
         """Finishes planning and waits for mission completion."""
-        if not self.ato_has_clients() and not self.confirm_no_client_launch():
+        if not self.game.ato_has_clients() and not self.confirm_no_client_launch():
             return
 
         if self.check_no_missing_pilots():


### PR DESCRIPTION
This PR implements more robust checks to stopping fast forward by:

- If the termination condition is that a player reaches a certain state, do not fast forward if there are no players
- If the termination condition is that a player reaches a certain state, do not fast forward if the player is already beyond that state
- If the termination condition is that a player reaches the IP, do not fast forward if there  is no IP or similar waypoint in the flight plan.