### PR TITLE
Update data: add units from Currenthill, Cold war unit packs. Add fuel consumption data for A-4EC, A-10A, A-10C, AV-8B, F-14A, F-14B, F-15C. Update hit points.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+# 14.1.0
+
+Saves from 14.x are compatible with 14.1.0.
+
+## Features/Improvements
+
+* **[Data]** Added new units from Currenthill and Cold War packs. Added M1A2 Abrams SEP V3 and MaxxPro M-RAP. Updated factions data for new units.
+* **[Data]** Added fuel usage data for A-4EC, A-10A, A-10C, AV-8B, F-14A, F-14B, F-15C allowing for better fuel estimation during fast forward and more detailed kneeboard fuel status.
+* **[Data]** Updated hit point data for all units.
+
 # 14.0.0
 
 Saves from 13.x are not compatible with 14.0.0.

--- a/resources/factions/argentina_1982.yaml
+++ b/resources/factions/argentina_1982.yaml
@@ -19,6 +19,7 @@ frontline_units:
   - AAVP-7A1 'Amtrac'
   - Scout LC with DSHK 12.7mm
   - Scout LC with KORD 12.7mm
+  - FV101
 artillery_units:
   - MLRS LC with B8M1 80mm
 logistics_units:

--- a/resources/factions/bluefor_coldwar.yaml
+++ b/resources/factions/bluefor_coldwar.yaml
@@ -33,6 +33,8 @@ frontline_units:
   - M113
   - M48 Chaparral
   - M60A3 "Patton"
+  - FV101
+  - FV107
 artillery_units:
   - M109A6 Paladin
 logistics_units:

--- a/resources/factions/bluefor_modern.yaml
+++ b/resources/factions/bluefor_modern.yaml
@@ -70,16 +70,22 @@ frontline_units:
   - M1043 HMMWV (M2 HMG)
   - M1045 HMMWV (BGM-71 TOW)
   - M1097 Heavy HMMWV Avenger
+  - M1126 Stryker CV
   - M1134 Stryker ATGM (BGM-71 TOW)
   - M1A2 Abrams
+  - M1A2 Abrams SEP V3
   - M2A2 Bradley
   - M6 Linebacker
   - Marder 1A3
   - Merkava Mk IV
   - VAB Mephisto
+  - MaxxPro MRAP
+  - M-ATV MRAP
 artillery_units:
   - M109A6 Paladin
   - M270 Multiple Launch Rocket System
+  - M142 HIMARS M31 GMLIRS HE
+  - M142 HIMARS M30 GMLIRS Cluster Munitions
 logistics_units:
   - Truck M818 6x6
 infantry_units:
@@ -91,12 +97,15 @@ preset_groups:
   - Hawk
   - Patriot
   - NASAMS AIM-120C
+  - IRIS-T SLM
 naval_units:
   - DDG Arleigh Burke IIa
   - CG Ticonderoga
   - LHA-1 Tarawa
   - CVN-74 John C. Stennis
-missiles: []
+missiles:
+  - M142 HIMARS M39A1 ATACMS Cluster Munitions
+  - M142 HIMARS M48 ATACMS HE
 air_defense_units:
   - EWR AN/FPS-117 Radar
   - M1097 Heavy HMMWV Avenger

--- a/resources/factions/dprk_1950_fictional.yaml
+++ b/resources/factions/dprk_1950_fictional.yaml
@@ -18,8 +18,8 @@ frontline_units:
   - BRDM-2
   - Grad MRL FDDM (FC)
   - MT-LB
-  - T-55A
   - ZU-23 on Ural-375
+  - T-34-85
 artillery_units:
   - BM-21 Grad
 logistics_units:

--- a/resources/factions/egypt_1973.yaml
+++ b/resources/factions/egypt_1973.yaml
@@ -16,7 +16,7 @@ frontline_units:
   - BMP-1
   - BRDM-2
   - BRDM-2_malyutka
-  - BTR-80
+  - BTR-60
   - PT-76
   - ZSU-23-4 Shilka
 artillery_units:

--- a/resources/factions/egypt_1973.yaml
+++ b/resources/factions/egypt_1973.yaml
@@ -15,6 +15,7 @@ frontline_units:
   - T-55A
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - PT-76
   - ZSU-23-4 Shilka

--- a/resources/factions/gdr_1985.yaml
+++ b/resources/factions/gdr_1985.yaml
@@ -20,6 +20,7 @@ frontline_units:
   - BMP-1
   - BMP-2
   - BRDM-2
+  - BRDM-2_malyutka
   - MT-LB
   - T-55A
   - T-72B with Kontakt-1 ERA

--- a/resources/factions/gdr_1985.yaml
+++ b/resources/factions/gdr_1985.yaml
@@ -21,6 +21,7 @@ frontline_units:
   - BMP-2
   - BRDM-2
   - BRDM-2_malyutka
+  - BTR-70
   - MT-LB
   - T-55A
   - T-72B with Kontakt-1 ERA

--- a/resources/factions/iran_1988.yaml
+++ b/resources/factions/iran_1988.yaml
@@ -19,7 +19,7 @@ tankers:
 frontline_units:
   - Chieftain Mk.3
   - BMP-1
-  - BTR-80
+  - BTR-60
   - M113
   - M60A3 "Patton"
   - ZSU-23-4 Shilka

--- a/resources/factions/iran_2015.yaml
+++ b/resources/factions/iran_2015.yaml
@@ -30,7 +30,7 @@ frontline_units:
   - Chieftain Mk.3
   - BMP-1
   - BMP-2
-  - BTR-80
+  - BTR-60
   - M113
   - M60A3 "Patton"
   - T-72B with Kontakt-1 ERA

--- a/resources/factions/iraq_1991.yaml
+++ b/resources/factions/iraq_1991.yaml
@@ -32,7 +32,7 @@ frontline_units:
   - BMP-1
   - BRDM-2
   - BRDM-2_malyutka
-  - BTR-80
+  - BTR-60
   - MT-LB
   - PT-76
   - T-55A

--- a/resources/factions/iraq_1991.yaml
+++ b/resources/factions/iraq_1991.yaml
@@ -31,6 +31,7 @@ frontline_units:
   - Chieftain Mk.3
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - MT-LB
   - PT-76

--- a/resources/factions/libya_2011.yaml
+++ b/resources/factions/libya_2011.yaml
@@ -19,6 +19,7 @@ tankers:
 frontline_units:
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - PT-76
   - SAM SA-8 Osa "Gecko" TEL
   - T-55A

--- a/resources/factions/north_korea_2000.yaml
+++ b/resources/factions/north_korea_2000.yaml
@@ -25,6 +25,7 @@ frontline_units:
   - PT-76
   - SA-9 Strela
   - T-55A
+  - T-62M
   - T-72B with Kontakt-1 ERA
   - T-80UD
   - ZSU-57-2 'Sparka'

