### PR TITLE
Add carrier attack as part of attackairinfrastructure compound task

### DIFF
--- a/game/commander/objectivefinder.py
+++ b/game/commander/objectivefinder.py
@@ -9,9 +9,12 @@ from game.ato.closestairfields import ClosestAirfields, ObjectiveDistanceCache
 from game.theater import (
     Airfield,
     ControlPoint,
+    Carrier,
     Fob,
     FrontLine,
+    Lha,
     MissionTarget,
+    NavalControlPoint,
     OffMapSpawn,
 )
 from game.theater.theatergroundobject import (
@@ -270,3 +273,14 @@ class ObjectiveFinder:
     def closest_airfields_to(location: MissionTarget) -> ClosestAirfields:
         """Returns the closest airfields to the given location."""
         return ObjectiveDistanceCache.get_closest_airfields(location)
+
+    def enemy_carriers(self) -> Iterator[NavalControlPoint]:
+        carriers = []
+        for control_point in self.enemy_control_points():
+            if not isinstance(control_point, Carrier) and not isinstance(
+                control_point, Lha
+            ):
+                continue
+            if control_point.allocated_aircraft().total_present >= 0:
+                carriers.append(control_point)
+        return self._targets_by_range(carriers)

--- a/game/commander/tasks/compound/attackairinfrastructure.py
+++ b/game/commander/tasks/compound/attackairinfrastructure.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 
 from game.commander.tasks.primitive.oca import PlanOcaStrike
+from game.commander.tasks.primitive.anticarrier import PlanAntiCarrier
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
 
@@ -13,3 +14,5 @@ class AttackAirInfrastructure(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
         for battle_position in state.oca_targets:
             yield [PlanOcaStrike(battle_position, self.aircraft_cold_start)]
+        for carrier in state.enemy_carriers:
+            yield [PlanAntiCarrier(carrier)]

--- a/game/commander/tasks/primitive/anticarrier.py
+++ b/game/commander/tasks/primitive/anticarrier.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from game.commander.missionproposals import EscortType
+from game.commander.tasks.packageplanningtask import PackagePlanningTask
+from game.commander.theaterstate import TheaterState
+from game.theater import ControlPoint
+from game.ato.flighttype import FlightType
+
+
+@dataclass
+class PlanAntiCarrier(PackagePlanningTask[ControlPoint]):
+    def preconditions_met(self, state: TheaterState) -> bool:
+        if self.target not in state.enemy_carriers:
+            return False
+        if not self.target_area_preconditions_met(state):
+            return False
+        return super().preconditions_met(state)
+
+    def apply_effects(self, state: TheaterState) -> None:
+        state.enemy_carriers.remove(self.target)
+
+    def propose_flights(self) -> None:
+        self.propose_flight(FlightType.ANTISHIP, 4)
+        self.propose_flight(FlightType.ESCORT, 4, EscortType.AirToAir)

--- a/game/commander/theaterstate.py
+++ b/game/commander/theaterstate.py
@@ -60,6 +60,7 @@ class TheaterState(WorldState["TheaterState"]):
     enemy_ships: list[NavalGroundObject]
     enemy_battle_positions: dict[ControlPoint, BattlePositions]
     oca_targets: list[ControlPoint]
+    enemy_carriers: list[ControlPoint]
     strike_targets: list[TheaterGroundObject]
     enemy_barcaps: list[ControlPoint]
     threat_zones: ThreatZones
@@ -130,6 +131,7 @@ class TheaterState(WorldState["TheaterState"]):
                 for cp, g in self.enemy_battle_positions.items()
             },
             oca_targets=list(self.oca_targets),
+            enemy_carriers=list(self.enemy_carriers),
             strike_targets=list(self.strike_targets),
             enemy_barcaps=list(self.enemy_barcaps),
             threat_zones=self.threat_zones,
@@ -188,6 +190,7 @@ class TheaterState(WorldState["TheaterState"]):
                 for cp in ordered_capturable_points
             },
             oca_targets=list(finder.oca_targets(min_aircraft=20)),
+            enemy_carriers=list(finder.enemy_carriers()),
             strike_targets=list(finder.strike_targets()),
             enemy_barcaps=list(game.theater.control_points_for(not player)),
             threat_zones=game.threat_zone_for(not player),

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -956,6 +956,8 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
                     ground_object.position.x = ground_object.position.x + delta.x
                     ground_object.position.y = ground_object.position.y + delta.y
                     for group in ground_object.groups:
+                        group.position.x += delta.x
+                        group.position.y += delta.y
                         for u in group.units:
                             u.position.x = u.position.x + delta.x
                             u.position.y = u.position.y + delta.y


### PR DESCRIPTION
This PR:
- Targets carriers as part of the attackairinfrastructure compound task.
- Adds a specific primitive task of anticarrier.
- Keeps track of enemy carriers in the theater state.
- Fixes a bug in ControlPoint where the carrier group position is not updated when the carrier is moved.