### PR TITLE
Allow campaign designers to define whether front line units travel on or off road, exclusion zones (for front line units)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ Saves from 14.x are not compatible with 15.0.0.
 * **[Engine]** Support for Kola map.
 * **[Engine]** Support for Cold War Germany map.
 * **[Campaign]** Make dawn/dusk/day/night times more accurate so that dawn/dusk missions do not happen during the dark in some seasons.
+* **[Campaign]** Campaign designers can define whether front line units travel on road or off road by setting the appropriate waypoint option for the M-113 unit defining the supply route. If the M-113 unit waypoints are set to travel on road, front line units will travel on road from where they are generated to their destinations. Otherwise, front line units will travel off road.
+* **[Campaign]** Campaign designers can define exclusion zones where front line units cannot be spawned using Free Form Polygons in the DCS Mission Editor. 
 * **[Data]** Updated weapons availability by year and fallbacks. Restricting weapons availability by campaign date is turned on by default.
 
 

--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import itertools
 from functools import cached_property
+import logging
 from pathlib import Path
 from typing import Iterator, List, TYPE_CHECKING
 from uuid import UUID
 
+from shapely.geometry import MultiPolygon, Polygon
+from shapely.ops import unary_union
+
 from dcs import Mission
 from dcs.countries import CombinedJointTaskForcesBlue, CombinedJointTaskForcesRed
 from dcs.country import Country
+from dcs.drawing.polygon import FreeFormPolygon
 from dcs.planes import F_15C
+from dcs.point import PointAction
 from dcs.ships import HandyWind, LHA_Tarawa, Stennis, USS_Arleigh_Burke_IIa
 from dcs.statics import Fortification, Warehouse
 from dcs.unitgroup import PlaneGroup, ShipGroup, StaticGroup, VehicleGroup
@@ -20,6 +26,9 @@ from game.campaignloader.controlpointconfig import ControlPointConfig
 from game.profiling import logged_duration
 from game.scenery_group import SceneryGroup
 from game.theater.controlpoint import ControlPoint
+from game.theater.frontline import FrontLinePoint
+from game.theater.landmap import Landmap
+
 from game.theater.presetlocation import PresetLocation
 
 if TYPE_CHECKING:
@@ -315,7 +324,11 @@ class MizCampaignLoader:
             # The unit will have its first waypoint at the source CP and the final
             # waypoint at the destination CP. Each waypoint defines the path of the
             # cargo ship.
-            waypoints = [p.position for p in group.points]
+            waypoints = []
+            for point in group.points:
+                waypoints.append(
+                    FrontLinePoint(point.position, point.action == PointAction.OnRoad)
+                )
             origin = self.theater.closest_control_point(waypoints[0])
             if origin is None:
                 raise RuntimeError(
@@ -453,9 +466,36 @@ class MizCampaignLoader:
             closest = self.theater.closest_control_point(scenery_group.centroid)
             closest.preset_locations.scenery.append(scenery_group)
 
+    def add_custom_exclusion_zones(self) -> None:
+        if self.theater.landmap is None:
+            return
+        polygons = []
+        for layer in self.mission.drawings.layers:
+            for draw_object in layer.objects:
+                if type(draw_object) != FreeFormPolygon:
+                    logging.debug(
+                        f"Object {draw_object.name} is not a FreeFormPolygon, ignoring"
+                    )
+                    continue
+                polygon_points = []
+                for point in draw_object.points:
+                    polygon_points.append(
+                        (
+                            point.x + draw_object.position.x,
+                            point.y + draw_object.position.y,
+                        )
+                    )
+                polygons.append(Polygon(polygon_points))
+        self.theater.landmap = Landmap(
+            self.theater.landmap.inclusion_zones,
+            unary_union([self.theater.landmap.exclusion_zones, MultiPolygon(polygons)]),
+            self.theater.landmap.sea_zones,
+        )
+
     def populate_theater(self) -> None:
         for control_point in self.control_points.values():
             self.theater.add_controlpoint(control_point)
         self.add_preset_locations()
         self.add_supply_routes()
         self.add_shipping_lanes()
+        self.add_custom_exclusion_zones()

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -217,7 +217,7 @@ class FlotGenerator:
                             position=infantry_position,
                             group_size=1,
                             heading=forward_heading.degrees,
-                            move_formation=PointAction.OffRoad,
+                            move_formation=self._point_action(),
                         )
                         infantry_group.hidden_on_mfd = True
             return