--- a/resources/factions/north_korea_2000.yaml
+++ b/resources/factions/north_korea_2000.yaml
@@ -21,7 +21,7 @@ frontline_units:
   - BMP-1
   - BRDM-2
   - BRDM-2_malyutka
-  - BTR-80
+  - BTR-60
   - PT-76
   - SA-9 Strela
   - T-55A

--- a/resources/factions/north_korea_2000.yaml
+++ b/resources/factions/north_korea_2000.yaml
@@ -20,6 +20,7 @@ tankers:
 frontline_units:
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - PT-76
   - SA-9 Strela

--- a/resources/factions/pakistan_2015.yaml
+++ b/resources/factions/pakistan_2015.yaml
@@ -16,7 +16,6 @@ awacs:
 tankers:
   - IL-78M
 frontline_units:
-  - BTR-80
   - HQ-7 Launcher
   - M113
   - T-55A

--- a/resources/factions/peru_1995.yaml
+++ b/resources/factions/peru_1995.yaml
@@ -15,6 +15,7 @@ aircrafts:
 frontline_units: 
   - AMX-13 75mm  
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80 
   - T-55A
   - M1043 HMMWV (M2 HMG)

--- a/resources/factions/pmc_russian.yaml
+++ b/resources/factions/pmc_russian.yaml
@@ -14,6 +14,7 @@ aircrafts:
   - Mi-8MTV2 Hip
 frontline_units:
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - Cobra
   - SA-13 Gopher (9K35 Strela-10M3)

--- a/resources/factions/pmc_russian_hard.yaml
+++ b/resources/factions/pmc_russian_hard.yaml
@@ -15,6 +15,7 @@ aircrafts:
 frontline_units:
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - BTR-D
   - Cobra

--- a/resources/factions/poland_2010.yaml
+++ b/resources/factions/poland_2010.yaml
@@ -30,6 +30,8 @@ artillery_units:
   - 2S1 Gvozdika
   - BM-21 Grad
   - SpGH DANA
+  - M142 HIMARS M31 GMLIRS HE
+  - M142 HIMARS M30 GMLIRS Cluster Munitions
 logistics_units:
   - LUV UAZ-469 Jeep
   - Truck Ural-375

--- a/resources/factions/russia_1965.yaml
+++ b/resources/factions/russia_1965.yaml
@@ -19,6 +19,7 @@ frontline_units:
   - BMD-1
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - BTR-D
   - PT-76

--- a/resources/factions/russia_1965.yaml
+++ b/resources/factions/russia_1965.yaml
@@ -25,6 +25,7 @@ frontline_units:
   - PT-76
   - S-60 57mm
   - T-55A
+  - T-62M
   - ZSU-57-2 'Sparka'
   - ZU-23 on Ural-375
 artillery_units:

--- a/resources/factions/russia_1965.yaml
+++ b/resources/factions/russia_1965.yaml
@@ -20,7 +20,7 @@ frontline_units:
   - BMP-1
   - BRDM-2
   - BRDM-2_malyutka
-  - BTR-80
+  - BTR-60
   - BTR-D
   - PT-76
   - S-60 57mm

--- a/resources/factions/russia_1975.yaml
+++ b/resources/factions/russia_1975.yaml
@@ -33,6 +33,7 @@ frontline_units:
   - PT-76
   - SAM SA-8 Osa "Gecko" TEL
   - T-55A
+  - T-62M
 artillery_units:
   - 2S1 Gvozdika
   - 2S9 Nona-S

--- a/resources/factions/russia_1975.yaml
+++ b/resources/factions/russia_1975.yaml
@@ -29,7 +29,7 @@ frontline_units:
   - BMP-1
   - BRDM-2
   - BRDM-2_malyutka
-  - BTR-80
+  - BTR-70
   - PT-76
   - SAM SA-8 Osa "Gecko" TEL
   - T-55A

--- a/resources/factions/russia_1975.yaml
+++ b/resources/factions/russia_1975.yaml
@@ -28,6 +28,7 @@ frontline_units:
   - BMD-1
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - PT-76
   - SAM SA-8 Osa "Gecko" TEL

--- a/resources/factions/russia_1980.yaml
+++ b/resources/factions/russia_1980.yaml
@@ -32,6 +32,7 @@ frontline_units:
   - BMD-1
   - BMP-1
   - BRDM-2
+  - BRDM-2_malyutka
   - BTR-80
   - PT-76
   - T-55A

--- a/resources/factions/russia_1980.yaml
+++ b/resources/factions/russia_1980.yaml
@@ -36,7 +36,7 @@ frontline_units:
   - BTR-70
   - PT-76
   - T-55A
-  - T-72B with Kontakt-1 ERA
+  - T-62M
 artillery_units: 
   - 2S1 Gvozdika
   - 2S9 Nona-S

--- a/resources/factions/russia_1980.yaml
+++ b/resources/factions/russia_1980.yaml
@@ -33,7 +33,7 @@ frontline_units:
   - BMP-1
   - BRDM-2
   - BRDM-2_malyutka
-  - BTR-80
+  - BTR-70
   - PT-76
   - T-55A
   - T-72B with Kontakt-1 ERA

--- a/resources/factions/russia_1990.yaml
+++ b/resources/factions/russia_1990.yaml
@@ -38,6 +38,7 @@ frontline_units:
 artillery_units:
   - 2S19 Msta-S
   - BM-27 Uragan
+  - TOS-1A
 logistics_units:
   - LUV UAZ-469 Jeep
   - Truck Ural-375

--- a/resources/factions/russia_1990.yaml
+++ b/resources/factions/russia_1990.yaml
@@ -35,6 +35,7 @@ frontline_units:
   - SA-13 Gopher (9K35 Strela-10M3)
   - T-72B with Kontakt-1 ERA
   - T-80UD
+  - T-80B
 artillery_units:
   - 2S19 Msta-S
   - BM-27 Uragan

--- a/resources/factions/russia_2010.yaml
+++ b/resources/factions/russia_2010.yaml
@@ -44,6 +44,7 @@ frontline_units:
 artillery_units:
   - 2S19 Msta-S
   - BM-27 Uragan
+  - TOS-1A
 logistics_units:
   - LUV UAZ-469 Jeep
   - Truck Ural-375
@@ -53,7 +54,9 @@ infantry_units:
   - Mortar 2B11 120mm
   - Paratrooper AKS
   - Paratrooper RPG-16
-missiles: []
+missiles:
+  - SS-26 Stone (9K720 Iskander) Cluster Munitions
+  - SS-26 Stone (9K720 Iskander) HE
 preset_groups:
   - SA-11
   - SA-10/S-300PS

--- a/resources/factions/russia_2010.yaml
+++ b/resources/factions/russia_2010.yaml
@@ -79,8 +79,9 @@ air_defense_units:
   - SAM SA-8 Osa "Gecko" TEL
   - SA-9 Strela
   - SA-13 Gopher (9K35 Strela-10M3)
