### PR TITLE
Add pre-mission AAR package option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Saves from 15.x are not compatible with 16.0.0.
 
 * **[Engine]** Support for DCS 2.9.28 including F-14B(U).
 * **[Mission Generation]** Automatic setup of Shrike fuzing when targeting SNR-75 (Fan Song), SNR-125 (Low Blow), 1S91 (Straight Flush), ST-68U (Tin Shield) and SON-9 (Fire Can) radars.
+* **[Mission Generation]** Add optional package-level Pre-Mission AAR holds for coordinating refueling before ingress.
 * **[Mods]** CJS Super Hornet mod updated to version 2.4.5.
 * **[Mods]** JAS39 mod updated to version 1.8.5.
 * **[Mods]** UH-60L updated to version 2.15.

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -58,6 +58,7 @@ class Flight(SidcDescribable):
         self.coalition = squadron.coalition
         self.squadron = squadron
         self.flight_type = flight_type
+        self.pre_mission_aar = package.pre_mission_aar
         if flight_type != FlightType.IDLE:
             self.squadron.claim_inventory(count)
         if roster is None:
@@ -96,6 +97,11 @@ class Flight(SidcDescribable):
     @property
     def flight_plan(self) -> FlightPlan[Any]:
         return self._flight_plan_builder.get_or_build()
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        if "pre_mission_aar" not in state:
+            self.pre_mission_aar = False
 
     def degrade_to_custom_flight_plan(self) -> None:
         from .flightplans.custom import Builder as CustomBuilder

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 
 
 class Flight(SidcDescribable):