@@ -243,7 +243,7 @@ class FlotGenerator:
             position=infantry_position,
             group_size=1,
             heading=forward_heading.degrees,
-            move_formation=PointAction.OffRoad,
+            move_formation=self._point_action(),
         )
         infantry_group.hidden_on_mfd = True
 
@@ -256,7 +256,7 @@ class FlotGenerator:
                 position=position,
                 group_size=1,
                 heading=forward_heading.degrees,
-                move_formation=PointAction.OffRoad,
+                move_formation=self._point_action(),
             )
             infantry_group.hidden_on_mfd = True
 
@@ -269,7 +269,7 @@ class FlotGenerator:
         reform_point = dcs_group.position.point_from_heading(
             forward_heading.degrees, 50
         )
-        dcs_group.add_waypoint(reform_point)
+        dcs_group.add_waypoint(reform_point, self._point_action())
 
     def _plan_artillery_action(
         self,
@@ -310,10 +310,10 @@ class FlotGenerator:
             )
             dcs_group.add_waypoint(
                 dcs_group.position.point_from_heading(forward_heading.degrees, 1),
-                PointAction.OffRoad,
+                self._point_action(),
             )
             dcs_group.points[2].tasks.append(Hold())
-            dcs_group.add_waypoint(retreat, PointAction.OffRoad)
+            dcs_group.add_waypoint(retreat, self._point_action())
 
             artillery_fallback = TriggerOnce(
                 Event.NoEvent, "ArtilleryRetreat #" + str(dcs_group.id)
@@ -366,7 +366,7 @@ class FlotGenerator:
                 target_point = self.conflict.theater.nearest_land_pos(
                     target.points[0].position + rand_offset
                 )
-                dcs_group.add_waypoint(target_point)
+                dcs_group.add_waypoint(target_point, self._point_action())
                 dcs_group.points[2].tasks.append(AttackGroup(target.id))
 
             if (
@@ -383,7 +383,7 @@ class FlotGenerator:
                 attack_point = self.find_offensive_point(
                     dcs_group, offset_heading, AGGRESIVE_MOVE_DISTANCE
                 )
-            dcs_group.add_waypoint(attack_point, PointAction.OffRoad)
+            dcs_group.add_waypoint(attack_point, self._point_action())
         elif stance == CombatStance.BREAKTHROUGH:
             # In breakthrough mode, the units will move forward
             # If the enemy base is close enough, the units will attack the base
@@ -401,7 +401,7 @@ class FlotGenerator:
                 attack_point = self.find_offensive_point(
                     dcs_group, offset_heading, BREAKTHROUGH_OFFENSIVE_DISTANCE
                 )
-            dcs_group.add_waypoint(attack_point, PointAction.OffRoad)
+            dcs_group.add_waypoint(attack_point, self._point_action())
         elif stance == CombatStance.ELIMINATION:
             # In elimination mode, the units focus on destroying as much enemy groups as possible
             targets = self.find_n_nearest_enemy_groups(dcs_group, enemy_groups, 3)
@@ -413,7 +413,7 @@ class FlotGenerator:
                 target_point = self.conflict.theater.nearest_land_pos(
                     target.points[0].position + rand_offset
                 )
-                dcs_group.add_waypoint(target_point, PointAction.OffRoad)
+                dcs_group.add_waypoint(target_point, self._point_action())
                 dcs_group.points[i + 1].tasks.append(AttackGroup(target.id))
             if (
                 to_cp.position.distance_to_point(dcs_group.points[0].position)
@@ -422,7 +422,7 @@ class FlotGenerator:
                 attack_point = self.conflict.theater.nearest_land_pos(
                     to_cp.position.random_point_within(500, 0)
                 )
-                dcs_group.add_waypoint(attack_point)
+                dcs_group.add_waypoint(attack_point, self._point_action())
 
         if stance != CombatStance.RETREAT:
             self.add_morale_trigger(dcs_group, forward_heading)
@@ -458,7 +458,7 @@ class FlotGenerator:
                 attack_point = self.find_offensive_point(
                     dcs_group, forward_heading, AGGRESIVE_MOVE_DISTANCE
                 )
-            dcs_group.add_waypoint(attack_point, PointAction.OffRoad)
+            dcs_group.add_waypoint(attack_point, self._point_action())
 
         if stance != CombatStance.RETREAT:
             self.add_morale_trigger(dcs_group, forward_heading)
@@ -512,8 +512,8 @@ class FlotGenerator:
                 reposition_point = retreat_point.point_from_heading(
                     forward_heading.degrees, 10
                 )  # Another point to make the unit face the enemy
-                dcs_group.add_waypoint(retreat_point, PointAction.OffRoad)
-                dcs_group.add_waypoint(reposition_point, PointAction.OffRoad)
+                dcs_group.add_waypoint(retreat_point, self._point_action())
+                dcs_group.add_waypoint(reposition_point, self._point_action())
 
     def add_morale_trigger(
         self, dcs_group: VehicleGroup, forward_heading: Heading
@@ -538,7 +538,7 @@ class FlotGenerator:
             self.find_retreat_point(
                 dcs_group, forward_heading, (int)(RETREAT_DISTANCE / 8)
             ),
-            PointAction.OffRoad,
+            self._point_action(),
         )
 
         # Fallback task
@@ -766,6 +766,7 @@ class FlotGenerator:
             position=at,
             group_size=count,
             heading=heading.degrees,
+            move_formation=self._point_action(),
         )
         group.hidden_on_mfd = True
 
@@ -776,3 +777,16 @@ class FlotGenerator:
             vehicle.player_can_drive = True
 
         return group
+
+    def _point_action(self) -> PointAction:
+        """
+        PointAction (OnRoad or OffRoad) for front line movements. If either point of the active segment
+        is set to go on road, the whole segment is to be traversed on roads as front line segments are
+        anchored at control points which are defined as off road.
+        """
+        if (
+            self.conflict.front_line.active_segment.point_a.on_road
+            or self.conflict.front_line.active_segment.point_b.on_road
+        ):
+            return PointAction.OnRoad
+        return PointAction.OffRoad

--- a/game/server/supplyroutes/models.py
+++ b/game/server/supplyroutes/models.py
@@ -12,6 +12,7 @@ from game.server.leaflet import LeafletPoint
 if TYPE_CHECKING:
     from game import Game
     from game.theater import ControlPoint
+    from game.theater.frontline import FrontLinePoint
     from game.transfers import MultiGroupTransport, TransportMap
 
 
@@ -76,7 +77,11 @@ class SupplyRouteJs(BaseModel):
 
     @staticmethod
     def for_link(
-        game: Game, a: ControlPoint, b: ControlPoint, points: list[Point], sea: bool
+        game: Game,
+        a: ControlPoint,
+        b: ControlPoint,
+        points: list[Point | FrontLinePoint],
+        sea: bool,
     ) -> SupplyRouteJs:
         return SupplyRouteJs(
             # Although these are not persistent objects in the backend, the frontend
@@ -107,22 +112,22 @@ class SupplyRouteJs(BaseModel):
         routes = []
         for control_point in game.theater.controlpoints:
             seen.add(control_point)
-            for destination, route in control_point.convoy_routes.items():
+            for destination, convoy_route in control_point.convoy_routes.items():
                 if destination in seen:
                     continue
                 routes.append(
                     SupplyRouteJs.for_link(
-                        game, control_point, destination, list(route), sea=False
+                        game, control_point, destination, list(convoy_route), sea=False
                     )
                 )
-            for destination, route in control_point.shipping_lanes.items():
+            for destination, shipping_route in control_point.shipping_lanes.items():
                 if destination in seen:
                     continue
                 if not destination.is_friendly_to(control_point):
                     continue
                 routes.append(
                     SupplyRouteJs.for_link(
-                        game, control_point, destination, list(route), sea=True
+                        game, control_point, destination, list(shipping_route), sea=True
                     )
                 )
         return routes

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -62,7 +62,7 @@ from game.sidc import (
 from game.theater.presetlocation import PresetLocation
 from game.utils import Distance, Heading, meters
 from .base import Base
-from .frontline import FrontLine
+from .frontline import FrontLine, FrontLinePoint
 from .missiontarget import MissionTarget
 from .theatergroundobject import (
     GenericCarrierGroundObject,
@@ -351,7 +351,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self.front_lines: dict[ControlPoint, FrontLine] = {}
         # TODO: Should be Airbase specific.
         self.connected_points: List[ControlPoint] = []
-        self.convoy_routes: Dict[ControlPoint, Tuple[Point, ...]] = {}
+        self.convoy_routes: Dict[ControlPoint, Tuple[FrontLinePoint, ...]] = {}
         self.shipping_lanes: Dict[ControlPoint, Tuple[Point, ...]] = {}
         self.base: Base = Base()
         self.cptype = cptype
@@ -610,13 +610,15 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         """
         ...
 
-    def convoy_origin_for(self, destination: ControlPoint) -> Point:
+    def convoy_origin_for(self, destination: ControlPoint) -> FrontLinePoint:
         return self.convoy_route_to(destination)[0]
 
-    def convoy_route_to(self, destination: ControlPoint) -> Sequence[Point]:
+    def convoy_route_to(self, destination: ControlPoint) -> Sequence[FrontLinePoint]:
         return self.convoy_routes[destination]
 
-    def create_convoy_route(self, to: ControlPoint, waypoints: Iterable[Point]) -> None:
+    def create_convoy_route(
+        self, to: ControlPoint, waypoints: Iterable[FrontLinePoint]
+    ) -> None:
         self.connected_points.append(to)
         self.stances[to.id] = CombatStance.DEFENSIVE
         self.convoy_routes[to] = tuple(waypoints)

--- a/game/theater/frontline.py
+++ b/game/theater/frontline.py
@@ -19,14 +19,23 @@ if TYPE_CHECKING:
 FRONTLINE_MIN_CP_DISTANCE = 5000
 
 
+class FrontLinePoint(Point):
+
+    def __init__(self, point: Point, on_road: bool):
+        self.__dict__.update(point.__dict__)
+        self.on_road = on_road
+
+    on_road: bool
+
+
 @dataclass
 class FrontLineSegment:
     """
     Describes a line segment of a FrontLine
     """
 
-    point_a: Point
-    point_b: Point
+    point_a: FrontLinePoint
+    point_b: FrontLinePoint
 
     @property
     def blue_forward_heading(self) -> Heading:
@@ -63,11 +72,14 @@ class FrontLine(MissionTarget):
             # *some* "front line" being drawn between these two. In this case there will
             # be no supply route to follow. Just create an arbitrary route between the
             # two points.
-            route = [blue_point.position, red_point.position]
+            route = [
+                FrontLinePoint(blue_point.position, False),
+                FrontLinePoint(red_point.position, False),
+            ]
         # Snap the beginning and end points to the CPs rather than the convoy waypoints,
         # which are on roads.
-        route[0] = blue_point.position
-        route[-1] = red_point.position
+        route[0] = FrontLinePoint(blue_point.position, False)
+        route[-1] = FrontLinePoint(red_point.position, False)
         self.segments: List[FrontLineSegment] = [
             FrontLineSegment(a, b) for a, b in pairwise(route)
         ]


### PR DESCRIPTION
This PR adds more customizations for campaign designers in the campaign .miz file.

1. Use on/off road option of M-113 supply route waypoints to determine whether front line units travel on or off road.
2. Load free form polygons as exclusion zones.