-  - SA-15 Tor
+  - SA-15 Gauntlet 9K332 M2
   - SA-19 Grison (2K22 Tunguska)
+  - SA-22 Greyhound
   - AAA ZU-23 Closed Emplacement
   - ZU-23 on Ural-375
   - ZSU-23-4 Shilka

--- a/resources/factions/russia_2020.yaml
+++ b/resources/factions/russia_2020.yaml
@@ -42,6 +42,7 @@ frontline_units:
 artillery_units:
   - 2S19 Msta-S
   - BM-27 Uragan
+  - TOS-1A
 logistics_units:
   - LUV UAZ-469 Jeep
   - Truck Ural-375
@@ -50,7 +51,9 @@ infantry_units:
   - MANPADS SA-18 Igla-S "Grouse"
   - Paratrooper AKS
   - Paratrooper RPG-16
-missiles: []
+missiles:
+  - SS-26 Stone (9K720 Iskander) Cluster Munitions
+  - SS-26 Stone (9K720 Iskander) HE
 preset_groups:
   - SA-11
   - SA-10/S-300PS

--- a/resources/factions/russia_2020.yaml
+++ b/resources/factions/russia_2020.yaml
@@ -35,10 +35,12 @@ tankers:
 frontline_units:
   - BMP-2
   - BMP-3
+  - BMPT Terminator
   - SA-19 Grison (2K22 Tunguska)
   - T-72B with Kontakt-1 ERA
   - T-80UD
   - T-90A
+  - T-90M
 artillery_units:
   - 2S19 Msta-S
   - BM-27 Uragan
@@ -74,8 +76,9 @@ air_defense_units:
   - SAM SA-8 Osa "Gecko" TEL
   - SA-9 Strela
   - SA-13 Gopher (9K35 Strela-10M3)
-  - SA-15 Tor
+  - SA-15 Gauntlet 9K332 M2
   - SA-19 Grison (2K22 Tunguska)
+  - SA-22 Greyhound
   - AAA ZU-23 Closed Emplacement
   - ZU-23 on Ural-375
   - ZSU-23-4 Shilka

--- a/resources/factions/soviet_union_1943.yaml
+++ b/resources/factions/soviet_union_1943.yaml
@@ -17,6 +17,7 @@ frontline_units:
   - Daimler Armoured Car Mk I
   - M2A1 Half-Track
   - M4A2(75) Sherman
+  - T-34-85
 artillery_units:
   - BM-21 Grad
 logistics_units:

--- a/resources/factions/syria_1948.yaml
+++ b/resources/factions/syria_1948.yaml
@@ -12,6 +12,7 @@ frontline_units:
   - Panzerkampfwagen IV Ausf. H
   - Sd.Kfz.234/2 Puma
   - Sd.Kfz.251 "Hanomag"
+  - T-34-85
 artillery_units: []
 logistics_units:
   - LUV UAZ-469 Jeep

--- a/resources/factions/syria_1967_with_ww2_weapons.yaml
+++ b/resources/factions/syria_1967_with_ww2_weapons.yaml
@@ -24,6 +24,7 @@ frontline_units:
   - S-60 57mm
   - "Sturmgesch\xFCtz III Ausf. G"
   - T-55A
+  - T-34-85
   - ZSU-57-2 'Sparka'
 artillery_units:
   - BM-21 Grad

--- a/resources/factions/syria_1973.yaml
+++ b/resources/factions/syria_1973.yaml
@@ -17,6 +17,7 @@ frontline_units:
   - BMP-1
   - MT-LB
   - PT-76
+  - BTR-60
   - S-60 57mm
   - T-55A
   - ZSU-57-2 'Sparka'

--- a/resources/factions/syria_1982.yaml
+++ b/resources/factions/syria_1982.yaml
@@ -16,6 +16,7 @@ tankers:
   - IL-78M
 frontline_units:
   - BMP-1
+  - BTR-60
   - MT-LB
   - PT-76
   - S-60 57mm

--- a/resources/factions/syria_2011.yaml
+++ b/resources/factions/syria_2011.yaml
@@ -30,6 +30,7 @@ frontline_units:
   - MT-LB
   - PT-76
   - T-55A
+  - T-62M
   - T-72B with Kontakt-1 ERA
   - T-90A
   - ZSU-57-2 'Sparka'
@@ -68,6 +69,7 @@ air_defense_units:
   - SA-9 Strela
   - SA-13 Gopher (9K35 Strela-10M3)
   - SA-19 Grison (2K22 Tunguska)
+  - SA-22 Greyhound
   - AAA ZU-23 Closed Emplacement
   - ZU-23 on Ural-375
   - ZSU-23-4 Shilka

--- a/resources/factions/syria_2012.yaml
+++ b/resources/factions/syria_2012.yaml
@@ -33,6 +33,7 @@ frontline_units:
   - MT-LB
   - PT-76
   - T-55A
+  - T-62M
   - T-72B with Kontakt-1 ERA
   - T-90A
   - ZSU-57-2 'Sparka'
@@ -72,6 +73,7 @@ air_defense_units:
   - SA-9 Strela
   - SA-13 Gopher (9K35 Strela-10M3)
   - SA-19 Grison (2K22 Tunguska)
+  - SA-22 Greyhound
   - AAA ZU-23 Closed Emplacement
   - ZU-23 on Ural-375
   - ZSU-23-4 Shilka

--- a/resources/factions/uae_2015.yaml
+++ b/resources/factions/uae_2015.yaml
@@ -40,6 +40,7 @@ naval_units:
 missiles: []
 air_defense_units:
   - EWR AN/FPS-117 Radar
+  - SA-22 Greyhound
 requirements: {}
 carrier_names: []
 has_jtac: true

--- a/resources/factions/uk_1990.yaml
+++ b/resources/factions/uk_1990.yaml
@@ -25,6 +25,8 @@ frontline_units:
   - M1043 HMMWV (M2 HMG)
   - M1045 HMMWV (BGM-71 TOW)
   - M1097 Heavy HMMWV Avenger
+  - FV101
+  - FV107
 artillery_units:
   - M109A6 Paladin
   - M270 Multiple Launch Rocket System

--- a/resources/factions/ukraine_2010.yaml
+++ b/resources/factions/ukraine_2010.yaml
@@ -24,8 +24,10 @@ frontline_units:
   - BTR-80
   - M1043 HMMWV (M2 HMG)
   - SA-13 Gopher (9K35 Strela-10M3)
+  - T-64BV
   - T-72B with Kontakt-1 ERA
   - T-80UD
+  - T-84 BM Oplot
 artillery_units: []
 logistics_units:
   - LUV UAZ-469 Jeep

