### PR TITLE
When selecting squadron in Create Flight window, order by number of available aircraft in descending order to avoid limiting flight size when another squadron has enough aircraft for a full flight

### DIFF
--- a/qt_ui/windows/mission/flight/SquadronSelector.py
+++ b/qt_ui/windows/mission/flight/SquadronSelector.py
@@ -47,7 +47,7 @@ class SquadronSelector(QComboBox):
         if aircraft is None:
             self.addItem("No aircraft selected", None)
             return
-
+        feasible_squadrons = []
         for squadron in self.air_wing.squadrons_for(aircraft):
             if not squadron.capable_of(task):
                 continue
@@ -55,6 +55,10 @@ class SquadronSelector(QComboBox):
                 continue
             if squadron.location.ferry_only:
                 continue
+            feasible_squadrons.append(squadron)
+        for squadron in sorted(
+            feasible_squadrons, key=lambda s: s.untasked_aircraft, reverse=True
+        ):
             self.addItem(f"{squadron.location}: {squadron}", squadron)
 
         if self.count() == 0:


### PR DESCRIPTION
This PR updates the logic for populating the squadrons in the Create Flight window.

Before this PR, the Squadron drop down can chow

Squadron A (selected by default): 1 aircraft, leading to a partially filled flight.
Squadron B: 4 aircraft, leading to a full flight.

This PR makes Squadron B the default.