### PR TITLE
Handle scenario where callsign is double freed

### DIFF
--- a/game/callsigns/callsigngenerator.py
+++ b/game/callsigns/callsigngenerator.py
@@ -99,7 +99,8 @@ class WesternGroupIdRegistry:
     def release_group_id(self, callsign: Callsign) -> None:
         if callsign.name is None:
             raise ValueError("Releasing eastern callsign")
-        self._names[callsign.name].appendleft(callsign.group_id)
+        if callsign.group_id not in self._names[callsign.name]:
+            self._names[callsign.name].appendleft(callsign.group_id)
 
 
 class EasternGroupIdRegistry:
@@ -120,7 +121,8 @@ class EasternGroupIdRegistry:
         return self._queue.popleft()
 
     def release_group_id(self, callsign: Callsign) -> None:
-        self._queue.appendleft(callsign.group_id)
+        if callsign.group_id not in self._queue:
+            self._queue.appendleft(callsign.group_id)
 
 
 class RoundRobinNameAllocator:

--- a/tests/callsigns/test_callsign_generator.py
+++ b/tests/callsigns/test_callsign_generator.py
@@ -48,10 +48,17 @@ def test_western_group_id_registry() -> None:
     registry.release_group_id(Callsign("Enfield", 1, 1))
     assert registry.alloc_group_id("Enfield") == 1
 
-    # Reset and check allocation og Enfield-1 and Springfield-1.
+    # Reset and check allocation of Enfield-1 and Springfield-1.
     registry.reset()
     assert registry.alloc_group_id("Enfield") == 1
     assert registry.alloc_group_id("Springfield") == 1
+    
+    # Reset and check double release of Enfield-1.
+    registry.reset()
+    registry.release_group_id(Callsign("Enfield", 1, 1))
+    registry.release_group_id(Callsign("Enfield", 1, 1))
+    assert registry.alloc_group_id("Enfield") == 1
+    assert registry.alloc_group_id("Enfield") == 2
 
 
 def test_eastern_group_id_registry() -> None:
@@ -68,6 +75,13 @@ def test_eastern_group_id_registry() -> None:
     # Reset and check allocation.
     registry.reset()
     assert registry.alloc_group_id() == 1
+    
+    # Check double release.
+    registry.reset()
+    registry.release_group_id(Callsign(None, 1, 1))
+    registry.release_group_id(Callsign(None, 1, 1))
+    assert registry.alloc_group_id() == 1
+    assert registry.alloc_group_id() == 2
 
 
 def test_round_robin_allocator() -> None:

--- a/tests/callsigns/test_callsign_generator.py
+++ b/tests/callsigns/test_callsign_generator.py
@@ -52,7 +52,7 @@ def test_western_group_id_registry() -> None:
     registry.reset()
     assert registry.alloc_group_id("Enfield") == 1
     assert registry.alloc_group_id("Springfield") == 1
-    
+
     # Reset and check double release of Enfield-1.
     registry.reset()
     registry.release_group_id(Callsign("Enfield", 1, 1))
@@ -75,7 +75,7 @@ def test_eastern_group_id_registry() -> None:
     # Reset and check allocation.
     registry.reset()
     assert registry.alloc_group_id() == 1
-    
+
     # Check double release.
     registry.reset()
     registry.release_group_id(Callsign(None, 1, 1))


### PR DESCRIPTION
This PR addresses a bug where we can release a callsign multiple times. In this case, the same callsign is re-used as many times as it was released, leading to flights with the same callsign.