--- a/resources/factions/usa_2005.yaml
+++ b/resources/factions/usa_2005.yaml
@@ -47,15 +47,21 @@ frontline_units:
   - M1043 HMMWV (M2 HMG)
   - M1045 HMMWV (BGM-71 TOW)
   - M1097 Heavy HMMWV Avenger
+  - M1126 Stryker CV
   - M1126 Stryker ICV (M2 HMG)
   - M1128 Stryker Mobile Gun System
   - M1134 Stryker ATGM (BGM-71 TOW)
   - M1A2 Abrams
+  - M1A2 Abrams SEP V3
   - M2A2 Bradley
   - M6 Linebacker
+  - MaxxPro MRAP
+  - M-ATV MRAP
 artillery_units:
   - M109A6 Paladin
   - M270 Multiple Launch Rocket System
+  - M142 HIMARS M31 GMLIRS HE
+  - M142 HIMARS M30 GMLIRS Cluster Munitions
 logistics_units:
   - Truck M818 6x6
 infantry_units:
@@ -72,7 +78,9 @@ naval_units:
   - CG Ticonderoga
   - LHA-1 Tarawa
   - CVN-74 John C. Stennis
-missiles: []
+missiles:
+  - M142 HIMARS M39A1 ATACMS Cluster Munitions
+  - M142 HIMARS M48 ATACMS HE
 air_defense_units:
   - EWR AN/FPS-117 Radar
   - M1097 Heavy HMMWV Avenger

--- a/resources/groups/IRIS-T SLM.yaml
+++ b/resources/groups/IRIS-T SLM.yaml
@@ -1,0 +1,9 @@
+name: IRIS-T SLM
+tasks:
+  - MERAD
+units:
+  - IRIS-T SLM SR
+  - IRIS-T SLM CP
+  - IRIS-T SLM LN
+layouts:
+  - 4 Launcher Site (Semicircle)

--- a/resources/units/aircraft/A-10A.yaml
+++ b/resources/units/aircraft/A-10A.yaml
@@ -16,6 +16,12 @@ price: 12
 role: Close Air Support/Attack
 variants:
   A-10A Thunderbolt II: {}
+fuel:
+  taxi: 100
+  climb_ppm: 16
+  cruise_ppm: 12
+  combat_ppm: 14
+  min_safe: 2000
 tasks:
   BAI: 680
   CAS: 680

--- a/resources/units/aircraft/A-10C.yaml
+++ b/resources/units/aircraft/A-10C.yaml
@@ -24,6 +24,12 @@ radios:
     namer: a10c-legacy
     intra_flight_radio_index: 2
     inter_flight_radio_index: 2
+fuel:
+  taxi: 100
+  climb_ppm: 16
+  cruise_ppm: 12
+  combat_ppm: 14
+  min_safe: 2000
 tasks:
   BAI: 820
   CAS: 820

--- a/resources/units/aircraft/A-10C_2.yaml
+++ b/resources/units/aircraft/A-10C_2.yaml
@@ -28,6 +28,12 @@ radios:
     namer: a10c-ii
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
+fuel:
+  taxi: 100
+  climb_ppm: 16
+  cruise_ppm: 12
+  combat_ppm: 14
+  min_safe: 2000
 tasks:
   BAI: 830
   CAS: 830

--- a/resources/units/aircraft/A-4E-C.yaml
+++ b/resources/units/aircraft/A-4E-C.yaml
@@ -15,6 +15,12 @@ role: Carrier-based Attack/Light Fighter
 gunfighter: true
 variants:
   A-4E Skyhawk: {}
+fuel:
+  taxi: 100
+  climb_ppm: 14
+  cruise_ppm: 7.7
+  combat_ppm: 9
+  min_safe: 800
 tasks:
   BAI: 660
   BARCAP: 160

--- a/resources/units/aircraft/AV8BNA.yaml
+++ b/resources/units/aircraft/AV8BNA.yaml
@@ -37,6 +37,12 @@ radios:
     type: common
     intra_flight_radio_index: 1
     inter_flight_radio_index: 2
+fuel:
+  taxi: 100
+  climb_ppm: 20
+  cruise_ppm: 11
+  combat_ppm: 14
+  min_safe: 2000
 # default_overrides:
 #   AAR_Zone1: 0
 #   AAR_Zone2: 0

--- a/resources/units/aircraft/CH-47Fbl1.yaml
+++ b/resources/units/aircraft/CH-47Fbl1.yaml
@@ -30,3 +30,4 @@ radios:
 tasks:
   Air Assault: 120
   Transport: 110
+hit_points: 58

--- a/resources/units/aircraft/F-14A-135-GR-Early.yaml
+++ b/resources/units/aircraft/F-14A-135-GR-Early.yaml
@@ -32,6 +32,12 @@ radios:
     namer: tomcat
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
+fuel:
+  taxi: 250
+  climb_ppm: 35
+  cruise_ppm: 13
+  combat_ppm: 16
+  min_safe: 2000
 default_overrides:
   INSAlignmentStored: true
 #   ALE39Loadout: 0

--- a/resources/units/aircraft/F-14A-135-GR.yaml
+++ b/resources/units/aircraft/F-14A-135-GR.yaml
@@ -32,6 +32,12 @@ radios:
     namer: tomcat
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
+fuel:
+  taxi: 250
+  climb_ppm: 35
+  cruise_ppm: 13
+  combat_ppm: 16
+  min_safe: 2000
 default_overrides:
   INSAlignmentStored: true
 #   ALE39Loadout: 0

--- a/resources/units/aircraft/F-14B.yaml
+++ b/resources/units/aircraft/F-14B.yaml
@@ -32,6 +32,12 @@ radios:
     namer: tomcat
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
+fuel:
+  taxi: 250
+  climb_ppm: 35
+  cruise_ppm: 13
+  combat_ppm: 16
+  min_safe: 2000
 default_overrides:
   INSAlignmentStored: true
 #   ALE39Loadout: 0

--- a/resources/units/aircraft/F-15C.yaml
+++ b/resources/units/aircraft/F-15C.yaml
@@ -9,6 +9,12 @@ origin: USA
 price: 20
 role: Air-Superiority Fighter
 max_range: 400
+fuel:
+  taxi: 100
+  climb_ppm: 36
+  cruise_ppm: 11
+  combat_ppm: 13
+  min_safe: 2000
 variants:
   F-15C Eagle: {}
   F-15J Eagle: {}

--- a/resources/units/aircraft/F-4E-45MC.yaml
+++ b/resources/units/aircraft/F-4E-45MC.yaml
@@ -51,4 +51,4 @@ tasks:
   SEAD Escort: 120
   Strike: 400
   TARCAP: 410
-hit_points: 20
+hit_points: 18

--- a/resources/units/aircraft/Mi-28N.yaml
+++ b/resources/units/aircraft/Mi-28N.yaml
@@ -19,4 +19,4 @@ tasks:
   BAI: 420
   CAS: 420
   OCA/Aircraft: 420