+    start_type: StartType
+    custom_name: Optional[str]
+
     def __init__(
         self,
         package: Package,

--- a/game/ato/flightplans/cas.py
+++ b/game/ato/flightplans/cas.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Type
 
+from game.flightplan.waypointactions.hold import Hold
 from game.theater import FrontLine
 from game.utils import Distance, Speed, kph, meters, dcs_to_shapely_point
 from .ibuilder import IBuilder
@@ -23,10 +24,20 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class CasLayout(PatrollingLayout):
     ingress: FlightWaypoint
+    pre_refuel: FlightWaypoint | None
+    nav_from_pre_refuel: list[FlightWaypoint]
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        state.setdefault("pre_refuel", None)
+        state.setdefault("nav_from_pre_refuel", [])
+        self.__dict__.update(state)
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
         yield self.departure
         yield from self.nav_to
+        if self.pre_refuel is not None:
+            yield self.pre_refuel
+            yield from self.nav_from_pre_refuel
         yield self.ingress
         yield self.patrol_start
         yield self.patrol_end
@@ -62,6 +73,64 @@ class CasFlightPlan(PatrollingFlightPlan[CasLayout], UiZoneDisplay):
     @property
     def combat_speed_waypoints(self) -> set[FlightWaypoint]:
         return {self.layout.ingress, self.layout.patrol_start, self.layout.patrol_end}
+
+    def tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_arrival_time
+        return super().tot_for_waypoint(waypoint)
+
+    def depart_time_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_push_time
+        return super().depart_time_for_waypoint(waypoint)
+
+    @property
+    def pre_refuel_duration(self) -> timedelta:
+        if self.layout.pre_refuel is None:
+            return timedelta()
+        return self.flight.coalition.game.settings.pre_mission_aar_hold_duration
+
+    @property
+    def pre_refuel_push_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        return self.patrol_start_time - self._travel_time_after_departure(
+            self.layout.pre_refuel, self.layout.patrol_start
+        )
+
+    @property
+    def pre_refuel_arrival_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        push_time = self.pre_refuel_push_time
+        if push_time is None:
+            return None
+        return push_time - self.pre_refuel_duration
+
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        travel_time = super().total_time_between_waypoints(a, b)
+        if a != self.layout.pre_refuel:
+            return travel_time
+        return travel_time + self.pre_refuel_duration
+
+    def add_waypoint_actions(self) -> None:
+        super().add_waypoint_actions()
+        if self.layout.pre_refuel is None:
+            return
+        pre_refuel = self.layout.pre_refuel
+        speed = self.flight.unit_type.patrol_speed
+        if speed is None:
+            speed = Speed.from_mach(0.6, pre_refuel.alt)
+        pre_refuel.add_action(
+            Hold(self.pre_refuel_push_time_provider, pre_refuel.alt, speed)
+        )
+
+    def pre_refuel_push_time_provider(self) -> datetime:
+        push_time = self.pre_refuel_push_time
+        assert push_time is not None
+        return push_time
 
     def ui_zone(self) -> UiZone:
         midpoint = (
@@ -136,15 +205,32 @@ class Builder(IBuilder[CasFlightPlan, CasLayout]):
             FlightWaypointType.INGRESS_CAS, ingress_point, location
         )
         ingress.description = f"Ingress to provide CAS at {location}"
-
-        return CasLayout(
-            departure=builder.takeoff(self.flight.departure),
-            nav_to=builder.nav_path(
+        nav_to = builder.nav_path(
+            self.flight.departure.position,
+            ingress_point,
+            patrol_altitude,
+            use_agl_patrol_altitude,
+        )
+        pre_refuel = None
+        nav_from_pre_refuel: list[FlightWaypoint] = []
+        if self.flight.pre_mission_aar and self.package.waypoints is not None:
+            pre_refuel = builder.pre_mission_aar(self.package.waypoints.refuel)
+            nav_to = builder.nav_path(
                 self.flight.departure.position,
+                pre_refuel.position,
+                patrol_altitude,
+                use_agl_patrol_altitude,
+            )
+            nav_from_pre_refuel = builder.nav_path(
+                pre_refuel.position,
                 ingress_point,
                 patrol_altitude,
                 use_agl_patrol_altitude,
-            ),
+            )
+
+        return CasLayout(
+            departure=builder.takeoff(self.flight.departure),
+            nav_to=nav_to,
             nav_from=builder.nav_path(
                 patrol_end,
                 self.flight.arrival.position,
@@ -152,6 +238,8 @@ class Builder(IBuilder[CasFlightPlan, CasLayout]):
                 use_agl_patrol_altitude,
             ),
             ingress=ingress,
+            pre_refuel=pre_refuel,
+            nav_from_pre_refuel=nav_from_pre_refuel,
             patrol_start=patrol_start_waypoint,
             patrol_end=patrol_end_waypoint,
             arrival=builder.land(self.flight.arrival),

--- a/game/ato/flightplans/escort.py
+++ b/game/ato/flightplans/escort.py
@@ -28,16 +28,33 @@ class Builder(FormationAttackBuilder[EscortFlightPlan, FormationAttackLayout]):
         join = builder.join(self.package.waypoints.join)
         split = builder.split(self.package.waypoints.split)
         refuel = builder.refuel(self.package.waypoints.refuel)
+        nav_to = builder.nav_path(
+            hold.position, join.position, self.doctrine.combat_altitude
+        )
+        pre_refuel = None
+        nav_from_pre_refuel = []
+        if self.flight.pre_mission_aar:
+            pre_refuel = builder.pre_mission_aar(self.package.waypoints.refuel)
+            nav_to = builder.nav_path(
+                hold.position,
+                pre_refuel.position,
+                self.doctrine.combat_altitude,
+            )
+            nav_from_pre_refuel = builder.nav_path(
+                pre_refuel.position,
+                join.position,
+                self.doctrine.combat_altitude,
+            )
 
         return FormationAttackLayout(
             departure=builder.takeoff(self.flight.departure),
             hold=hold,
-            nav_to=builder.nav_path(
-                hold.position, join.position, self.doctrine.combat_altitude
-            ),
+            nav_to=nav_to,
+            pre_refuel=pre_refuel,
             join=join,
             ingress=ingress,
             targets=[target],
+            nav_from_pre_refuel=nav_from_pre_refuel,
             split=split,
             refuel=refuel,
             nav_from=builder.nav_path(

--- a/game/ato/flightplans/flightplan.py
+++ b/game/ato/flightplans/flightplan.py
@@ -199,6 +199,22 @@ class FlightPlan(ABC, Generic[LayoutT]):
         distance = meters(a.position.distance_to_point(b.position))
         return timedelta(hours=distance.nautical_miles / speed.knots * error_factor)
 
+    def _travel_time_after_departure(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        """Travel from ``a`` to ``b`` after leaving any task at ``a``."""
+        waypoints = self.waypoints
+        start = waypoints.index(a)
+        end = waypoints.index(b)
+        total = timedelta()
+        edges = zip(waypoints[start:end], waypoints[start + 1 : end + 1])
+        for idx, (previous, waypoint) in enumerate(edges):
+            if idx == 0:
+                total += self.travel_time_between_waypoints(previous, waypoint)
+            else:
+                total += self.total_time_between_waypoints(previous, waypoint)
+        return total
+
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
         raise NotImplementedError
 

--- a/game/ato/flightplans/flightplan.py
+++ b/game/ato/flightplans/flightplan.py
@@ -239,7 +239,10 @@ class FlightPlan(ABC, Generic[LayoutT]):
                 yield waypoint
 
     def takeoff_time(self) -> datetime:
-        return self.tot - self._travel_time_to_waypoint(self.tot_waypoint)
+        tot = self.tot_for_waypoint(self.tot_waypoint)
+        if tot is None:
+            tot = self.tot
+        return tot - self._travel_time_to_waypoint(self.tot_waypoint)
 
     def minimum_duration_from_start_to_tot(self) -> timedelta:
         return (

--- a/game/ato/flightplans/flightplanbuildertypes.py
+++ b/game/ato/flightplans/flightplanbuildertypes.py
@@ -40,6 +40,8 @@ class FlightPlanBuilderTypes:
                 target, NavalControlPoint
             ):
                 return RecoveryTankerFlightPlan.builder_type()
+            if flight.package.pre_mission_aar and isinstance(target, FrontLine):
+                return PackageRefuelingFlightPlan.builder_type()
             if target.is_friendly(flight.squadron.player) or isinstance(
                 target, FrontLine
             ):

--- a/game/ato/flightplans/formation.py
+++ b/game/ato/flightplans/formation.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class FormationLayout(LoiterLayout, ABC):
     nav_to: list[FlightWaypoint]
+    pre_refuel: FlightWaypoint | None
     join: FlightWaypoint
     split: FlightWaypoint
     refuel: FlightWaypoint
@@ -75,6 +76,8 @@ class FormationFlightPlan(LoiterFlightPlan[LayoutT], ABC):
     def split_time(self) -> datetime: ...
 
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_arrival_time
         if waypoint == self.layout.join:
             return self.join_time
         elif waypoint == self.layout.split:
@@ -82,10 +85,46 @@ class FormationFlightPlan(LoiterFlightPlan[LayoutT], ABC):
         return None
 
     @property
+    def pre_refuel_duration(self) -> timedelta:
+        if self.layout.pre_refuel is None:
+            return timedelta()
+        return self.flight.coalition.game.settings.pre_mission_aar_hold_duration
+
+    @property
+    def pre_refuel_push_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        return self.push_time - self.total_time_between_waypoints(
+            self.layout.pre_refuel, self.layout.join
+        )
+
+    @property
+    def pre_refuel_arrival_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        push_time = self.pre_refuel_push_time
+        if push_time is None:
+            return None
+        return push_time - self.pre_refuel_duration
+
+    @property
     def push_time(self) -> datetime:
         return self.join_time - self.travel_time_between_waypoints(
             self.layout.hold, self.layout.join
         )
+
+    def depart_time_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_push_time
+        return super().depart_time_for_waypoint(waypoint)
+
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        travel_time = super().total_time_between_waypoints(a, b)
+        if a != self.layout.pre_refuel:
+            return travel_time
+        return travel_time + self.pre_refuel_duration
 
     @property
     def mission_begin_on_station_time(self) -> datetime | None:
@@ -94,6 +133,25 @@ class FormationFlightPlan(LoiterFlightPlan[LayoutT], ABC):
     @property
     def mission_departure_time(self) -> datetime:
         return self.split_time
+
+    def provide_pre_refuel_push_time(self) -> datetime:
+        push_time = self.pre_refuel_push_time
+        assert push_time is not None
+        return push_time
+
+    def add_waypoint_actions(self) -> None:
+        super().add_waypoint_actions()
+        if self.layout.pre_refuel is None:
+            return
+        from game.flightplan.waypointactions.hold import Hold
+
+        pre_refuel = self.layout.pre_refuel
+        speed = self.flight.unit_type.patrol_speed
+        if speed is None:
+            speed = Speed.from_mach(0.6, pre_refuel.alt)
+        pre_refuel.add_action(
+            Hold(self.provide_pre_refuel_push_time, pre_refuel.alt, speed)
+        )
 
     @self_type_guard
     def is_formation(

--- a/game/ato/flightplans/formationattack.py
+++ b/game/ato/flightplans/formationattack.py
@@ -27,11 +27,20 @@ if TYPE_CHECKING:
 class FormationAttackLayout(FormationLayout):
     ingress: FlightWaypoint
     targets: list[FlightWaypoint]
+    nav_from_pre_refuel: list[FlightWaypoint]
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        state.setdefault("pre_refuel", None)
+        state.setdefault("nav_from_pre_refuel", [])
+        self.__dict__.update(state)
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
         yield self.departure
         yield self.hold
         yield from self.nav_to
+        if self.pre_refuel is not None:
+            yield self.pre_refuel
+            yield from self.nav_from_pre_refuel
         yield self.join
         yield self.ingress
         yield from self.targets
@@ -79,10 +88,24 @@ class FormationAttackFlightPlan(FormationFlightPlan[FormationAttackLayout], ABC)
 
     @property
     def join_time(self) -> datetime:
-        travel_time = self.total_time_between_waypoints(
+        travel_time = self._travel_time_after_departure(
             self.layout.join, self.layout.ingress
         )
         return self.ingress_time - travel_time
+
+    @property
+    def push_time(self) -> datetime:
+        return self.join_time - self._travel_time_after_departure(
+            self.layout.hold, self.layout.join
+        )
+
+    @property
+    def pre_refuel_push_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        return self.join_time - self._travel_time_after_departure(
+            self.layout.pre_refuel, self.layout.join
+        )
 
     @property
     def split_time(self) -> datetime:
@@ -158,16 +181,33 @@ class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
         split = builder.split(self.package.waypoints.split)
         split.wants_escort = True
         refuel = builder.refuel(self.package.waypoints.refuel)
+        nav_to = builder.nav_path(
+            hold.position, join.position, self.doctrine.combat_altitude
+        )
+        pre_refuel = None
+        nav_from_pre_refuel: list[FlightWaypoint] = []
+        if self.flight.pre_mission_aar:
+            pre_refuel = builder.pre_mission_aar(self.package.waypoints.refuel)
+            nav_to = builder.nav_path(
+                hold.position,
+                pre_refuel.position,
+                self.doctrine.combat_altitude,
+            )
+            nav_from_pre_refuel = builder.nav_path(
+                pre_refuel.position,
+                join.position,
+                self.doctrine.combat_altitude,
+            )
 
         return FormationAttackLayout(
             departure=builder.takeoff(self.flight.departure),
             hold=hold,
-            nav_to=builder.nav_path(
-                hold.position, join.position, self.doctrine.combat_altitude
-            ),
+            nav_to=nav_to,
+            pre_refuel=pre_refuel,
             join=join,
             ingress=ingress,
             targets=target_waypoints,
+            nav_from_pre_refuel=nav_from_pre_refuel,
             split=split,
             refuel=refuel,
             nav_from=builder.nav_path(

--- a/game/ato/flightplans/packagerefueling.py
+++ b/game/ato/flightplans/packagerefueling.py
@@ -19,11 +19,6 @@ class PackageRefuelingFlightPlan(RefuelingFlightPlan):
     def builder_type() -> Type[Builder]:
         return Builder
 
-    def default_tot_offset(self) -> timedelta:
-        if self.package.pre_mission_aar:
-            return -timedelta(minutes=5)
-        return super().default_tot_offset()
-
     @property
     def patrol_duration(self) -> timedelta:
         recovery_duration = self.recovery_refuel_duration
@@ -53,9 +48,9 @@ class PackageRefuelingFlightPlan(RefuelingFlightPlan):
 
     @property
     def patrol_start_time(self) -> datetime:
-        first_pre_refuel = self.first_pre_mission_aar_time
-        if first_pre_refuel is not None:
-            return min(self.native_patrol_start_time, first_pre_refuel)
+        pre_refuel_start = self.pre_mission_aar_tanker_start_time
+        if pre_refuel_start is not None:
+            return min(self.native_patrol_start_time, pre_refuel_start)
         if self.package.pre_mission_aar or self.tot_offset != timedelta():
             return min(self.native_patrol_start_time, self.tot)
         return self.native_patrol_start_time

--- a/game/ato/flightplans/packagerefueling.py
+++ b/game/ato/flightplans/packagerefueling.py
@@ -19,12 +19,25 @@ class PackageRefuelingFlightPlan(RefuelingFlightPlan):
     def builder_type() -> Type[Builder]:
         return Builder
 
+    def default_tot_offset(self) -> timedelta:
+        if self.package.pre_mission_aar:
+            return -timedelta(minutes=5)
+        return super().default_tot_offset()
+
     @property
     def patrol_duration(self) -> timedelta:
+        recovery_duration = self.recovery_refuel_duration
+        native_end_time = self.native_patrol_start_time + recovery_duration
+        if self.patrol_start_time >= self.native_patrol_start_time:
+            return recovery_duration
+        return native_end_time - self.patrol_start_time
+
+    @property
+    def recovery_refuel_duration(self) -> timedelta:
         # TODO: Only consider aircraft that can refuel with this tanker type.
         refuel_time_minutes = 5
-        for self.flight in self.package.flights:
-            flight_size = self.flight.roster.max_size
+        for flight in self.package.flights:
+            flight_size = flight.roster.max_size
             refuel_time_minutes = refuel_time_minutes + 4 * flight_size + 1
 
         return timedelta(minutes=refuel_time_minutes)
@@ -40,6 +53,15 @@ class PackageRefuelingFlightPlan(RefuelingFlightPlan):
 
     @property
     def patrol_start_time(self) -> datetime:
+        first_pre_refuel = self.first_pre_mission_aar_time
+        if first_pre_refuel is not None:
+            return min(self.native_patrol_start_time, first_pre_refuel)
+        if self.package.pre_mission_aar or self.tot_offset != timedelta():
+            return min(self.native_patrol_start_time, self.tot)
+        return self.native_patrol_start_time
+
+    @property
+    def native_patrol_start_time(self) -> datetime:
         altitude = self.flight.unit_type.patrol_altitude
 
         if altitude is None:

--- a/game/ato/flightplans/refuelingflightplan.py
+++ b/game/ato/flightplans/refuelingflightplan.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
 from abc import ABC
-from datetime import datetime
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 from game.utils import Distance, Speed, knots, meters
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
 
+if TYPE_CHECKING:
+    from game.ato.package import Package
+
 
 class RefuelingFlightPlan(PatrollingFlightPlan[PatrollingLayout], ABC):
+    PRE_MISSION_AAR_TANKER_LEAD_TIME = timedelta(minutes=5)
+
     @property
     def patrol_speed(self) -> Speed:
         # TODO: Could use self.flight.unit_type.preferred_patrol_speed(altitude).
@@ -20,26 +29,43 @@ class RefuelingFlightPlan(PatrollingFlightPlan[PatrollingLayout], ABC):
         # No harm in setting this, but we ought to clean up a bit.
         return meters(0)
 
+    def pre_mission_aar_packages(self) -> Iterable[Package]:
+        return [self.package]
+
     @property
     def first_pre_mission_aar_time(self) -> datetime | None:
-        coalition = getattr(self.flight, "coalition", None)
-        ato = getattr(coalition, "ato", None)
-        packages = getattr(ato, "packages", [self.package])
+        if getattr(self, "_checking_pre_mission_aar_time", False):
+            self._pre_mission_aar_time_reentered = True
+            return None
 
+        self._checking_pre_mission_aar_time = True
         first_pre_refuel: datetime | None = None
-        for package in packages:
-            for flight in package.flights:
-                if flight == self.flight:
-                    continue
-                flight_plan = getattr(flight, "flight_plan", None)
-                if flight_plan is None:
-                    continue
-                pre_refuel = getattr(flight_plan.layout, "pre_refuel", None)
-                if pre_refuel is None:
-                    continue
-                arrival_time = flight_plan.tot_for_waypoint(pre_refuel)
-                if arrival_time is None:
-                    continue
-                if first_pre_refuel is None or arrival_time < first_pre_refuel:
-                    first_pre_refuel = arrival_time
-        return first_pre_refuel
+        try:
+            for package in self.pre_mission_aar_packages():
+                for flight in package.flights:
+                    if flight == self.flight:
+                        continue
+                    flight_plan = getattr(flight, "flight_plan", None)
+                    if flight_plan is None:
+                        continue
+                    pre_refuel = getattr(flight_plan.layout, "pre_refuel", None)
+                    if pre_refuel is None:
+                        continue
+                    self._pre_mission_aar_time_reentered = False
+                    arrival_time = flight_plan.tot_for_waypoint(pre_refuel)
+                    if self._pre_mission_aar_time_reentered:
+                        continue
+                    if arrival_time is None:
+                        continue
+                    if first_pre_refuel is None or arrival_time < first_pre_refuel:
+                        first_pre_refuel = arrival_time
+            return first_pre_refuel
+        finally:
+            self._checking_pre_mission_aar_time = False
+
+    @property
+    def pre_mission_aar_tanker_start_time(self) -> datetime | None:
+        first_pre_refuel = self.first_pre_mission_aar_time
+        if first_pre_refuel is None:
+            return None
+        return first_pre_refuel - self.PRE_MISSION_AAR_TANKER_LEAD_TIME

--- a/game/ato/flightplans/refuelingflightplan.py
+++ b/game/ato/flightplans/refuelingflightplan.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from datetime import datetime
 
 from game.utils import Distance, Speed, knots, meters
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
@@ -18,3 +19,27 @@ class RefuelingFlightPlan(PatrollingFlightPlan[PatrollingLayout], ABC):
         # TODO: Factor out a common base of the combat and non-combat race-tracks.
         # No harm in setting this, but we ought to clean up a bit.
         return meters(0)
+
+    @property
+    def first_pre_mission_aar_time(self) -> datetime | None:
+        coalition = getattr(self.flight, "coalition", None)
+        ato = getattr(coalition, "ato", None)
+        packages = getattr(ato, "packages", [self.package])
+
+        first_pre_refuel: datetime | None = None
+        for package in packages:
+            for flight in package.flights:
+                if flight == self.flight:
+                    continue
+                flight_plan = getattr(flight, "flight_plan", None)
+                if flight_plan is None:
+                    continue
+                pre_refuel = getattr(flight_plan.layout, "pre_refuel", None)
+                if pre_refuel is None:
+                    continue
+                arrival_time = flight_plan.tot_for_waypoint(pre_refuel)
+                if arrival_time is None:
+                    continue
+                if first_pre_refuel is None or arrival_time < first_pre_refuel:
+                    first_pre_refuel = arrival_time
+        return first_pre_refuel

--- a/game/ato/flightplans/sweep.py
+++ b/game/ato/flightplans/sweep.py
@@ -9,8 +9,9 @@ from dcs.task import Targets
 
 from game.flightplan import HoldZoneGeometry
 from game.flightplan.waypointactions.engagetargets import EngageTargets
+from game.flightplan.waypointactions.hold import Hold
 from game.flightplan.waypointoptions.formation import Formation
-from game.utils import Heading, nautical_miles
+from game.utils import Heading, Speed, nautical_miles
 from .ibuilder import IBuilder
 from .loiter import LoiterFlightPlan, LoiterLayout
 from .waypointbuilder import WaypointBuilder
@@ -22,14 +23,24 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class SweepLayout(LoiterLayout):
     nav_to: list[FlightWaypoint]
+    pre_refuel: FlightWaypoint | None
+    nav_from_pre_refuel: list[FlightWaypoint]
     sweep_start: FlightWaypoint
     sweep_end: FlightWaypoint
     nav_from: list[FlightWaypoint]
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        state.setdefault("pre_refuel", None)
+        state.setdefault("nav_from_pre_refuel", [])
+        self.__dict__.update(state)
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
         yield self.departure
         yield self.hold
         yield from self.nav_to
+        if self.pre_refuel is not None:
+            yield self.pre_refuel
+            yield from self.nav_from_pre_refuel
         yield self.sweep_start
         yield self.sweep_end
         yield from self.nav_from
@@ -67,6 +78,8 @@ class SweepFlightPlan(LoiterFlightPlan[SweepLayout]):
         return self.tot
 
     def tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_arrival_time
         if waypoint == self.layout.sweep_start:
             return self.sweep_start_time
         if waypoint == self.layout.sweep_end:
@@ -76,13 +89,46 @@ class SweepFlightPlan(LoiterFlightPlan[SweepLayout]):
     def depart_time_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
         if waypoint == self.layout.hold:
             return self.push_time
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_push_time
         return None
 
     @property
     def push_time(self) -> datetime:
-        return self.sweep_end_time - self.travel_time_between_waypoints(
-            self.layout.hold, self.layout.sweep_end
+        return self.sweep_start_time - self._travel_time_after_departure(
+            self.layout.hold, self.layout.sweep_start
         )
+
+    @property
+    def pre_refuel_duration(self) -> timedelta:
+        if self.layout.pre_refuel is None:
+            return timedelta()
+        return self.flight.coalition.game.settings.pre_mission_aar_hold_duration
+
+    @property
+    def pre_refuel_push_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        return self.sweep_start_time - self._travel_time_after_departure(
+            self.layout.pre_refuel, self.layout.sweep_start
+        )
+
+    @property
+    def pre_refuel_arrival_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        push_time = self.pre_refuel_push_time
+        if push_time is None:
+            return None
+        return push_time - self.pre_refuel_duration
+
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        travel_time = super().total_time_between_waypoints(a, b)
+        if a != self.layout.pre_refuel:
+            return travel_time
+        return travel_time + self.pre_refuel_duration
 
     @property
     def mission_begin_on_station_time(self) -> datetime | None:
@@ -94,6 +140,14 @@ class SweepFlightPlan(LoiterFlightPlan[SweepLayout]):
 
     def add_waypoint_actions(self) -> None:
         super().add_waypoint_actions()
+        if self.layout.pre_refuel is not None:
+            pre_refuel = self.layout.pre_refuel
+            speed = self.flight.unit_type.patrol_speed
+            if speed is None:
+                speed = Speed.from_mach(0.6, pre_refuel.alt)
+            pre_refuel.add_action(
+                Hold(self.pre_refuel_push_time_provider, pre_refuel.alt, speed)
+            )
         self.layout.sweep_start.set_option(Formation.LINE_ABREAST_OPEN)
         self.layout.sweep_start.add_action(
             EngageTargets(
@@ -104,6 +158,11 @@ class SweepFlightPlan(LoiterFlightPlan[SweepLayout]):
                 ],
             )
         )
+
+    def pre_refuel_push_time_provider(self) -> datetime:
+        push_time = self.pre_refuel_push_time
+        assert push_time is not None
+        return push_time
 
 
 class Builder(IBuilder[SweepFlightPlan, SweepLayout]):
@@ -121,13 +180,30 @@ class Builder(IBuilder[SweepFlightPlan, SweepLayout]):
         start, end = builder.sweep(start_pos, target, self.doctrine.combat_altitude)
 
         hold = builder.hold(self._hold_point())
+        nav_to = builder.nav_path(
+            hold.position, start.position, self.doctrine.combat_altitude
+        )
+        pre_refuel = None
+        nav_from_pre_refuel: list[FlightWaypoint] = []
+        if self.flight.pre_mission_aar:
+            pre_refuel = builder.pre_mission_aar(self.package.waypoints.refuel)
+            nav_to = builder.nav_path(
+                hold.position,
+                pre_refuel.position,
+                self.doctrine.combat_altitude,
+            )
+            nav_from_pre_refuel = builder.nav_path(
+                pre_refuel.position,
+                start.position,
+                self.doctrine.combat_altitude,
+            )
 
         return SweepLayout(
             departure=builder.takeoff(self.flight.departure),
             hold=hold,
-            nav_to=builder.nav_path(
-                hold.position, start.position, self.doctrine.combat_altitude
-            ),
+            nav_to=nav_to,
+            pre_refuel=pre_refuel,
+            nav_from_pre_refuel=nav_from_pre_refuel,
             nav_from=builder.nav_path(
                 end.position,
                 self.flight.arrival.position,

--- a/game/ato/flightplans/tarcap.py
+++ b/game/ato/flightplans/tarcap.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Type
 
+from game.flightplan.waypointactions.hold import Hold
 from game.utils import Distance, Speed, feet
 from .capbuilder import CapBuilder
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
@@ -17,11 +18,21 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class TarCapLayout(PatrollingLayout):
+    pre_refuel: FlightWaypoint | None
+    nav_from_pre_refuel: list[FlightWaypoint]
     refuel: FlightWaypoint | None
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        state.setdefault("pre_refuel", None)
+        state.setdefault("nav_from_pre_refuel", [])
+        self.__dict__.update(state)
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
         yield self.departure
         yield from self.nav_to
+        if self.pre_refuel is not None:
+            yield self.pre_refuel
+            yield from self.nav_from_pre_refuel
         yield self.patrol_start
         yield self.patrol_end
         if self.refuel is not None:
@@ -64,9 +75,47 @@ class TarCapFlightPlan(PatrollingFlightPlan[TarCapLayout]):
         return -timedelta(minutes=2)
 
     def depart_time_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_push_time
         if waypoint == self.layout.patrol_end:
             return self.patrol_end_time
         return super().depart_time_for_waypoint(waypoint)
+
+    def tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        if waypoint == self.layout.pre_refuel:
+            return self.pre_refuel_arrival_time
+        return super().tot_for_waypoint(waypoint)
+
+    @property
+    def pre_refuel_duration(self) -> timedelta:
+        if self.layout.pre_refuel is None:
+            return timedelta()
+        return self.flight.coalition.game.settings.pre_mission_aar_hold_duration
+
+    @property
+    def pre_refuel_push_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        return self.patrol_start_time - self._travel_time_after_departure(
+            self.layout.pre_refuel, self.layout.patrol_start
+        )
+
+    @property
+    def pre_refuel_arrival_time(self) -> datetime | None:
+        if self.layout.pre_refuel is None:
+            return None
+        push_time = self.pre_refuel_push_time
+        if push_time is None:
+            return None
+        return push_time - self.pre_refuel_duration
+
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        travel_time = super().total_time_between_waypoints(a, b)
+        if a != self.layout.pre_refuel:
+            return travel_time
+        return travel_time + self.pre_refuel_duration
 
     @property
     def patrol_start_time(self) -> datetime:
@@ -81,6 +130,23 @@ class TarCapFlightPlan(PatrollingFlightPlan[TarCapLayout]):
         if end is not None:
             return end
         return super().patrol_end_time
+
+    def add_waypoint_actions(self) -> None:
+        super().add_waypoint_actions()
+        if self.layout.pre_refuel is None:
+            return
+        pre_refuel = self.layout.pre_refuel
+        speed = self.flight.unit_type.patrol_speed
+        if speed is None:
+            speed = Speed.from_mach(0.6, pre_refuel.alt)
+        pre_refuel.add_action(
+            Hold(self.pre_refuel_push_time_provider, pre_refuel.alt, speed)
+        )
+
+    def pre_refuel_push_time_provider(self) -> datetime:
+        push_time = self.pre_refuel_push_time
+        assert push_time is not None
+        return push_time
 
 
 class Builder(CapBuilder[TarCapFlightPlan, TarCapLayout]):
@@ -99,23 +165,36 @@ class Builder(CapBuilder[TarCapFlightPlan, TarCapLayout]):
 
         start, end = builder.race_track(orbit0p, orbit1p, patrol_alt)
 
+        pre_refuel = None
+        nav_to_destination = orbit0p
+        nav_from_pre_refuel: list[FlightWaypoint] = []
         refuel = None
         nav_from_origin = orbit1p
 
         if self.package.waypoints is not None:
+            if self.flight.pre_mission_aar:
+                pre_refuel = builder.pre_mission_aar(self.package.waypoints.refuel)
+                nav_to_destination = pre_refuel.position
+                nav_from_pre_refuel = builder.nav_path(
+                    pre_refuel.position,
+                    orbit0p,
+                    patrol_alt,
+                )
             refuel = builder.refuel(self.package.waypoints.refuel)
             nav_from_origin = refuel.position
 
         return TarCapLayout(
             departure=builder.takeoff(self.flight.departure),
             nav_to=builder.nav_path(
-                self.flight.departure.position, orbit0p, patrol_alt
+                self.flight.departure.position, nav_to_destination, patrol_alt
             ),
             nav_from=builder.nav_path(
                 nav_from_origin, self.flight.arrival.position, patrol_alt
             ),
             patrol_start=start,
             patrol_end=end,
+            pre_refuel=pre_refuel,
+            nav_from_pre_refuel=nav_from_pre_refuel,
             refuel=refuel,
             arrival=builder.land(self.flight.arrival),
             divert=builder.divert(self.flight.divert),

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime, timedelta
-from typing import Type
+from typing import TYPE_CHECKING, Type
 
 from game.utils import Heading, feet, meters, nautical_miles
 from .ibuilder import IBuilder
@@ -9,18 +10,26 @@ from .patrolling import PatrollingLayout
 from .refuelingflightplan import RefuelingFlightPlan
 from .waypointbuilder import WaypointBuilder
 
+if TYPE_CHECKING:
+    from game.ato.package import Package
+
 
 class TheaterRefuelingFlightPlan(RefuelingFlightPlan):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
 
+    def pre_mission_aar_packages(self) -> Iterable[Package]:
+        coalition = getattr(self.flight, "coalition", None)
+        ato = getattr(coalition, "ato", None)
+        return getattr(ato, "packages", [self.package])
+
     @property
     def patrol_start_time(self) -> datetime:
-        first_pre_refuel = self.first_pre_mission_aar_time
-        if first_pre_refuel is None:
+        pre_refuel_start = self.pre_mission_aar_tanker_start_time
+        if pre_refuel_start is None:
             return super().patrol_start_time
-        return min(super().patrol_start_time, first_pre_refuel)
+        return min(super().patrol_start_time, pre_refuel_start)
 
     @property
     def patrol_duration(self) -> timedelta:

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Type
 
 from game.utils import Heading, feet, meters, nautical_miles
@@ -16,14 +16,25 @@ class TheaterRefuelingFlightPlan(RefuelingFlightPlan):
         return Builder
 
     @property
+    def patrol_start_time(self) -> datetime:
+        first_pre_refuel = self.first_pre_mission_aar_time
+        if first_pre_refuel is None:
+            return super().patrol_start_time
+        return min(super().patrol_start_time, first_pre_refuel)
+
+    @property
     def patrol_duration(self) -> timedelta:
         # Add 30 minutes to desired_player_mission_duration as TOTs for flights
         # can sit up to this time. This extension means the tanker remains on
         # station for the flights' return.
-        return (
+        native_duration = (
             self.flight.coalition.game.settings.desired_player_mission_duration
             + timedelta(minutes=30)
         )
+        native_end_time = self.tot + native_duration
+        if self.patrol_start_time >= self.tot:
+            return native_duration
+        return native_end_time - self.patrol_start_time
 
 
 class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -201,6 +201,14 @@ class WaypointBuilder:
             pretty_name="Refuel",
         )
 
+    def pre_mission_aar(self, position: Point) -> FlightWaypoint:
+        waypoint = self.hold(position)
+        waypoint.name = "PRE-REFUEL"
+        waypoint.waypoint_type = FlightWaypointType.PRE_MISSION_AAR
+        waypoint.description = "Refuel before mission push time"
+        waypoint.pretty_name = "Pre-Refuel"
+        return waypoint
+
     def recovery_tanker(self, position: Point) -> FlightWaypoint:
         alt_type: AltitudeReference = "BARO"
 

--- a/game/ato/flightwaypointtype.py
+++ b/game/ato/flightwaypointtype.py
@@ -51,3 +51,4 @@ class FlightWaypointType(IntEnum):
     INGRESS_AIR_ASSAULT = 31
     RECOVERY_TANKER = 32
     INGRESS_ANTI_SHIP = 33
+    PRE_MISSION_AAR = 34  # Pre-mission refueling hold point.

--- a/game/ato/package.py
+++ b/game/ato/package.py
@@ -31,6 +31,7 @@ class Package:
         # change. This is really a UI property rather than a game property, but we want
         # it to persist in the save.
         self.auto_asap = auto_asap
+        self.pre_mission_aar = False
         self.flights: list[Flight] = []
 
         # Desired TOT as an offset from mission start. Obviously datetime.min is bogus,
@@ -43,6 +44,11 @@ class Package:
     @property
     def has_players(self) -> bool:
         return any(flight.client_count for flight in self.flights)
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.__dict__.update(state)
+        if "pre_mission_aar" not in state:
+            self.pre_mission_aar = False
 
     @property
     def formation_speed(self) -> Optional[Speed]:

--- a/game/missiongenerator/aircraft/waypoints/premissionaar.py
+++ b/game/missiongenerator/aircraft/waypoints/premissionaar.py
@@ -1,0 +1,21 @@
+from dcs.point import MovingPoint
+from dcs.task import RefuelingTaskAction
+
+from game.ato import FlightType
+from .pydcswaypointbuilder import PydcsWaypointBuilder
+
+
+class PreMissionAarBuilder(PydcsWaypointBuilder):
+    def add_tasks(self, waypoint: MovingPoint) -> None:
+        if self._has_refueling_available():
+            waypoint.add_task(RefuelingTaskAction())
+        return super().add_tasks(waypoint)
+
+    def _has_refueling_available(self) -> bool:
+        if self.package.has_flight_with_task(FlightType.REFUELING):
+            return True
+        ato = getattr(self.flight.coalition, "ato", None)
+        for package in getattr(ato, "packages", []):
+            if package.has_flight_with_task(FlightType.REFUELING):
+                return True
+        return False

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -83,6 +83,9 @@ class PydcsWaypointBuilder:
         tot = self.flight.flight_plan.tot_for_waypoint(self.waypoint)
         if tot is not None:
             self.set_waypoint_tot(waypoint, tot, self.generated_waypoint_idx)
+        self.waypoint.departure_time = self.flight.flight_plan.depart_time_for_waypoint(
+            self.waypoint
+        )
         self.add_tasks(waypoint)
         return waypoint
 

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -34,6 +34,7 @@ from .landingpoint import LandingPointBuilder
 from .landingzone import LandingZoneBuilder
 from .ocaaircraftingress import OcaAircraftIngressBuilder
 from .ocarunwayingress import OcaRunwayIngressBuilder
+from .premissionaar import PreMissionAarBuilder
 from .pydcswaypointbuilder import PydcsWaypointBuilder, TARGET_WAYPOINTS
 from .racetrack import RaceTrackBuilder
 from .racetrackend import RaceTrackEndBuilder
@@ -142,6 +143,7 @@ class WaypointGenerator:
             FlightWaypointType.PATROL: RaceTrackEndBuilder,
             FlightWaypointType.PATROL_TRACK: RaceTrackBuilder,
             FlightWaypointType.PICKUP_ZONE: LandingZoneBuilder,
+            FlightWaypointType.PRE_MISSION_AAR: PreMissionAarBuilder,
             FlightWaypointType.RECOVERY_TANKER: RecoveryTankerBuilder,
             FlightWaypointType.REFUEL: RefuelPointBuilder,
             FlightWaypointType.SPLIT: SplitPointBuilder,

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -67,6 +67,7 @@ class WaypointGenerator:
     def create_waypoints(self) -> tuple[timedelta, list[FlightWaypoint]]:
         for waypoint in self.flight.points:
             waypoint.tot = None
+            waypoint.departure_time = None
 
         waypoints = self.flight.flight_plan.waypoints
         mission_start_time = self.set_takeoff_time(waypoints[0])

--- a/game/server/waypoints/models.py
+++ b/game/server/waypoints/models.py
@@ -13,10 +13,14 @@ def timing_info(flight: Flight, waypoint_idx: int) -> str:
 
     waypoint = flight.flight_plan.waypoints[waypoint_idx - 1]
     prefix = "TOT"
-    time = flight.flight_plan.tot_for_waypoint(waypoint)
-    if time is None:
+    if waypoint.waypoint_type == FlightWaypointType.PRE_MISSION_AAR:
         prefix = "Depart"
         time = flight.flight_plan.depart_time_for_waypoint(waypoint)
+    else:
+        time = flight.flight_plan.tot_for_waypoint(waypoint)
+        if time is None:
+            prefix = "Depart"
+            time = flight.flight_plan.depart_time_for_waypoint(waypoint)
     if time is None:
         return ""
     return f"{prefix} {time}"

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -473,6 +473,20 @@ class Settings:
             "and other flights have their TOTs."
         ),
     )
+    pre_mission_aar_hold_duration: timedelta = minutes_option(
+        "Pre-Mission AAR hold duration",
+        page=MISSION_GENERATOR_PAGE,
+        section=GAMEPLAY_SECTION,
+        default=timedelta(minutes=15),
+        min=1,
+        max=120,
+        detail=(
+            "Pre-Mission AAR can significantly increase time to target. When using "
+            "it, consider increasing Desired Mission Duration by 30-60 minutes so "
+            "enemy CAP and support flights remain active when the package reaches "
+            "the target."
+        ),
+    )
 
     # Performance
     perf_smoke_gen: bool = boolean_option(

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -211,6 +211,10 @@ class PackageModel(QAbstractListModel):
 
     def set_asap(self, asap: bool) -> None:
         with self.game_model.sim_controller.paused_sim():
+            if not asap and self.package.auto_asap:
+                self.package.set_tot_asap(
+                    self.game_model.sim_controller.current_time_in_sim
+                )
             self.package.auto_asap = asap
             self.update_tot()
 

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -27,6 +27,10 @@ from qt_ui.simcontroller import SimController
 from qt_ui.uiconstants import AIRCRAFT_ICONS
 
 
+def index_in_range(index: QModelIndex, row_count: int) -> bool:
+    return index.isValid() and 0 <= index.row() < row_count
+
+
 class DeletableChildModelManager:
     """Manages lifetimes for child models.
 
@@ -125,7 +129,7 @@ class PackageModel(QAbstractListModel):
         return len(self.package.flights)
 
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:
-        if not index.isValid():
+        if not index_in_range(index, self.rowCount()):
             return None
         flight = self.flight_at_index(index)
         if role == Qt.DisplayRole:
@@ -162,6 +166,8 @@ class PackageModel(QAbstractListModel):
 
     def cancel_or_abort_flight_at_index(self, index: QModelIndex) -> None:
         """Removes the flight at the given index from the package."""
+        if not index_in_range(index, self.rowCount()):
+            return
         self.cancel_or_abort_flight(self.flight_at_index(index))
 
     def cancel_or_abort_flight(self, flight: Flight) -> None:
@@ -240,7 +246,8 @@ class PackageModel(QAbstractListModel):
             yield flight
 
     def on_sim_update(self, _events: GameUpdateEvents) -> None:
-        self.dataChanged.emit(self.index(0), self.index(self.rowCount()))
+        if self.rowCount():
+            self.dataChanged.emit(self.index(0), self.index(self.rowCount() - 1))
 
 
 class AtoModel(QAbstractListModel):
@@ -266,7 +273,7 @@ class AtoModel(QAbstractListModel):
         return len(self.ato.packages)
 
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:
-        if not index.isValid():
+        if not index_in_range(index, self.rowCount()):
             return None
         package = self.ato.packages[index.row()]
         if role == Qt.DisplayRole:
@@ -289,6 +296,8 @@ class AtoModel(QAbstractListModel):
 
     def cancel_or_abort_package_at_index(self, index: QModelIndex) -> None:
         """Removes the package at the given index from the ATO."""
+        if not index_in_range(index, self.rowCount()):
+            return
         self.cancel_or_abort_package(self.package_at_index(index))
 
     def cancel_or_abort_package(self, package: Package) -> None:
@@ -349,6 +358,8 @@ class AtoModel(QAbstractListModel):
 
     def get_package_model(self, index: QModelIndex) -> PackageModel:
         """Returns a model for the package at the given index."""
+        if not index_in_range(index, self.rowCount()):
+            raise IndexError("Package index out of range")
         return self.package_models.acquire(self.package_at_index(index))
 
     def find_matching_package_model(self, package: Package) -> Optional[PackageModel]:
@@ -364,7 +375,8 @@ class AtoModel(QAbstractListModel):
             yield self.package_models.acquire(package)
 
     def on_sim_update(self, _events: GameUpdateEvents) -> None:
-        self.dataChanged.emit(self.index(0), self.index(self.rowCount()))
+        if self.rowCount():
+            self.dataChanged.emit(self.index(0), self.index(self.rowCount() - 1))
 
 
 class TransferModel(QAbstractListModel):
@@ -384,7 +396,7 @@ class TransferModel(QAbstractListModel):
         return self.transfers.pending_transfer_count
 
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:
-        if not index.isValid():
+        if not index_in_range(index, self.rowCount()):
             return None
         transfer = self.transfer_at_index(index)
         if role == Qt.DisplayRole:
@@ -414,6 +426,8 @@ class TransferModel(QAbstractListModel):
 
     def cancel_transfer_at_index(self, index: QModelIndex) -> None:
         """Cancels the planned unit transfer at the given index."""
+        if not index_in_range(index, self.rowCount()):
+            return
         self.cancel_transfer(self.transfer_at_index(index))
 
     def cancel_transfer(self, transfer: TransferOrder) -> None:
@@ -443,7 +457,7 @@ class AirWingModel(QAbstractListModel):
         return self.game_model.game.air_wing_for(self.player).size
 
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:
-        if not index.isValid():
+        if not index_in_range(index, self.rowCount()):
             return None
         squadron = self.squadron_at_index(index)
         if role == Qt.DisplayRole:
@@ -487,7 +501,7 @@ class SquadronModel(QAbstractListModel):
         return self.squadron.number_of_pilots_including_inactive
 
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:
-        if not index.isValid():
+        if not index_in_range(index, self.rowCount()):
             return None
         pilot = self.pilot_at_index(index)
         if role == Qt.DisplayRole:

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 
 from game.ato.flight import Flight
 from game.ato.flightplans.planningerror import PlanningError
+from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.game import Game
 from game.server import EventStream
@@ -98,6 +99,17 @@ class QPackageDialog(QDialog):
         self.auto_asap.toggled.connect(self.set_asap)
         self.tot_column.addWidget(self.auto_asap)
 
+        self.pre_mission_aar = QCheckBox("Pre-Mission AAR")
+        self.pre_mission_aar.setToolTip(
+            "Adds a pre-mission refueling hold to the flights in this package."
+        )
+        self.pre_mission_aar.setChecked(self.package_model.package.pre_mission_aar)
+        self.pre_mission_aar.setEnabled(
+            self.package_model.package.all_flights_waiting_for_start()
+        )
+        self.pre_mission_aar.toggled.connect(self.set_pre_mission_aar)
+        self.tot_column.addWidget(self.pre_mission_aar)
+
         self.tot_help_label = QLabel(
             '<a href="https://github.com/dcs-liberation/dcs_liberation/wiki/Mission-planning"><span style="color:#FFFFFF;">Help</span></a>'
         )
@@ -170,6 +182,21 @@ class QPackageDialog(QDialog):
         self.package_model.set_asap(checked)
         self.tot_spinner.setEnabled(not self.package_model.package.auto_asap)
         self.update_tot()
+
+    def set_pre_mission_aar(self, checked: bool) -> None:
+        self.package_model.package.pre_mission_aar = checked
+        for flight in self.package_model.package.flights:
+            try:
+                flight.pre_mission_aar = checked
+                if flight.flight_type is FlightType.REFUELING:
+                    flight.set_flight_type(FlightType.REFUELING)
+                flight.recreate_flight_plan()
+            except PlanningError as ex:
+                logging.exception("Could not recreate flight")
+                QMessageBox.critical(
+                    self, "Could not update flight", str(ex), QMessageBox.Ok
+                )
+        self.package_model.update_tot()
 
     def update_tot(self) -> None:
         self.tot_spinner.setTime(self.tot_qtime())

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
@@ -123,10 +123,14 @@ class QFlightWaypointList(QTableView):
         if waypoint.waypoint_type == FlightWaypointType.TAKEOFF:
             return self.takeoff_text(flight)
         prefix = ""
-        time = flight.flight_plan.tot_for_waypoint(waypoint)
-        if time is None:
+        if waypoint.waypoint_type == FlightWaypointType.PRE_MISSION_AAR:
             prefix = "Depart "
             time = flight.flight_plan.depart_time_for_waypoint(waypoint)
+        else:
+            time = flight.flight_plan.tot_for_waypoint(waypoint)
+            if time is None:
+                prefix = "Depart "
+                time = flight.flight_plan.depart_time_for_waypoint(waypoint)
         if time is None:
             return ""
         return f"{prefix}{time:%H:%M:%S}"

--- a/tests/ato/test_pre_mission_aar.py
+++ b/tests/ato/test_pre_mission_aar.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from dcs import Point
+from dcs.point import MovingPoint
 from dcs.terrain import Caucasus
 
 from game.ato import FlightWaypoint
@@ -18,11 +19,17 @@ from game.ato.flight import Flight
 from game.ato.flighttype import FlightType
 from game.ato.flightwaypointtype import FlightWaypointType
 from game.ato.package import Package
+from game.ato.starttype import StartType
 from game.flightplan.waypointactions.hold import Hold
 from game.missiongenerator.aircraft.waypoints.premissionaar import PreMissionAarBuilder
+from game.missiongenerator.aircraft.waypoints.racetrack import RaceTrackBuilder
+from game.missiongenerator.missiondata import TankerInfo
+from game.radio.radios import MHz
+from game.radio.tacan import TacanBand, TacanChannel
 from game.settings.settings import Settings
 from game.theater.frontline import FrontLine
 from game.utils import feet, kph
+from qt_ui.models import PackageModel
 
 
 class FakeDcsWaypoint:
@@ -167,6 +174,27 @@ def test_refuel_task_precedes_hold_task() -> None:
     ]
 
 
+def test_refuel_and_hold_are_serialized_on_pre_mission_aar_waypoint() -> None:
+    mission_start = datetime(2026, 8, 21, 12)
+    push_time = mission_start + timedelta(minutes=15)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    pre_refuel.add_action(Hold(lambda: push_time, feet(20000), kph(400)))
+    dcs_waypoint = MovingPoint(pre_refuel.position)
+    builder: Any = object.__new__(PreMissionAarBuilder)
+    builder.package = SimpleNamespace(has_flight_with_task=lambda task: True)
+    builder.waypoint = pre_refuel
+    builder.now = mission_start
+
+    builder.add_tasks(dcs_waypoint)
+
+    tasks = dcs_waypoint.dict()["task"]["params"]["tasks"]
+    assert tasks[1]["id"] == "Refueling"
+    assert tasks[2]["id"] == "ControlledTask"
+    assert tasks[2]["params"]["task"]["id"] == "Orbit"
+    assert tasks[2]["params"]["task"]["params"]["pattern"] == "Circle"
+    assert tasks[2]["params"]["stopCondition"]["time"] == 15 * 60
+
+
 def test_refuel_task_is_added_for_external_tanker_package() -> None:
     dcs_waypoint = FakeDcsWaypoint()
     external_tanker_package = SimpleNamespace(
@@ -211,6 +239,34 @@ def test_sweep_pre_mission_aar_hold_duration_is_respected() -> None:
     assert depart_time is not None
     assert arrival_time is not None
     assert depart_time - arrival_time == timedelta(minutes=15)
+    assert plan.depart_time_for_waypoint(layout.sweep_start) is None
+
+
+def test_pre_mission_aar_waypoint_stores_departure_time_for_kneeboard() -> None:
+    package = SimpleNamespace(time_over_target=datetime(2026, 8, 21, 12))
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    layout = SweepLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        hold=waypoint("HOLD", FlightWaypointType.LOITER),
+        nav_to=[],
+        pre_refuel=pre_refuel,
+        nav_from_pre_refuel=[],
+        sweep_start=waypoint("SWEEP START"),
+        sweep_end=waypoint("SWEEP END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = SweepFlightPlan(cast(Any, fake_flight(package)), layout)
+
+    pre_refuel.tot = plan.tot_for_waypoint(pre_refuel)
+    pre_refuel.departure_time = plan.depart_time_for_waypoint(pre_refuel)
+
+    assert pre_refuel.tot is not None
+    assert pre_refuel.departure_time is not None
+    assert pre_refuel.departure_time - pre_refuel.tot == timedelta(minutes=15)
+    assert layout.sweep_start.departure_time is None
 
 
 def test_package_tanker_starts_early_for_pre_mission_aar_and_keeps_recovery_window() -> (
@@ -256,13 +312,14 @@ def test_package_tanker_starts_early_for_pre_mission_aar_and_keeps_recovery_wind
         bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
     )
     plan = TestPlan(cast(Any, tanker_flight), layout)
+    tanker_start = pre_refuel_arrival - timedelta(minutes=5)
 
-    assert plan.patrol_start_time == pre_refuel_arrival
+    assert plan.patrol_start_time == tanker_start
     assert (
         plan.patrol_start_time + plan.patrol_duration
         == native_start + recovery_duration
     )
-    assert plan.tot_offset == -timedelta(minutes=5)
+    assert plan.tot_offset == timedelta()
 
 
 def test_package_tanker_uses_native_offset_without_pre_mission_aar() -> None:
@@ -298,6 +355,45 @@ def test_package_tanker_uses_native_offset_without_pre_mission_aar() -> None:
     plan = TestPlan(cast(Any, tanker_flight), layout)
 
     assert plan.tot_offset == timedelta()
+
+
+def test_disabling_asap_freezes_current_earliest_tot() -> None:
+    now = datetime(2026, 8, 21, 12)
+
+    class FakePackage:
+        auto_asap = True
+        time_over_target = now
+
+        def set_tot_asap(self, current_time: datetime) -> None:
+            self.time_over_target = current_time + timedelta(minutes=30)
+
+        def clamp_tot_for_current_time(self, current_time: datetime) -> None:
+            pass
+
+    package = FakePackage()
+
+    class PausedSim:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    package_model = cast(Any, PackageModel.__new__(PackageModel))
+    package_model.package = package
+    package_model.game_model = SimpleNamespace(
+        sim_controller=SimpleNamespace(
+            current_time_in_sim=now,
+            paused_sim=lambda: PausedSim(),
+        )
+    )
+    package_model.tot_changed = SimpleNamespace(emit=lambda: None)
+    package_model.layoutChanged = SimpleNamespace(emit=lambda: None)
+
+    package_model.set_asap(False)
+
+    assert package.auto_asap is False
+    assert package.time_over_target == now + timedelta(minutes=30)
 
 
 def test_theater_tanker_starts_for_external_pre_mission_aar_package() -> None:
@@ -338,8 +434,9 @@ def test_theater_tanker_starts_for_external_pre_mission_aar_package() -> None:
         bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
     )
     plan = TheaterRefuelingFlightPlan(cast(Any, tanker_flight), layout)
+    tanker_start = pre_refuel_arrival - timedelta(minutes=5)
 
-    assert plan.patrol_start_time == pre_refuel_arrival
+    assert plan.patrol_start_time == tanker_start
     assert (
         plan.patrol_start_time + plan.patrol_duration
         == native_start + desired_duration + timedelta(minutes=30)
@@ -387,7 +484,50 @@ def test_theater_tanker_created_before_pre_mission_aar_package_still_syncs() -> 
     outbound_flight = SimpleNamespace(flight_plan=outbound_flight_plan)
     coalition.ato.packages.append(SimpleNamespace(flights=[outbound_flight]))
 
-    assert plan.patrol_start_time == pre_refuel_arrival
+    assert plan.patrol_start_time == pre_refuel_arrival - timedelta(minutes=5)
+
+
+def test_theater_tanker_pre_mission_aar_sync_does_not_recurse() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    desired_duration = timedelta(minutes=60)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    tanker_flight = SimpleNamespace()
+    tanker_package = SimpleNamespace(
+        flights=[tanker_flight],
+        pre_mission_aar=False,
+        time_over_target=native_start,
+    )
+    coalition = SimpleNamespace(
+        ato=SimpleNamespace(packages=[tanker_package]),
+        game=SimpleNamespace(
+            settings=SimpleNamespace(desired_player_mission_duration=desired_duration)
+        ),
+    )
+    tanker_flight.package = tanker_package
+    tanker_flight.coalition = coalition
+    tanker_flight.unit_type = SimpleNamespace(patrol_speed=kph(400))
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TheaterRefuelingFlightPlan(cast(Any, tanker_flight), layout)
+
+    recursive_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: plan.patrol_start_time,
+    )
+    coalition.ato.packages.append(
+        SimpleNamespace(flights=[SimpleNamespace(flight_plan=recursive_flight_plan)])
+    )
+
+    assert plan.patrol_start_time == native_start
 
 
 def test_package_tanker_uses_pre_refuel_waypoint_even_without_flight_flag() -> None:
@@ -430,7 +570,251 @@ def test_package_tanker_uses_pre_refuel_waypoint_even_without_flight_flag() -> N
     )
     plan = TestPlan(cast(Any, tanker_flight), layout)
 
-    assert plan.patrol_start_time == pre_refuel_arrival
+    assert plan.patrol_start_time == pre_refuel_arrival - timedelta(minutes=5)
+
+
+def test_package_tanker_ignores_other_packages_pre_mission_aar() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    own_pre_refuel_arrival = native_start - timedelta(minutes=30)
+    other_pre_refuel_arrival = native_start - timedelta(hours=1)
+    own_pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    other_pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    own_flight = SimpleNamespace(
+        flight_plan=SimpleNamespace(
+            layout=SimpleNamespace(pre_refuel=own_pre_refuel),
+            tot_for_waypoint=lambda waypoint: own_pre_refuel_arrival,
+        )
+    )
+    other_flight = SimpleNamespace(
+        flight_plan=SimpleNamespace(
+            layout=SimpleNamespace(pre_refuel=other_pre_refuel),
+            tot_for_waypoint=lambda waypoint: other_pre_refuel_arrival,
+        )
+    )
+    tanker_flight = SimpleNamespace()
+    package = SimpleNamespace(
+        flights=[own_flight, tanker_flight],
+        pre_mission_aar=True,
+        time_over_target=native_start,
+    )
+    coalition = SimpleNamespace(
+        ato=SimpleNamespace(
+            packages=[
+                SimpleNamespace(flights=[other_flight]),
+                package,
+            ]
+        )
+    )
+    tanker_flight.package = package
+    tanker_flight.coalition = coalition
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return native_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return timedelta(minutes=20)
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.patrol_start_time == own_pre_refuel_arrival - timedelta(minutes=5)
+
+
+def test_package_tanker_takeoff_uses_pre_mission_aar_station_time() -> None:
+    package_tot = datetime(2026, 8, 21, 12)
+    pre_refuel_arrival = package_tot - timedelta(minutes=30)
+    station_time = pre_refuel_arrival - timedelta(minutes=5)
+    travel_to_racetrack = timedelta(minutes=30)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    outbound_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: pre_refuel_arrival,
+    )
+    outbound_flight = SimpleNamespace(flight_plan=outbound_flight_plan)
+    tanker_flight = SimpleNamespace(
+        start_type=StartType.RUNWAY,
+        client_count=0,
+        departure=SimpleNamespace(is_fleet=False),
+    )
+    package = SimpleNamespace(
+        flights=[outbound_flight, tanker_flight],
+        pre_mission_aar=True,
+        time_over_target=package_tot,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return package_tot
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return timedelta(minutes=20)
+
+        def travel_time_between_waypoints(
+            self, a: FlightWaypoint, b: FlightWaypoint
+        ) -> timedelta:
+            if b == self.layout.patrol_start:
+                return travel_to_racetrack
+            return timedelta()
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.tot == package_tot
+    assert plan.patrol_start_time == station_time
+    assert plan.takeoff_time() == station_time - travel_to_racetrack
+
+
+def test_package_tanker_startup_uses_pre_mission_aar_station_time() -> None:
+    package_tot = datetime(2026, 8, 21, 12)
+    pre_refuel_arrival = package_tot - timedelta(minutes=30)
+    station_time = pre_refuel_arrival - timedelta(minutes=5)
+    travel_to_racetrack = timedelta(minutes=30)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    outbound_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: pre_refuel_arrival,
+    )
+    outbound_flight = SimpleNamespace(flight_plan=outbound_flight_plan)
+    tanker_flight = SimpleNamespace(
+        start_type=StartType.COLD,
+        client_count=0,
+        departure=SimpleNamespace(is_fleet=False),
+    )
+    package = SimpleNamespace(
+        flights=[outbound_flight, tanker_flight],
+        pre_mission_aar=True,
+        time_over_target=package_tot,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return package_tot
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return timedelta(minutes=20)
+
+        def travel_time_between_waypoints(
+            self, a: FlightWaypoint, b: FlightWaypoint
+        ) -> timedelta:
+            if b == self.layout.patrol_start:
+                return travel_to_racetrack
+            return timedelta()
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.startup_time() == (
+        station_time - travel_to_racetrack - timedelta(minutes=2) - timedelta(minutes=8)
+    )
+
+
+def test_tanker_racetrack_start_serializes_tanker_beacon_before_orbit() -> None:
+    mission_start = datetime(2026, 8, 21, 12)
+    patrol_start = waypoint("RACETRACK START", FlightWaypointType.PATROL_TRACK)
+    patrol_end = waypoint("RACETRACK END", FlightWaypointType.PATROL)
+    dcs_waypoint = MovingPoint(patrol_start.position)
+    dcs_waypoint.alt = int(patrol_start.alt.meters)
+    tanker_flight = SimpleNamespace(
+        package=SimpleNamespace(
+            flights=[],
+            pre_mission_aar=False,
+            time_over_target=mission_start,
+        ),
+        unit_type=SimpleNamespace(
+            patrol_speed=kph(400),
+            dcs_unit_type=SimpleNamespace(tacan=True),
+        ),
+    )
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return mission_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return timedelta(minutes=30)
+
+    flight_plan = TestPlan(
+        cast(Any, tanker_flight),
+        PatrollingLayout(
+            departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+            nav_to=[],
+            patrol_start=patrol_start,
+            patrol_end=patrol_end,
+            nav_from=[],
+            arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+            divert=None,
+            bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+        ),
+    )
+    tanker_flight.flight_plan = flight_plan
+    tanker_info = TankerInfo(
+        group_name="Tanker",
+        callsign="Texaco",
+        variant="KC-130",
+        freq=MHz(251),
+        tacan=TacanChannel(37, TacanBand.Y),
+        start_time=mission_start,
+        end_time=mission_start + timedelta(minutes=30),
+        blue=True,
+    )
+    builder: Any = object.__new__(RaceTrackBuilder)
+    tanker_flight.flight_type = FlightType.REFUELING
+    builder.flight = tanker_flight
+    builder.mission_data = SimpleNamespace(tankers=[tanker_info])
+    builder.group = SimpleNamespace(units=[SimpleNamespace(id=1)])
+    builder.now = mission_start
+
+    builder.add_tasks(dcs_waypoint)
+
+    tasks = list(dcs_waypoint.dict()["task"]["params"]["tasks"].values())
+
+    def serialized_task_id(task: dict[str, Any]) -> str:
+        if task["id"] == "WrappedAction":
+            return str(task["params"]["action"]["id"])
+        return str(task["id"])
+
+    task_ids = [serialized_task_id(task) for task in tasks]
+    assert task_ids == ["Tanker", "ActivateBeacon", "ControlledTask"]
+    assert tasks[2]["params"]["task"]["id"] == "Orbit"
+    assert tasks[2]["params"]["task"]["params"]["pattern"] == "Race-Track"
 
 
 def test_package_tanker_respects_manual_tot_offset() -> None:

--- a/tests/ato/test_pre_mission_aar.py
+++ b/tests/ato/test_pre_mission_aar.py
@@ -1,0 +1,644 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato import FlightWaypoint
+from game.ato.flightplans.cas import CasFlightPlan, CasLayout
+from game.ato.flightplans.flightplanbuildertypes import FlightPlanBuilderTypes
+from game.ato.flightplans.packagerefueling import PackageRefuelingFlightPlan
+from game.ato.flightplans.patrolling import PatrollingLayout
+from game.ato.flightplans.formationattack import FormationAttackLayout
+from game.ato.flightplans.sweep import SweepFlightPlan, SweepLayout
+from game.ato.flightplans.tarcap import TarCapFlightPlan, TarCapLayout
+from game.ato.flightplans.theaterrefueling import TheaterRefuelingFlightPlan
+from game.ato.flight import Flight
+from game.ato.flighttype import FlightType
+from game.ato.flightwaypointtype import FlightWaypointType
+from game.ato.package import Package
+from game.flightplan.waypointactions.hold import Hold
+from game.missiongenerator.aircraft.waypoints.premissionaar import PreMissionAarBuilder
+from game.settings.settings import Settings
+from game.theater.frontline import FrontLine
+from game.utils import feet, kph
+
+
+class FakeDcsWaypoint:
+    def __init__(self) -> None:
+        self.tasks: list[Any] = []
+
+    def add_task(self, task: Any) -> None:
+        self.tasks.append(task)
+
+
+def waypoint(
+    name: str, waypoint_type: FlightWaypointType = FlightWaypointType.NAV
+) -> FlightWaypoint:
+    return FlightWaypoint(name, waypoint_type, Point(0, 0, Caucasus()), feet(20000))
+
+
+def fake_flight(package: Any) -> Any:
+    return SimpleNamespace(
+        package=package,
+        coalition=SimpleNamespace(
+            game=SimpleNamespace(
+                settings=SimpleNamespace(
+                    pre_mission_aar_hold_duration=timedelta(minutes=15)
+                )
+            )
+        ),
+        squadron=SimpleNamespace(aircraft=SimpleNamespace(cruise_speed=kph(400))),
+        unit_type=SimpleNamespace(patrol_speed=kph(400)),
+    )
+
+
+def test_sweep_pre_mission_aar_is_before_sweep_start() -> None:
+    package = SimpleNamespace(time_over_target=datetime(2026, 8, 21, 12))
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    layout = SweepLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        hold=waypoint("HOLD", FlightWaypointType.LOITER),
+        nav_to=[],
+        pre_refuel=pre_refuel,
+        nav_from_pre_refuel=[],
+        sweep_start=waypoint("SWEEP START"),
+        sweep_end=waypoint("SWEEP END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+
+    plan = SweepFlightPlan(cast(Any, fake_flight(package)), layout)
+
+    assert [w.name for w in plan.waypoints] == [
+        "TAKEOFF",
+        "HOLD",
+        "PRE-REFUEL",
+        "SWEEP START",
+        "SWEEP END",
+        "LANDING",
+        "BULLSEYE",
+    ]
+
+
+def test_tarcap_pre_mission_aar_is_before_patrol_start_and_return_refuel_remains() -> (
+    None
+):
+    package = SimpleNamespace(time_over_target=datetime(2026, 8, 21, 12))
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    return_refuel = waypoint("REFUEL", FlightWaypointType.REFUEL)
+    layout = TarCapLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        pre_refuel=pre_refuel,
+        nav_from_pre_refuel=[],
+        refuel=return_refuel,
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+
+    plan = TarCapFlightPlan(cast(Any, fake_flight(package)), layout)
+
+    assert [w.name for w in plan.waypoints] == [
+        "TAKEOFF",
+        "PRE-REFUEL",
+        "PATROL START",
+        "PATROL END",
+        "REFUEL",
+        "LANDING",
+        "BULLSEYE",
+    ]
+
+
+def test_cas_pre_mission_aar_is_before_ingress() -> None:
+    package = SimpleNamespace(time_over_target=datetime(2026, 8, 21, 12))
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    layout = CasLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        ingress=waypoint("INGRESS", FlightWaypointType.INGRESS_CAS),
+        pre_refuel=pre_refuel,
+        nav_from_pre_refuel=[],
+        patrol_start=waypoint("FLOT START"),
+        patrol_end=waypoint("FLOT END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+
+    plan = CasFlightPlan(cast(Any, fake_flight(package)), layout)
+
+    assert [w.name for w in plan.waypoints] == [
+        "TAKEOFF",
+        "PRE-REFUEL",
+        "INGRESS",
+        "FLOT START",
+        "FLOT END",
+        "LANDING",
+        "BULLSEYE",
+    ]
+
+
+def test_refuel_task_precedes_hold_task() -> None:
+    mission_start = datetime(2026, 8, 21, 12)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    pre_refuel.add_action(
+        Hold(lambda: mission_start + timedelta(minutes=15), feet(20000), kph(400))
+    )
+    dcs_waypoint = FakeDcsWaypoint()
+    builder: Any = object.__new__(PreMissionAarBuilder)
+    builder.package = SimpleNamespace(has_flight_with_task=lambda task: True)
+    builder.waypoint = pre_refuel
+    builder.now = mission_start
+
+    builder.add_tasks(cast(Any, dcs_waypoint))
+
+    assert [task.id for task in dcs_waypoint.tasks] == [
+        "Refueling",
+        "ControlledTask",
+    ]
+
+
+def test_refuel_task_is_added_for_external_tanker_package() -> None:
+    dcs_waypoint = FakeDcsWaypoint()
+    external_tanker_package = SimpleNamespace(
+        has_flight_with_task=lambda task: task == FlightType.REFUELING
+    )
+    builder: Any = object.__new__(PreMissionAarBuilder)
+    builder.package = SimpleNamespace(has_flight_with_task=lambda task: False)
+    builder.flight = SimpleNamespace(
+        coalition=SimpleNamespace(
+            ato=SimpleNamespace(packages=[external_tanker_package])
+        )
+    )
+    builder.waypoint = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    builder.now = datetime(2026, 8, 21, 12)
+
+    builder.add_tasks(cast(Any, dcs_waypoint))
+
+    assert [task.id for task in dcs_waypoint.tasks] == ["Refueling"]
+
+
+def test_sweep_pre_mission_aar_hold_duration_is_respected() -> None:
+    package = SimpleNamespace(time_over_target=datetime(2026, 8, 21, 12))
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    layout = SweepLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        hold=waypoint("HOLD", FlightWaypointType.LOITER),
+        nav_to=[],
+        pre_refuel=pre_refuel,
+        nav_from_pre_refuel=[],
+        sweep_start=waypoint("SWEEP START"),
+        sweep_end=waypoint("SWEEP END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+
+    plan = SweepFlightPlan(cast(Any, fake_flight(package)), layout)
+    depart_time = plan.depart_time_for_waypoint(pre_refuel)
+    arrival_time = plan.tot_for_waypoint(pre_refuel)
+
+    assert depart_time is not None
+    assert arrival_time is not None
+    assert depart_time - arrival_time == timedelta(minutes=15)
+
+
+def test_package_tanker_starts_early_for_pre_mission_aar_and_keeps_recovery_window() -> (
+    None
+):
+    native_start = datetime(2026, 8, 21, 12)
+    package_tot = native_start - timedelta(minutes=10)
+    recovery_duration = timedelta(minutes=20)
+    pre_refuel_arrival = native_start - timedelta(minutes=30)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    outbound_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: pre_refuel_arrival,
+    )
+    outbound_flight = SimpleNamespace(
+        pre_mission_aar=True, flight_plan=outbound_flight_plan
+    )
+    tanker_flight = SimpleNamespace()
+    package = SimpleNamespace(
+        flights=[outbound_flight, tanker_flight],
+        pre_mission_aar=True,
+        time_over_target=package_tot,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return native_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return recovery_duration
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.patrol_start_time == pre_refuel_arrival
+    assert (
+        plan.patrol_start_time + plan.patrol_duration
+        == native_start + recovery_duration
+    )
+    assert plan.tot_offset == -timedelta(minutes=5)
+
+
+def test_package_tanker_uses_native_offset_without_pre_mission_aar() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    recovery_duration = timedelta(minutes=20)
+    tanker_flight = SimpleNamespace()
+    package = SimpleNamespace(
+        flights=[tanker_flight],
+        pre_mission_aar=False,
+        time_over_target=native_start,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return native_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return recovery_duration
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.tot_offset == timedelta()
+
+
+def test_theater_tanker_starts_for_external_pre_mission_aar_package() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    desired_duration = timedelta(minutes=60)
+    pre_refuel_arrival = native_start - timedelta(minutes=30)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    outbound_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: pre_refuel_arrival,
+    )
+    outbound_flight = SimpleNamespace(flight_plan=outbound_flight_plan)
+    pre_refuel_package = SimpleNamespace(flights=[outbound_flight])
+    tanker_flight = SimpleNamespace()
+    tanker_package = SimpleNamespace(
+        flights=[tanker_flight],
+        pre_mission_aar=False,
+        time_over_target=native_start,
+    )
+    coalition = SimpleNamespace(
+        ato=SimpleNamespace(packages=[pre_refuel_package, tanker_package]),
+        game=SimpleNamespace(
+            settings=SimpleNamespace(desired_player_mission_duration=desired_duration)
+        ),
+    )
+    tanker_flight.package = tanker_package
+    tanker_flight.coalition = coalition
+    tanker_flight.unit_type = SimpleNamespace(patrol_speed=kph(400))
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TheaterRefuelingFlightPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.patrol_start_time == pre_refuel_arrival
+    assert (
+        plan.patrol_start_time + plan.patrol_duration
+        == native_start + desired_duration + timedelta(minutes=30)
+    )
+
+
+def test_theater_tanker_created_before_pre_mission_aar_package_still_syncs() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    desired_duration = timedelta(minutes=60)
+    pre_refuel_arrival = native_start - timedelta(minutes=30)
+    tanker_flight = SimpleNamespace()
+    tanker_package = SimpleNamespace(
+        flights=[tanker_flight],
+        pre_mission_aar=False,
+        time_over_target=native_start,
+    )
+    coalition = SimpleNamespace(
+        ato=SimpleNamespace(packages=[tanker_package]),
+        game=SimpleNamespace(
+            settings=SimpleNamespace(desired_player_mission_duration=desired_duration)
+        ),
+    )
+    tanker_flight.package = tanker_package
+    tanker_flight.coalition = coalition
+    tanker_flight.unit_type = SimpleNamespace(patrol_speed=kph(400))
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TheaterRefuelingFlightPlan(cast(Any, tanker_flight), layout)
+    assert plan.patrol_start_time == native_start
+
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    outbound_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: pre_refuel_arrival,
+    )
+    outbound_flight = SimpleNamespace(flight_plan=outbound_flight_plan)
+    coalition.ato.packages.append(SimpleNamespace(flights=[outbound_flight]))
+
+    assert plan.patrol_start_time == pre_refuel_arrival
+
+
+def test_package_tanker_uses_pre_refuel_waypoint_even_without_flight_flag() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    package_tot = native_start - timedelta(minutes=10)
+    recovery_duration = timedelta(minutes=20)
+    pre_refuel_arrival = native_start - timedelta(minutes=30)
+    pre_refuel = waypoint("PRE-REFUEL", FlightWaypointType.PRE_MISSION_AAR)
+    outbound_flight_plan = SimpleNamespace(
+        layout=SimpleNamespace(pre_refuel=pre_refuel),
+        tot_for_waypoint=lambda waypoint: pre_refuel_arrival,
+    )
+    outbound_flight = SimpleNamespace(flight_plan=outbound_flight_plan)
+    tanker_flight = SimpleNamespace()
+    package = SimpleNamespace(
+        flights=[outbound_flight, tanker_flight],
+        pre_mission_aar=True,
+        time_over_target=package_tot,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return native_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return recovery_duration
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.patrol_start_time == pre_refuel_arrival
+
+
+def test_package_tanker_respects_manual_tot_offset() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    package_tot = native_start - timedelta(minutes=10)
+    recovery_duration = timedelta(minutes=20)
+    tanker_flight = SimpleNamespace()
+    package = SimpleNamespace(
+        flights=[tanker_flight],
+        pre_mission_aar=False,
+        time_over_target=package_tot,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return native_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return recovery_duration
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+    plan.tot_offset = -timedelta(minutes=5)
+
+    assert plan.patrol_start_time == package_tot - timedelta(minutes=5)
+
+
+def test_frontline_refueling_uses_package_tanker_when_pre_mission_aar_enabled() -> None:
+    target = object.__new__(FrontLine)
+    package = SimpleNamespace(target=target, pre_mission_aar=True)
+    flight = SimpleNamespace(
+        flight_type=FlightType.REFUELING,
+        package=package,
+        squadron=SimpleNamespace(player=True),
+    )
+
+    assert (
+        FlightPlanBuilderTypes.for_flight(cast(Any, flight))
+        == PackageRefuelingFlightPlan.builder_type()
+    )
+
+
+def test_frontline_refueling_uses_theater_tanker_when_pre_mission_aar_disabled() -> (
+    None
+):
+    target = object.__new__(FrontLine)
+    package = SimpleNamespace(target=target, pre_mission_aar=False)
+    flight = SimpleNamespace(
+        flight_type=FlightType.REFUELING,
+        package=package,
+        squadron=SimpleNamespace(player=True),
+    )
+
+    assert (
+        FlightPlanBuilderTypes.for_flight(cast(Any, flight))
+        == TheaterRefuelingFlightPlan.builder_type()
+    )
+
+
+def test_package_tanker_uses_native_timing_without_pre_mission_aar() -> None:
+    native_start = datetime(2026, 8, 21, 12)
+    recovery_duration = timedelta(minutes=20)
+    outbound_flight = SimpleNamespace(pre_mission_aar=False)
+    tanker_flight = SimpleNamespace()
+    package = SimpleNamespace(
+        flights=[outbound_flight, tanker_flight],
+        pre_mission_aar=False,
+        time_over_target=native_start,
+    )
+    tanker_flight.package = package
+
+    class TestPlan(PackageRefuelingFlightPlan):
+        @property
+        def native_patrol_start_time(self) -> datetime:
+            return native_start
+
+        @property
+        def recovery_refuel_duration(self) -> timedelta:
+            return recovery_duration
+
+    layout = PatrollingLayout(
+        departure=waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+        nav_to=[],
+        patrol_start=waypoint("PATROL START"),
+        patrol_end=waypoint("PATROL END"),
+        nav_from=[],
+        arrival=waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+    )
+    plan = TestPlan(cast(Any, tanker_flight), layout)
+
+    assert plan.patrol_start_time == native_start
+    assert plan.patrol_duration == recovery_duration
+
+
+def test_pre_mission_aar_distance_setting_was_removed() -> None:
+    assert not hasattr(Settings, "pre_mission_aar_distance")
+
+
+def test_old_package_save_defaults_pre_mission_aar_flag() -> None:
+    package = object.__new__(Package)
+    package.__setstate__({"flights": []})
+
+    assert package.pre_mission_aar is False
+
+
+def test_old_flight_save_defaults_pre_mission_aar_flag() -> None:
+    flight = object.__new__(Flight)
+    flight.__setstate__({})
+
+    assert flight.pre_mission_aar is False
+
+
+def test_old_formation_attack_layout_save_defaults_pre_mission_aar_fields() -> None:
+    layout = object.__new__(FormationAttackLayout)
+    layout.__setstate__(
+        {
+            "departure": waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+            "hold": waypoint("HOLD", FlightWaypointType.LOITER),
+            "nav_to": [],
+            "join": waypoint("JOIN"),
+            "ingress": waypoint("INGRESS"),
+            "targets": [waypoint("TARGET")],
+            "split": waypoint("SPLIT"),
+            "refuel": waypoint("REFUEL", FlightWaypointType.REFUEL),
+            "nav_from": [],
+            "arrival": waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+            "divert": None,
+            "bullseye": waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+        }
+    )
+
+    assert layout.pre_refuel is None
+    assert layout.nav_from_pre_refuel == []
+    assert "PRE-REFUEL" not in [waypoint.name for waypoint in layout.iter_waypoints()]
+
+
+def test_old_sweep_layout_save_defaults_pre_mission_aar_fields() -> None:
+    layout = object.__new__(SweepLayout)
+    layout.__setstate__(
+        {
+            "departure": waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+            "hold": waypoint("HOLD", FlightWaypointType.LOITER),
+            "nav_to": [],
+            "sweep_start": waypoint("SWEEP START"),
+            "sweep_end": waypoint("SWEEP END"),
+            "nav_from": [],
+            "arrival": waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+            "divert": None,
+            "bullseye": waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+        }
+    )
+
+    assert layout.pre_refuel is None
+    assert layout.nav_from_pre_refuel == []
+    assert "PRE-REFUEL" not in [waypoint.name for waypoint in layout.iter_waypoints()]
+
+
+def test_old_tarcap_layout_save_defaults_pre_mission_aar_fields() -> None:
+    layout = object.__new__(TarCapLayout)
+    layout.__setstate__(
+        {
+            "departure": waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+            "nav_to": [],
+            "patrol_start": waypoint("PATROL START"),
+            "patrol_end": waypoint("PATROL END"),
+            "refuel": waypoint("REFUEL", FlightWaypointType.REFUEL),
+            "nav_from": [],
+            "arrival": waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+            "divert": None,
+            "bullseye": waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+        }
+    )
+
+    assert layout.pre_refuel is None
+    assert layout.nav_from_pre_refuel == []
+    assert "PRE-REFUEL" not in [waypoint.name for waypoint in layout.iter_waypoints()]
+
+
+def test_old_cas_layout_save_defaults_pre_mission_aar_fields() -> None:
+    layout = object.__new__(CasLayout)
+    layout.__setstate__(
+        {
+            "departure": waypoint("TAKEOFF", FlightWaypointType.TAKEOFF),
+            "nav_to": [],
+            "ingress": waypoint("INGRESS", FlightWaypointType.INGRESS_CAS),
+            "patrol_start": waypoint("FLOT START"),
+            "patrol_end": waypoint("FLOT END"),
+            "nav_from": [],
+            "arrival": waypoint("LANDING", FlightWaypointType.LANDING_POINT),
+            "divert": None,
+            "bullseye": waypoint("BULLSEYE", FlightWaypointType.BULLSEYE),
+        }
+    )
+
+    assert layout.pre_refuel is None
+    assert layout.nav_from_pre_refuel == []
+    assert "PRE-REFUEL" not in [waypoint.name for waypoint in layout.iter_waypoints()]


### PR DESCRIPTION
## Summary

Adds Pre-Mission AAR as a package-level option. When enabled, flights created for that package receive an outbound pre-mission refueling and hold phase before the mission ingress/target phase.

The implementation reuses Liberation's existing package refuel point/tanker station instead of creating a separate AAR location. The generated waypoint orders refueling before Hold, so AI can evaluate and refuel first, then remain in the Hold until the calculated departure/push time. This preserves package timing even if the AI decides not to refuel, for example when unlimited fuel is enabled.

Fighter Sweep and TARCAP are supported using their existing flight-plan structures. The normal post-mission REFUEL behavior remains intact. When Pre-Mission AAR is disabled, existing Liberation behavior is unchanged.

This also includes the related settings/UI integration, waypoint serialization/UI support, save compatibility handling, and focused tests for the new behavior.

## Validation

- Black: passed
- mypy tests: passed
- Relevant Python tests: 32 passed
- Python test suite: 146 passed, 2 skipped, 500 deselected
- git diff --check: passed

Local check notes outside this PR diff:

- mypy game: failed in existing/unrelated areas not changed by this PR (`start_type`/`custom_name` typing errors)
- React tests: failed in existing/unrelated frontend setup areas outside this PR diff
- frontend build: failed in existing/unrelated frontend typing/setup areas outside this PR diff