### PR TITLE
Fix airborne TACAN Y band generation

### DIFF
--- a/game/missiongenerator/aircraft/waypoints/racetrack.py
+++ b/game/missiongenerator/aircraft/waypoints/racetrack.py
@@ -1,18 +1,12 @@
 import logging
 
 from dcs.point import MovingPoint
-from dcs.task import (
-    ActivateBeaconCommand,
-    ControlledTask,
-    EngageTargets,
-    OrbitAction,
-    Tanker,
-    Targets,
-)
+from dcs.task import ControlledTask, EngageTargets, OrbitAction, Tanker, Targets
 
 from game.ato import FlightType
 from game.ato.flightplans.patrolling import PatrollingFlightPlan
 from .pydcswaypointbuilder import PydcsWaypointBuilder
+from .tankertacan import tanker_tacan_beacon
 
 
 class RaceTrackBuilder(PydcsWaypointBuilder):
@@ -72,12 +66,5 @@ class RaceTrackBuilder(PydcsWaypointBuilder):
             }.get(tanker_info.callsign)
 
             waypoint.add_task(
-                ActivateBeaconCommand(
-                    tacan.number,
-                    tacan.band.value,
-                    tacan_callsign,
-                    bearing=True,
-                    unit_id=self.group.units[0].id,
-                    aa=True,
-                )
+                tanker_tacan_beacon(tacan, tacan_callsign, self.group.units[0].id)
             )

--- a/game/missiongenerator/aircraft/waypoints/recoverytanker.py
+++ b/game/missiongenerator/aircraft/waypoints/recoverytanker.py
@@ -1,9 +1,10 @@
 from dcs.point import MovingPoint
-from dcs.task import ActivateBeaconCommand, RecoveryTanker, Tanker
+from dcs.task import RecoveryTanker, Tanker
 
 from game.ato import FlightType
 from game.utils import feet, knots
 from .pydcswaypointbuilder import PydcsWaypointBuilder
+from .tankertacan import tanker_tacan_beacon
 
 
 class RecoveryTankerBuilder(PydcsWaypointBuilder):
@@ -57,12 +58,5 @@ class RecoveryTankerBuilder(PydcsWaypointBuilder):
             }.get(tanker_info.callsign)
 
             waypoint.add_task(
-                ActivateBeaconCommand(
-                    tacan.number,
-                    tacan.band.value,
-                    tacan_callsign,
-                    bearing=True,
-                    unit_id=self.group.units[0].id,
-                    aa=True,
-                )
+                tanker_tacan_beacon(tacan, tacan_callsign, self.group.units[0].id)
             )

--- a/game/missiongenerator/aircraft/waypoints/tankertacan.py
+++ b/game/missiongenerator/aircraft/waypoints/tankertacan.py
@@ -1,0 +1,24 @@
+from dcs.task import ActivateBeaconCommand
+
+from game.radio.tacan import TacanBand, TacanChannel
+
+# DCS uses separate beacon system IDs for airborne TACAN X and Y.
+AIRBORNE_TACAN_SYSTEM = {
+    TacanBand.X: 4,
+    TacanBand.Y: 5,
+}
+
+
+def tanker_tacan_beacon(
+    tacan: TacanChannel, callsign: str | None, unit_id: int
+) -> ActivateBeaconCommand:
+    beacon = ActivateBeaconCommand(
+        tacan.number,
+        tacan.band.value,
+        callsign,
+        bearing=True,
+        unit_id=unit_id,
+        aa=True,
+    )
+    beacon.params["action"]["params"]["system"] = AIRBORNE_TACAN_SYSTEM[tacan.band]
+    return beacon

--- a/tests/missiongenerator/aircraft/test_tankertacan.py
+++ b/tests/missiongenerator/aircraft/test_tankertacan.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+import pytest
+
+from game.missiongenerator.aircraft.waypoints.tankertacan import (
+    AIRBORNE_TACAN_SYSTEM,
+    tanker_tacan_beacon,
+)
+from game.radio.tacan import TacanBand, TacanChannel
+
+
+@pytest.mark.parametrize(
+    ("band", "expected_system"),
+    [
+        (TacanBand.X, 4),
+        (TacanBand.Y, 5),
+    ],
+)
+def test_tanker_tacan_beacon_uses_airborne_system_for_band(
+    band: TacanBand, expected_system: int
+) -> None:
+    tacan = TacanChannel(37, band)
+
+    beacon = tanker_tacan_beacon(tacan, "TEX", unit_id=463)
+
+    params: dict[str, Any] = beacon.params["action"]["params"]
+    assert params["channel"] == 37
+    assert params["modeChannel"] == band.value
+    assert params["system"] == expected_system
+    assert AIRBORNE_TACAN_SYSTEM[band] == expected_system


### PR DESCRIPTION
## Summary

Fixes tanker TACAN beacon generation for airborne Y-band channels.

Liberation could assign and display a tanker TACAN such as `37Y`, and the generated mission data preserved `modeChannel = "Y"`, but the serialized beacon still used the airborne TACAN X system value. In DCS runtime this caused the tanker to transmit on `37X` instead of `37Y`.

## Root cause

Liberation used pydcs `ActivateBeaconCommand(..., aa=True)` for tanker beacons. The current pydcs command serializes A/A TACAN as `system = 4` regardless of the requested `modeChannel`. DCS distinguishes airborne TACAN X and Y systems:

- Airborne TACAN X: `system = 4`
- Airborne TACAN Y: `system = 5`

So a generated beacon with `modeChannel = "Y"` and `system = 4` looked correct in Liberation/ME-facing fields, but behaved as A/A X once the mission was running.

## Fix

Add a small tanker TACAN beacon helper in Liberation that keeps using the pydcs `ActivateBeaconCommand`, then corrects the serialized airborne TACAN system according to the assigned `TacanBand`:

- `TacanBand.X` -> `system = 4`
- `TacanBand.Y` -> `system = 5`

Both regular racetrack tankers and recovery tankers now use this helper. This does not change TACAN allocation, callsigns, tanker planning, kneeboard generation, or unrelated beacon behavior.

## Tests

Added focused regression coverage for both bands, verifying:

- `channel = 37` is preserved
- `modeChannel` matches the requested X/Y band
- airborne TACAN system is `4` for X and `5` for Y

Checked locally against the PR workflow's Python gates:

```text
.\\.venv311\\Scripts\\python.exe -m black --check game tests
426 files would be left unchanged

.\\.venv311\\Scripts\\python.exe -m mypy game
Success: no issues found in 385 source files

.\\.venv311\\Scripts\\python.exe -m mypy tests
Success: no issues found in 41 source files

.\\.venv311\\Scripts\\python.exe -m pytest tests
126 passed, 2 skipped, 500 deselected
```

Also manually validated in DCS with a KC-130 assigned `37Y`: the tanker was receivable on `37Y` and not incorrectly transmitting on `37X`.