-hit_points: 15
+hit_points: 20

--- a/resources/units/aircraft/MiG-29 Fulcrum.yaml
+++ b/resources/units/aircraft/MiG-29 Fulcrum.yaml
@@ -49,4 +49,4 @@ tasks:
   OCA/Runway: 410
   Strike: 410
   TARCAP: 370
-hit_points: 16
+hit_points: 20

--- a/resources/units/aircraft/OH58D.yaml
+++ b/resources/units/aircraft/OH58D.yaml
@@ -34,4 +34,4 @@ tasks:
   OCA/Aircraft: 470
   DEAD: 50
   Escort: 10
-hit_points: 12
+hit_points: 10

--- a/resources/units/aircraft/Tu-95MS.yaml
+++ b/resources/units/aircraft/Tu-95MS.yaml
@@ -19,4 +19,4 @@ variants:
 tasks:
   DEAD: 190
   Strike: 670
-hit_points: 60
+hit_points: 18

--- a/resources/units/ground_units/BRDM-2.yaml
+++ b/resources/units/ground_units/BRDM-2.yaml
@@ -1,12 +1,12 @@
 class: Recon
-description: "The PT-76 is a Soviet amphibious light tank that was introduced in the\
-  \ early 1950s and soon became the standard reconnaissance tank of the Soviet Army\
-  \ and the other Warsaw Pact armed forces. It was widely exported to other friendly\
-  \ states, like India, Iraq, Syria, North Korea and North Vietnam. Overall, some\
-  \ 25 countries used the PT-76. The tank's full name is Floating Tank\u201376 (\u043F\
-  \u043B\u0430\u0432\u0430\u044E\u0449\u0438\u0439 \u0442\u0430\u043D\u043A, plavayushchiy\
-  \ tank, or \u041F\u0422-76). 76 stands for the caliber of the main armament: the\
-  \ 76.2 mm D-56T series rifled tank gun."
+description: "The BRDM-2 (Boyevaya Razvedyvatelnaya Dozornaya Mashina, \u0411\u043E\
+  \u0435\u0432\u0430\u044F \u0420\u0430\u0437\u0432\u0435\u0434\u044B\u0432\u0430\u0442\
+  \u0435\u043B\u044C\u043D\u0430\u044F \u0414\u043E\u0437\u043E\u0440\u043D\u0430\u044F\
+  \ \u041C\u0430\u0448\u0438\u043D\u0430, literally \"Combat Reconnaissance/Patrol\
+  \ Vehicle\") is an amphibious armoured patrol car used by Russia and the former\
+  \ Soviet Union. It was also known under the designations BTR-40PB, BTR-40P-2 and\
+  \ GAZ 41-08. This vehicle, like many other Soviet designs, has been exported extensively\
+  \ and is in use in at least 38 countries."
 introduced: 1962
 manufacturer: GAZ
 origin: USSR/Russia

--- a/resources/units/ground_units/BRDM-2_malyutka.yaml
+++ b/resources/units/ground_units/BRDM-2_malyutka.yaml
@@ -1,0 +1,13 @@
+class: Recon
+description: "The BRDM-2 is an amphibious armoured patrol car used by Russia and the former\
+  \ Soviet Union. It was also known under the designations BTR-40PB, BTR-40P-2 and\
+  \ GAZ 41-08. This vehicle, like many other Soviet designs, has been exported extensively\
+  \ and is in use in at least 38 countries. This version is equipped with the AT-3 Sagger ATGM."
+introduced: 1963
+manufacturer: GAZ
+origin: USSR/Russia
+price: 6
+role: Amphibious Armoured Car
+variants:
+  BRDM-2_malyutka: {}
+hit_points: 3

--- a/resources/units/ground_units/BTR-60.yaml
+++ b/resources/units/ground_units/BTR-60.yaml
@@ -1,0 +1,9 @@
+class: APC
+description: "The BTR-70 is an eight-wheeled armored personnel carrier originally developed by the Soviet Union during the late 1960s under the manufacturing code GAZ-4905. On August 21, 1972, it was accepted into Soviet service and would later be widely exported."
+introduced: 1972
+origin: USSR/Russia
+price: 8
+role: Armoured Personnel Carrier
+variants:
+  BTR-70: {}
+hit_points: 3

--- a/resources/units/ground_units/BTR-60.yaml
+++ b/resources/units/ground_units/BTR-60.yaml
@@ -1,5 +1,5 @@
 class: APC
-description: "The BTR-70 is an eight-wheeled armored personnel carrier originally developed by the Soviet Union during the late 1960s under the manufacturing code GAZ-4905. On August 21, 1972, it was accepted into Soviet service and would later be widely exported."
+description: "The BTR-60 is the first vehicle in a series of Soviet eight-wheeled armoured personnel carriers (APCs). It was developed in the late 1950s as a replacement for the BTR-152 and was seen in public for the first time in 1961."
 introduced: 1972
 origin: USSR/Russia
 price: 8

--- a/resources/units/ground_units/BTR-60.yaml
+++ b/resources/units/ground_units/BTR-60.yaml
@@ -5,5 +5,5 @@ origin: USSR/Russia
 price: 8
 role: Armoured Personnel Carrier
 variants:
-  BTR-70: {}
+  BTR-60: {}
 hit_points: 3

--- a/resources/units/ground_units/BTR-70.yaml
+++ b/resources/units/ground_units/BTR-70.yaml
@@ -1,0 +1,9 @@
+class: APC
+description: "The BTR-60 is the first vehicle in a series of Soviet eight-wheeled armoured personnel carriers (APCs). It was developed in the late 1950s as a replacement for the BTR-152 and was seen in public for the first time in 1961."
+introduced: 1961
+origin: USSR/Russia
+price: 8
+role: Armoured Personnel Carrier
+variants:
+  BTR-70: {}
+hit_points: 3

--- a/resources/units/ground_units/BTR-70.yaml
+++ b/resources/units/ground_units/BTR-70.yaml
@@ -1,5 +1,5 @@
 class: APC
-description: "The BTR-60 is the first vehicle in a series of Soviet eight-wheeled armoured personnel carriers (APCs). It was developed in the late 1950s as a replacement for the BTR-152 and was seen in public for the first time in 1961."
+description: "The BTR-70 is an eight-wheeled armored personnel carrier originally developed by the Soviet Union during the late 1960s under the manufacturing code GAZ-4905. On August 21, 1972, it was accepted into Soviet service and would later be widely exported."
 introduced: 1961
 origin: USSR/Russia
 price: 8

--- a/resources/units/ground_units/CHAP_9K720_Cluster.yaml
+++ b/resources/units/ground_units/CHAP_9K720_Cluster.yaml
@@ -1,0 +1,9 @@
+class: Missile
+description: The 9K720 Iskander (NATO reporting name SS-26 Stone) is a family of Russian mobile short-range ballistic missile systems with a range of up to 500km (270 nmi; 310 mi). 
+introduced: 2006
+origin: Russia
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  SS-26 Stone (9K720 Iskander) Cluster Munitions: {}
+hit_points: 4

--- a/resources/units/ground_units/CHAP_9K720_HE.yaml
+++ b/resources/units/ground_units/CHAP_9K720_HE.yaml
@@ -1,0 +1,9 @@
+class: Missile
+description: The 9K720 Iskander (NATO reporting name SS-26 Stone) is a family of Russian mobile short-range ballistic missile systems with a range of up to 500km (270 nmi; 310 mi). 
+introduced: 2006
+origin: Russia
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  SS-26 Stone (9K720 Iskander) HE: {}
+hit_points: 3

--- a/resources/units/ground_units/CHAP_BMPT.yaml
+++ b/resources/units/ground_units/CHAP_BMPT.yaml
@@ -1,0 +1,9 @@
+class: Tank
+description: 'The BMPT Terminator is an armored fighting vehicle, designed for supporting tanks and other AFVs in urban areas. '
+introduced: 2011
+origin: Russia
+price: 25
+role: Tank Support Vehicle
+variants:
+  BMPT "Terminator": {}
+hit_points: 20

--- a/resources/units/ground_units/CHAP_BMPT.yaml
+++ b/resources/units/ground_units/CHAP_BMPT.yaml
@@ -5,5 +5,5 @@ origin: Russia
 price: 25
 role: Tank Support Vehicle
 variants:
-  BMPT "Terminator": {}
+  BMPT Terminator: {}
 hit_points: 20

--- a/resources/units/ground_units/CHAP_FV101.yaml
+++ b/resources/units/ground_units/CHAP_FV101.yaml
@@ -1,0 +1,11 @@
+class: Recon
+description: "The FV101 Scorpion is a British armoured reconnaissance vehicle and light tank."
+introduced: 1973
+manufacturer: Alvis/BAE Systems
+origin: UK
+price: 6
+role: Recon light tank
+variants:
+  CHAP_FV101: {}
+
+hit_points: 8

--- a/resources/units/ground_units/CHAP_FV101.yaml
+++ b/resources/units/ground_units/CHAP_FV101.yaml
@@ -6,6 +6,5 @@ origin: UK
 price: 6
 role: Recon light tank
 variants:
-  CHAP_FV101: {}
-
+  FV101: {}
 hit_points: 8

--- a/resources/units/ground_units/CHAP_FV107.yaml
+++ b/resources/units/ground_units/CHAP_FV107.yaml
@@ -6,6 +6,5 @@ origin: UK
 price: 6
 role: Recon light tank
 variants:
-  CHAP_FV107: {}
-
+  FV107: {}
 hit_points: 8

--- a/resources/units/ground_units/CHAP_FV107.yaml
+++ b/resources/units/ground_units/CHAP_FV107.yaml
@@ -1,0 +1,11 @@
+class: Recon
+description: "The FV107 Scimitar is an armoured tracked military reconnaissance vehicle, sometimes classed as a light tank, used by the British Army"
+introduced: 1974
+manufacturer: Alvis/BAE Systems
+origin: UK
+price: 6
+role: Recon light tank
+variants:
+  CHAP_FV107: {}
+
+hit_points: 8

--- a/resources/units/ground_units/CHAP_IRISTSLM_CP.yaml
+++ b/resources/units/ground_units/CHAP_IRISTSLM_CP.yaml
@@ -1,0 +1,5 @@
+class: CommandPost
+price: 25
+variants:
+  IRIS-T SLM CP: null
+hit_points: 3

--- a/resources/units/ground_units/CHAP_IRISTSLM_LN.yaml
+++ b/resources/units/ground_units/CHAP_IRISTSLM_LN.yaml
@@ -1,0 +1,5 @@
+class: TELAR
+price: 30
+variants:
+  IRIS-T SLM LN: null
+hit_points: 3

--- a/resources/units/ground_units/CHAP_IRISTSLM_STR.yaml
+++ b/resources/units/ground_units/CHAP_IRISTSLM_STR.yaml
@@ -1,0 +1,5 @@
+class: SearchTrackRadar
+price: 28
+variants:
+  IRIS-T SLM SR: null
+hit_points: 3

--- a/resources/units/ground_units/CHAP_M1130.yaml
+++ b/resources/units/ground_units/CHAP_M1130.yaml
@@ -1,0 +1,11 @@
+class: APC
+description: 'The CV (Command Vehicle) Stryker is a family of eight-wheeled
+  armored fighting vehicles derived from the Canadian LAV III. '
+introduced: 2002
+manufacturer: General Dynamics
+origin: USA
+price: 10
+role: Armoured Personnel Carrier
+variants:
+  M1126 Stryker CV: {}
+hit_points: 4

--- a/resources/units/ground_units/CHAP_M142_ATACMS_M39A1.yaml
+++ b/resources/units/ground_units/CHAP_M142_ATACMS_M39A1.yaml
@@ -1,0 +1,9 @@
+class: Missile
+description: The M142 High Mobility Artillery Rocket System (HIMARS) is a light multiple rocket launcher. The M39A1 variant uses the Army Tactical Missile System (ATACMS) 610 mm surface-to-surface missile carrying 950 M74 Anti-personnel and Anti-materiel (APAM) bomblets and a range of up to 165km/100mi.
+manufacturer: Lockheed Martin
+origin: USA
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  M142 HIMARS M39A1 ATACMS Cluster Munitions: {}
+hit_points: 3

--- a/resources/units/ground_units/CHAP_M142_ATACMS_M48.yaml
+++ b/resources/units/ground_units/CHAP_M142_ATACMS_M48.yaml
@@ -1,0 +1,9 @@
+class: Missile
+description: The M142 High Mobility Artillery Rocket System (HIMARS) is a light multiple rocket launcher. The M48 variant uses the Army Tactical Missile System (ATACMS) 610 mm surface-to-surface missile carrying a 500-pound (230 kg) WDU-18/B penetrating high explosive blast fragmentation warhead of the US Navy's Harpoon anti-ship missile and a range of up to 300km/186mi.
+manufacturer: Lockheed Martin
+origin: USA
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  M142 HIMARS M48 ATACMS HE: {}
+hit_points: 3

--- a/resources/units/ground_units/CHAP_M142_GMLRS_M30.yaml
+++ b/resources/units/ground_units/CHAP_M142_GMLRS_M30.yaml
@@ -1,0 +1,10 @@
+class: Artillery
+description: The M142 High Mobility Artillery Rocket System (HIMARS) is a light multiple rocket launcher. The M30 variant uses the Guided Multiple Launch Rocket System (GMLRS) 227 mm rockets carrying 404 DPICM M101 submunitions.
+introduced: 2005
+manufacturer: Lockheed Martin
+origin: USA
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  M142 HIMARS M30 GMLIRS Cluster Munitions: {}
+hit_points: 3

--- a/resources/units/ground_units/CHAP_M142_GMLRS_M31.yaml
+++ b/resources/units/ground_units/CHAP_M142_GMLRS_M31.yaml
@@ -1,0 +1,9 @@
+class: Artillery
+description: The M142 High Mobility Artillery Rocket System (HIMARS) is a light multiple rocket launcher. The M31 variant uses the Guided Multiple Launch Rocket System (GMLRS) 227 mm rockets carrying a 200 lb (91 kg) high-explosive unitary warhead
+manufacturer: Lockheed Martin
+origin: USA
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  M142 HIMARS M31 GMLIRS HE: {}
+hit_points: 3

--- a/resources/units/ground_units/CHAP_MATV.yaml
+++ b/resources/units/ground_units/CHAP_MATV.yaml
@@ -1,0 +1,10 @@
+class: Recon
+description: 'The Oshkosh M-ATV is a mine-resistant ambush protected vehicle.'
+introduced: 2009
+manufacturer: Oshkosh
+origin: USA
+price: 2
+role: Recon
+variants:
+  M-ATV MRAP: {}
+hit_points: 4

--- a/resources/units/ground_units/CHAP_PantsirS1.yaml
+++ b/resources/units/ground_units/CHAP_PantsirS1.yaml
@@ -1,0 +1,10 @@
+class: SHORAD
+description: "The Pantsir-S1 was designed to provide point air defence against aircraft, helicopters, precision munitions, cruise missiles and UAVs; and to provide additional protection to air defence units against enemy air attacks employing precision munitions, especially at low to extremely low altitudes"
+introduced: 2012
+manufacturer: Ulyanovsk
+origin: USSR/Russia
+price: 14
+role: Self-Propelled Surface-to-Air Missile Launcher
+variants:
+  SA-22 Greyhound: {}
+hit_points: 5

--- a/resources/units/ground_units/CHAP_T64BV.yaml
+++ b/resources/units/ground_units/CHAP_T64BV.yaml
@@ -1,0 +1,9 @@
+class: Tank
+description: The T-64 is a Soviet tank introduced in the early 1960s. The BV variant is a modernization by Ukroboronprom with third-generation surveillance and sighting units and is equipped with a new 12.7mm Snipex Laska K-2 heavy machine gun. It features up-to-date radio stations and additional "navigation, internal and external communication systems which meets NATO standards.
+introduced: 2022
+origin: Ukraine
+price: 18
+role: Main Battle Tank
+variants:
+  T-64BV: {}
+hit_points: 24

--- a/resources/units/ground_units/CHAP_T84OplotM.yaml
+++ b/resources/units/ground_units/CHAP_T84OplotM.yaml
@@ -1,0 +1,9 @@
+class: Tank
+description: "The T-84 is a Ukrainian main battle tank (MBT), based on the Soviet T-80 MBT introduced in 1976, specifically the diesel engine version: T-80UD. The T-84 was first built in 1994 and 10 vehicles entered service in the Ukrainian Armed Forces in 1999 under the name BM Oplot"
+introduced: 1999
+origin: Ukraine
+price: 25
+role: Main Battle Tank
+variants:
+  T-84 BM Oplot: {}
+hit_points: 27

--- a/resources/units/ground_units/CHAP_T90M.yaml
+++ b/resources/units/ground_units/CHAP_T90M.yaml
@@ -10,5 +10,5 @@ origin: Russia
 price: 30
 role: Main Battle Tank
 variants:
-  T-90A: {}
-hit_points: 26
+  T-90M: {}
+hit_points: 28

--- a/resources/units/ground_units/CHAP_TOS1A.yaml
+++ b/resources/units/ground_units/CHAP_TOS1A.yaml
@@ -1,0 +1,9 @@
+class: Artillery
+description: TOS-1 Buratino Heavy Flamethrower System is a Soviet 220 mm 30-barrel multiple rocket launcher capable of using thermobaric warheads.
+introduced: 1988
+origin: Russia
+price: 20
+role: Multiple-Launch Rocket System
+variants:
+  TOS-1A: {}
+hit_points: 12

--- a/resources/units/ground_units/CHAP_TorM2.yaml
+++ b/resources/units/ground_units/CHAP_TorM2.yaml
@@ -1,0 +1,10 @@
+class: SHORAD
+description: "The Tor is an all-weather, low-to medium-altitude, short-range surface-to-air missile system designed for destroying airplanes, helicopters, cruise missiles, unmanned aerial vehicles and short-range ballistic threats (anti-munitions)"
+introduced: 1986
+manufacturer: IEMZ Kupol
+origin: USSR/Russia
+price: 10
+role: Self-Propelled Surface-to-Air Missile Launcher
+variants:
+  SA-15 Gauntlet: {}
+hit_points: 3

--- a/resources/units/ground_units/CHAP_TorM2.yaml
+++ b/resources/units/ground_units/CHAP_TorM2.yaml
@@ -6,5 +6,5 @@ origin: USSR/Russia
 price: 10
 role: Self-Propelled Surface-to-Air Missile Launcher
 variants:
-  SA-15 Gauntlet: {}
+  SA-15 Gauntlet 9K332 M2: {}
 hit_points: 3

--- a/resources/units/ground_units/FuSe-65.yaml
+++ b/resources/units/ground_units/FuSe-65.yaml
@@ -2,3 +2,4 @@ class: EarlyWarningRadar
 price: 25
 variants:
   EWR FuSe-65 Würzburg-Riese: null
+hit_points: 20

--- a/resources/units/ground_units/LARC-V.yaml
+++ b/resources/units/ground_units/LARC-V.yaml
@@ -2,3 +2,4 @@ class: Logistics
 price: 2
 variants:
   LARC-V: null
+hit_points: 3

--- a/resources/units/ground_units/M1A2C_SEP_V3.yaml
+++ b/resources/units/ground_units/M1A2C_SEP_V3.yaml
@@ -1,0 +1,19 @@
+class: Tank
+description: The M1 Abrams is a third-generation American main battle tank designed
+  by Chrysler Defense (now General Dynamics Land Systems) and named for General
+  Creighton Abrams. Conceived for modern armored ground warfare and now one of the
+  heaviest tanks in service at nearly 68 short tons. The M1 Abrams entered service
+  in 1980 and currently serves as the main battle tank of the United States Army and
+  Marine Corps. The export version is used by the armies of Egypt, Kuwait, Saudi Arabia,
+  Australia, and Iraq. The Abrams was first used in combat in the Persian Gulf War
+  and has seen combat in both the War in Afghanistan and Iraq War under U.S. service,
+  while Iraqi Abrams tanks have seen action in the war against ISIL and have seen
+  use by Saudi Arabia during the Yemeni Civil War.
+introduced: 1998
+manufacturer: General Dynamics
+origin: USA
+price: 25
+role: Main Battle Tank
+variants:
+  M1A2 Abrams SEP V3: {}
+hit_points: 32

--- a/resources/units/ground_units/M48 Chaparral.yaml
+++ b/resources/units/ground_units/M48 Chaparral.yaml
@@ -10,4 +10,4 @@ price: 16
 role: Self-Propelled Surface-to-Air Missile Launcher
 variants:
   M48 Chaparral: {}
-hit_points: 2
+hit_points: 3

--- a/resources/units/ground_units/MaxxPro_MRAP.yaml
+++ b/resources/units/ground_units/MaxxPro_MRAP.yaml
@@ -1,0 +1,10 @@
+class: Recon
+description: 'The International M1224 MaxxPro MRAP (Mine-Resistant Ambush Protected) is an armored fighting vehicle.'
+introduced: 2007
+manufacturer: Navistari
+origin: USA
+price: 2
+role: Recon
+variants:
+  MaxxPro MRAP: {}
+hit_points: 4

--- a/resources/units/ground_units/Osa 9A33 ln.yaml
+++ b/resources/units/ground_units/Osa 9A33 ln.yaml
@@ -1,4 +1,7 @@
 class: SHORAD
+description: "The 9K33 Osa (NATO reporting name SA-8 Gecko) is a highly mobile, low-altitude, short-range\
+  \ tactical surface-to-air missile system developed in the Soviet Union in the 1960s\
+  \ and fielded in 1972. Its export version name is Romb."
 price: 28
 variants:
   SAM SA-8 Osa "Gecko" TEL: null

--- a/resources/units/ground_units/PT_76.yaml
+++ b/resources/units/ground_units/PT_76.yaml
@@ -1,12 +1,12 @@
 class: Recon
-description: "The BRDM-2 (Boyevaya Razvedyvatelnaya Dozornaya Mashina, \u0411\u043E\
-  \u0435\u0432\u0430\u044F \u0420\u0430\u0437\u0432\u0435\u0434\u044B\u0432\u0430\u0442\
-  \u0435\u043B\u044C\u043D\u0430\u044F \u0414\u043E\u0437\u043E\u0440\u043D\u0430\u044F\
-  \ \u041C\u0430\u0448\u0438\u043D\u0430, literally \"Combat Reconnaissance/Patrol\
-  \ Vehicle\") is an amphibious armoured patrol car used by Russia and the former\
-  \ Soviet Union. It was also known under the designations BTR-40PB, BTR-40P-2 and\
-  \ GAZ 41-08. This vehicle, like many other Soviet designs, has been exported extensively\
-  \ and is in use in at least 38 countries."
+description: "The PT-76 is a Soviet amphibious light tank that was introduced in the\
+  \ early 1950s and soon became the standard reconnaissance tank of the Soviet Army\
+  \ and the other Warsaw Pact armed forces. It was widely exported to other friendly\
+  \ states, like India, Iraq, Syria, North Korea and North Vietnam. Overall, some\
+  \ 25 countries used the PT-76. The tank's full name is Floating Tank\u201376 (\u043F\
+  \u043B\u0430\u0432\u0430\u044E\u0449\u0438\u0439 \u0442\u0430\u043D\u043A, plavayushchiy\
+  \ tank, or \u041F\u0422-76). 76 stands for the caliber of the main armament: the\
+  \ 76.2 mm D-56T series rifled tank gun."
 introduced: 1951
 manufacturer: VTZ, Kirov Factory
 origin: USSR/Russia

--- a/resources/units/ground_units/SK_C_28_naval_gun.yaml
+++ b/resources/units/ground_units/SK_C_28_naval_gun.yaml
@@ -2,4 +2,4 @@ class: AAA
 price: 0
 variants:
   Gun 15cm SK C/28 Naval in Bunker: null
-hit_points: 160
+hit_points: 260

--- a/resources/units/ground_units/T-34-85.yaml
+++ b/resources/units/ground_units/T-34-85.yaml
@@ -1,0 +1,10 @@
+class: Tank
+description: The T-34 is a Soviet medium tank from World War II.
+introduced: 1940
+origin: USSR/Russia
+price: 18
+role: Main Battle Tank
+variants:
+  T-34-85: {}
+
+hit_points: 15

--- a/resources/units/ground_units/T-80B.yaml
+++ b/resources/units/ground_units/T-80B.yaml
@@ -12,5 +12,5 @@ origin: USSR/Russia
 price: 25
 role: Main Battle Tank
 variants:
-  T-80UD: {}
+  T-80B: {}
 hit_points: 28

--- a/resources/units/ground_units/T62M.yaml
+++ b/resources/units/ground_units/T62M.yaml
@@ -6,5 +6,5 @@ origin: USSR/Russia
 price: 18
 role: Main Battle Tank
 variants:
-  T62M: {}
+  T-62M: {}
 hit_points: 18

--- a/resources/units/ground_units/T62M.yaml
+++ b/resources/units/ground_units/T62M.yaml
@@ -1,0 +1,10 @@
+class: Tank
+description: The T-62 is a Soviet main battle tank that was first introduced in 1961. As a further development of the T-55 series, the T-62 retained many similar design elements of its predecessor including low profile and thick turret armour.
+introduced: 1961
+manufacturer: Kharkiv/UralVagonZavod
+origin: USSR/Russia
+price: 18
+role: Main Battle Tank
+variants:
+  T62M: {}
+hit_points: 18

--- a/resources/units/ships/santafe.yaml
+++ b/resources/units/ships/santafe.yaml
@@ -2,4 +2,4 @@ class: Submarine
 price: 0
 variants:
   ARA Santa Fe S-21: null
-hit_points: 100
+hit_points: 3

--- a/unshipped_data/hit_points/update.py
+++ b/unshipped_data/hit_points/update.py
@@ -18,9 +18,9 @@ def update_yaml(file: str, hit_points: int) -> None:
     # update, ignore existing hit_points settings
     found = False
     key = "hit_points"
-    for line in data:
+    for index, line in enumerate(data):
         if line[0 : len(key) + 1] == f"{key}:":
-            line = f"{key}: {hit_points}\n"
+            data[index] = f"{key}: {hit_points}\n"
             found = True
     if not found:
         data.append(f"{key}: {hit_points}\n")


### PR DESCRIPTION
This PR:

- Added new units from Currenthill and Cold War packs. Added M1A2 Abrams SEP V3 and MaxxPro M-RAP. 
- Updated factions data for new units.
- Added fuel usage data for A-4EC, A-10A, A-10C, AV-8B, F-14A, F-14B, F-15C allowing for better fuel estimation during fast forward and more detailed kneeboard fuel status.
- Updated hit point data for all units.